### PR TITLE
Refactor extract RolapStarRegistry

### DIFF
--- a/mondrian/src/main/java/mondrian/rolap/RolapCube.java
+++ b/mondrian/src/main/java/mondrian/rolap/RolapCube.java
@@ -1786,7 +1786,7 @@ public class RolapCube extends CubeBase {
             // base cubes, so we need to iterate through each and flush
             // the ones that should be flushed. Could use a CacheControl
             // method here.
-            for (RolapStar star1 : schema.getStars()) {
+            for (RolapStar star1 : schema.getRolapStarRegistry().getStars()) {
                 // this will only flush the star's aggregate cache if
                 // 1) DisableCaching is true or 2) the star's cube has
                 // cacheAggregations set to false in the schema.
@@ -1805,7 +1805,7 @@ public class RolapCube extends CubeBase {
             if (star != null && star.getFactTable().getRelation().equals(getFact())) {
                 return star;
             }
-            star = schema.makeRolapStar(getFact());
+            star = schema.getRolapStarRegistry().makeRolapStar(getFact());
         }
         return star;
     }

--- a/mondrian/src/main/java/mondrian/rolap/RolapStarRegistry.java
+++ b/mondrian/src/main/java/mondrian/rolap/RolapStarRegistry.java
@@ -1,0 +1,99 @@
+/*
+ * This software is subject to the terms of the Eclipse Public License v1.0
+ * Agreement, available at the following URL:
+ * http://www.eclipse.org/legal/epl-v10.html.
+ * You must accept the terms of that agreement to use this software.
+ *
+ * Copyright (C) 2001-2005 Julian Hyde
+ * Copyright (C) 2005-2019 Hitachi Vantara and others
+ * All Rights Reserved.
+ *
+ * For more information please visit the Project: Hitachi Vantara - Mondrian
+ *
+ * ---- All changes after Fork in 2023 ------------------------
+ *
+ * Project: Eclipse daanse
+ *
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors after Fork in 2023:
+ *   SmartCity Jena - initial
+ *   Stefan Bischof (bipolis.org) - initial
+ */
+package mondrian.rolap;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.daanse.olap.api.Context;
+import org.eclipse.daanse.olap.core.AbstractBasicContext;
+import org.eclipse.daanse.rolap.mapping.api.model.RelationalQueryMapping;
+
+/**
+ * A registry for {@link RolapStar}s of this Schema.
+ */
+public class RolapStarRegistry {
+	private final Map<List<String>, RolapStar> stars = new HashMap<>();
+	private RolapSchema schema;
+	private Context context;
+
+	public RolapStarRegistry(RolapSchema schema, Context context) {
+		this.schema = schema;
+		this.context = context;
+	}
+
+	/**
+	 * Looks up a {@link RolapStar}, creating it if it does not exist.
+	 *
+	 * {@link RolapStar.Table#addJoin} works in a similar way.
+	 */
+	synchronized RolapStar getOrCreateStar(final RelationalQueryMapping fact) {
+		final List<String> rolapStarKey = RolapUtil.makeRolapStarKey(fact);
+		RolapStar star = stars.get(rolapStarKey);
+		if (star == null) {
+			star = makeRolapStar(fact);
+			stars.put(rolapStarKey, star);
+			// let cache manager load pending segments
+			// from external cache if needed
+			RolapConnection internalConnection = schema.getInternalConnection();
+			AbstractBasicContext abc = (AbstractBasicContext) internalConnection.getContext();
+			abc.getAggregationManager().getCacheMgr(internalConnection).loadCacheForStar(star);
+		}
+		return star;
+	}
+
+	public RolapStar getStar(final String factTableName) {
+		return getStar(makeRolapStarKey(factTableName));
+	}
+
+	public RolapStar makeRolapStar(final RelationalQueryMapping fact) {
+		return new RolapStar(schema, context, fact);
+	}
+
+	public synchronized RolapStar getStar(List<String> starKey) {
+		return stars.get(starKey);
+	}
+
+	public synchronized Collection<RolapStar> getStars() {
+		return stars.values();
+	}
+
+	/**
+	 * Generates rolap star key based on the fact table name.
+	 * 
+	 * @param factTableName the fact table name based on which is generated the
+	 *                      rolap star key
+	 * @return the rolap star key
+	 */
+	static List<String> makeRolapStarKey(String factTableName) {
+		return List.of(factTableName);
+	}
+}

--- a/mondrian/src/main/java/mondrian/rolap/RolapUtil.java
+++ b/mondrian/src/main/java/mondrian/rolap/RolapUtil.java
@@ -693,14 +693,7 @@ public class RolapUtil {
       return Collections.unmodifiableList(rlStarKey);
     }
 
-    /**Generates rolap star key based on the fact table name.
-     * @param factTableName the fact table name
-     * based on which is generated the rolap star key
-     * @return the rolap star key
-     */
-    public static List<String> makeRolapStarKey(String factTableName) {
-      return Collections.unmodifiableList(Arrays.asList(factTableName));
-    }
+
 
     /**
      * <p>Determines whether the GROUP BY clause is required, based on the

--- a/mondrian/src/main/java/mondrian/rolap/agg/SegmentCacheManager.java
+++ b/mondrian/src/main/java/mondrian/rolap/agg/SegmentCacheManager.java
@@ -22,7 +22,6 @@ import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
-import java.util.concurrent.CancellationException;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
@@ -48,7 +47,6 @@ import org.slf4j.LoggerFactory;
 
 import mondrian.olap.Util;
 import mondrian.rolap.CacheControlImpl;
-import mondrian.rolap.FastBatchingCellReader;
 import mondrian.rolap.RolapSchema;
 import mondrian.rolap.RolapStar;
 import mondrian.rolap.RolapStoredMeasure;
@@ -1721,7 +1719,7 @@ public class SegmentCacheManager {
         continue;
       }
       // We have a schema match.
-      return schema.getStar( header.rolapStarFactTableName );
+      return schema.getRolapStarRegistry().getStar( header.rolapStarFactTableName );
     }
     return null;
   }

--- a/mondrian/src/main/java/mondrian/rolap/aggmatcher/AggTableManager.java
+++ b/mondrian/src/main/java/mondrian/rolap/aggmatcher/AggTableManager.java
@@ -308,7 +308,7 @@ public class AggTableManager {
     }
 
     private Collection<RolapStar> getStars() {
-        return schema.getStars();
+        return schema.getRolapStarRegistry().getStars();
     }
 
     /**

--- a/mondrian/src/main/java/org/eclipse/daanse/rolap/element/package-info.java
+++ b/mondrian/src/main/java/org/eclipse/daanse/rolap/element/package-info.java
@@ -1,0 +1,17 @@
+/*
+* Copyright (c) 2025 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   SmartCity Jena - initial
+*   Stefan Bischof (bipolis.org) - initial
+*/
+//TODO: RM EXPORT
+@org.osgi.annotation.bundle.Export
+@org.osgi.annotation.versioning.Version("0.0.1")
+package org.eclipse.daanse.rolap.element;

--- a/mondrian/src/test/java/mondrian/rolap/RolapSchemaTest.java
+++ b/mondrian/src/test/java/mondrian/rolap/RolapSchemaTest.java
@@ -72,7 +72,6 @@ import mondrian.olap.RoleImpl;
 import mondrian.olap.SystemWideProperties;
 import mondrian.olap.exceptions.RoleUnionGrantsException;
 import mondrian.olap.exceptions.UnknownRoleException;
-import mondrian.rolap.RolapSchema.RolapStarRegistry;
 import mondrian.rolap.agg.AggregationManager;
 import mondrian.rolap.agg.SegmentCacheManager;
 import mondrian.rolap.util.RelationUtil;
@@ -298,11 +297,11 @@ class RolapSchemaTest {
       assertSame(expectedStar, actualStar);
       assertEquals(1, rolapStarRegistry.getStars().size());
       assertEquals(expectedStar, rolapStarRegistry.getStar(rolapStarKey));
-      verify(schemaSpy, times(1)).makeRolapStar(fact);
+      verify(rolapStarRegistry, times(1)).makeRolapStar(fact);
       //test that no new rolap star has created,
       //but extracted already existing one from the registry
       RolapStar actualStar2 = rolapStarRegistry.getOrCreateStar(fact);
-      verify(schemaSpy, times(1)).makeRolapStar(fact);
+      verify(rolapStarRegistry, times(1)).makeRolapStar(fact);
       assertSame(expectedStar, actualStar2);
       assertEquals(1, rolapStarRegistry.getStars().size());
       assertEquals(expectedStar, rolapStarRegistry.getStar(rolapStarKey));
@@ -326,7 +325,7 @@ class RolapSchemaTest {
       //Put rolap star to the registry
       rolapStarRegistry.getOrCreateStar(fact);
 
-      RolapStar actualStar = schemaSpy.getStar(rolapStarKey);
+      RolapStar actualStar = rolapStarRegistry.getStar(rolapStarKey);
       assertSame(rlStarMock, actualStar);
     }
 
@@ -344,7 +343,7 @@ class RolapSchemaTest {
       //Put rolap star to the registry
       rolapStarRegistry.getOrCreateStar(fact);
 
-      RolapStar actualStar = schemaSpy.getStar(RelationUtil.getAlias(fact));
+      RolapStar actualStar = schemaSpy.getRolapStarRegistry().getStar(RelationUtil.getAlias(fact));
       assertSame(rlStarMock, actualStar);
     }
 
@@ -355,7 +354,7 @@ class RolapSchemaTest {
       //not to the schemaSpy
       RolapStarRegistry rolapStarRegistry = schemaSpy.getRolapStarRegistry();
       //the star mock
-      doReturn(rlStarMock).when(schemaSpy).makeRolapStar(fact);
+      doReturn(rlStarMock).when(rolapStarRegistry).makeRolapStar(fact);
       //Set the schema spy to be linked with the rolap star registry
       assertTrue(
               replaceRolapSchemaLinkedToStarRegistry(
@@ -364,7 +363,7 @@ class RolapSchemaTest {
               "For testing purpose object this$0 in the inner class "
                       + "should be replaced to the rolap schema spy "
                       + "but this not happend");
-      verify(schemaSpy, times(0)).makeRolapStar(fact);
+      verify(rolapStarRegistry, times(0)).makeRolapStar(fact);
       return rolapStarRegistry;
     }
 

--- a/mondrian/src/test/java/mondrian/rolap/RolapUtilTest.java
+++ b/mondrian/src/test/java/mondrian/rolap/RolapUtilTest.java
@@ -26,7 +26,6 @@ import org.eclipse.daanse.rolap.mapping.api.model.RelationalQueryMapping;
 import org.eclipse.daanse.rolap.mapping.pojo.SQLMappingImpl;
 import org.eclipse.daanse.rolap.mapping.pojo.TableQueryMappingImpl;
 import org.junit.jupiter.api.Test;
-import org.opencube.junit5.SchemaUtil;
 
 class RolapUtilTest {
 
@@ -50,7 +49,7 @@ class RolapUtilTest {
     				  .withStatement("`TableAlias`.`promotion_id` = 112")
     				  .build())
     		  .build();
-      List<String> polapStarKey = RolapUtil.makeRolapStarKey(FACT_NAME);
+      List<String> polapStarKey = RolapStarRegistry.makeRolapStarKey(FACT_NAME);
       assertNotNull(polapStarKey);
       polapStarKey.add("OneMore");
       fail(
@@ -72,7 +71,7 @@ class RolapUtilTest {
     				  .withStatement("`TableAlias`.`promotion_id` = 112")
     				  .build())
     		  .build();
-    List<String> polapStarKey = RolapUtil.makeRolapStarKey(FACT_NAME);
+    List<String> polapStarKey = RolapStarRegistry.makeRolapStarKey(FACT_NAME);
     assertNotNull(polapStarKey);
     assertEquals(1, polapStarKey.size());
     assertEquals(FACT_NAME, polapStarKey.get(0));

--- a/mondrian/src/test/java/mondrian/rolap/TestAggregationManager.java
+++ b/mondrian/src/test/java/mondrian/rolap/TestAggregationManager.java
@@ -3624,14 +3624,14 @@ class TestAggregationManager extends BatchTestCase {
         withSchema(context, SchemaModifiers.TestAggregationManagerModifier7::new);
         Connection connection = context.getConnection();
         RolapStar star = connection.getSchemaReader()
-            .getSchema().getStar("sales_fact_1997");
+            .getSchema().getRolapStarRegistry().getStar("sales_fact_1997");
         AggStar aggStar1 = getAggStar(star, "agg_c_10_sales_fact_1997");
         AggStar aggStarSpy = spy(
             getAggStar(star, "agg_c_10_sales_fact_1997"));
         // make sure the test AggStar will be prioritized first
         when(aggStarSpy.getSize(chooseAggregateByVolume)).thenReturn(0l);
         connection.getSchemaReader()
-            .getSchema().getStar("sales_fact_1997").addAggStar(aggStarSpy);
+            .getSchema().getRolapStarRegistry().getStar("sales_fact_1997").addAggStar(aggStarSpy);
         boolean[] rollup = { false };
         AggStar returnedStar = AggregationManager
             .findAgg(
@@ -3704,13 +3704,13 @@ class TestAggregationManager extends BatchTestCase {
         withSchema(context, SchemaModifiers.TestAggregationManagerModifier3::new);
 
         RolapStar star = context.getConnection().getSchemaReader()
-            .getSchema().getStar("sales_fact_1997");
+            .getSchema().getRolapStarRegistry().getStar("sales_fact_1997");
         AggStar aggStarSpy = spy(
             getAggStar(star, "agg_c_special_sales_fact_1997"));
         // make sure the test AggStar will be prioritized first
         when(aggStarSpy.getSize(context.getConfig().chooseAggregateByVolume())).thenReturn(0l);
         context.getConnection().getSchemaReader()
-            .getSchema().getStar("sales_fact_1997").addAggStar(aggStarSpy);
+            .getSchema().getRolapStarRegistry().getStar("sales_fact_1997").addAggStar(aggStarSpy);
 
         boolean[] rollup = { false };
         AggStar returnedStar = AggregationManager
@@ -3804,13 +3804,13 @@ class TestAggregationManager extends BatchTestCase {
          */
         withSchema(context, SchemaModifiers.TestAggregationManagerModifier4::new);
         RolapStar star = context.getConnection().getSchemaReader()
-            .getSchema().getStar("sales_fact_1997");
+            .getSchema().getRolapStarRegistry().getStar("sales_fact_1997");
         AggStar aggStarSpy = spy(
             getAggStar(star, "agg_g_ms_pcat_sales_fact_1997"));
         // make sure the test AggStar will be prioritized first
         when(aggStarSpy.getSize(context.getConfig().chooseAggregateByVolume())).thenReturn(0l);
         context.getConnection().getSchemaReader()
-            .getSchema().getStar("sales_fact_1997").addAggStar(aggStarSpy);
+            .getSchema().getRolapStarRegistry().getStar("sales_fact_1997").addAggStar(aggStarSpy);
         boolean[] rollup = { false };
         AggStar returnedStar = AggregationManager
             .findAgg(

--- a/mondrian/test.bndrun
+++ b/mondrian/test.bndrun
@@ -90,6 +90,7 @@
 	org.mockito.mockito-core;version='[4.9.0,4.9.1)',\
 	org.objenesis;version='[3.3.0,3.3.1)',\
 	org.opentest4j;version='[1.2.0,1.2.1)',\
+	org.osgi.service.cm;version='[1.6.1,1.6.2)',\
 	org.osgi.service.component;version='[1.5.1,1.5.2)',\
 	org.osgi.test.assertj.framework;version='[1.3.0,1.3.1)',\
 	org.osgi.test.common;version='[1.3.0,1.3.1)',\


### PR DESCRIPTION
- Move RolapStarRegistry to a separate class
- Update RolapCube to use RolapStarRegistry
- Remove redundant methods from RolapSchema
- Adjust tests to use RolapStarRegistry
- Update RolapUtil to remove makeRolapStarKey method