### PR TITLE
Add role-based connection handling and metadata to OLAP services

### DIFF
--- a/mondrian/src/main/java/mondrian/rolap/SqlTupleReader.java
+++ b/mondrian/src/main/java/mondrian/rolap/SqlTupleReader.java
@@ -579,12 +579,12 @@ public Object getCacheKey() {
   }
 
     private Execution getExecution(Context context) {
-        if (LocusImpl.isEmpty()) {
-            final Statement statement = context.getConnection().getInternalStatement();
-            return new ExecutionImpl(statement, context.getConfig().executeDurationValue());
-        } else {
+//        if (LocusImpl.isEmpty()) {
+//            final Statement statement = context.getConnection().getInternalStatement();
+//            return new ExecutionImpl(statement, context.getConfig().executeDurationValue());
+//        } else {
             return LocusImpl.peek().getExecution();
-        }
+//        }
     }
 
     @Override

--- a/mondrian/src/main/java/mondrian/rolap/agg/SegmentCacheManager.java
+++ b/mondrian/src/main/java/mondrian/rolap/agg/SegmentCacheManager.java
@@ -22,7 +22,6 @@ import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
-import java.util.concurrent.CancellationException;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
@@ -50,7 +49,6 @@ import org.slf4j.LoggerFactory;
 import mondrian.olap.Util;
 import mondrian.rolap.CacheControlImpl;
 import mondrian.rolap.CacheKey;
-import mondrian.rolap.FastBatchingCellReader;
 import mondrian.rolap.RolapSchema;
 import mondrian.rolap.RolapSchemaCache;
 import mondrian.rolap.RolapStar;
@@ -593,12 +591,12 @@ public class SegmentCacheManager {
    */
   public SegmentWithData peek( final CellRequest request ) {
     Locus locus = null;
-    try {
+//    try {
         locus = LocusImpl.peek();
-    } catch (Exception e) {
-        locus = new LocusImpl( new ExecutionImpl(getContext().getConnection().getInternalStatement(), getContext().getConfig().executeDurationValue()), null, "Loading cells" );
-        LocusImpl.push( locus );
-    }
+//    } catch (Exception e) {
+//        locus = new LocusImpl( new ExecutionImpl(getContext().getConnection().getInternalStatement(), getContext().getConfig().executeDurationValue()), null, "Loading cells" );
+//        LocusImpl.push( locus );
+//    }
     final SegmentCacheManager.PeekResponse response =
       execute(
         new PeekCommand( request, locus ) );

--- a/mondrian/src/main/java/org/eclipse/daanse/olap/api/Context.java
+++ b/mondrian/src/main/java/org/eclipse/daanse/olap/api/Context.java
@@ -78,11 +78,13 @@ public interface Context {
 	/*
 	 * Gives access to the {@link Connection}.
 	 */
-	Connection getConnection();
+	Connection getConnectionWithDefaultRole();
+	Connection getConnection(List<String> roles);
 
     Connection getConnection(ConnectionProps props);
+    
 
-    Scenario createScenario();
+    Scenario createScenario(List<String> roles);
 
 	void addConnection(Connection rolapConnection);
 

--- a/mondrian/src/main/java/org/eclipse/daanse/olap/rolap/core/BasicContext.java
+++ b/mondrian/src/main/java/org/eclipse/daanse/olap/rolap/core/BasicContext.java
@@ -14,6 +14,7 @@
 package org.eclipse.daanse.olap.rolap.core;
 
 import java.sql.Connection;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Semaphore;
@@ -165,8 +166,12 @@ public class BasicContext extends AbstractBasicContext implements RolapContext{
 	}
 
 	@Override
-	public org.eclipse.daanse.olap.api.Connection getConnection() {
+	public org.eclipse.daanse.olap.api.Connection getConnectionWithDefaultRole() {
 		return getConnection(new RolapConnectionPropsR());
+	}
+	@Override
+	public org.eclipse.daanse.olap.api.Connection getConnection(List<String> roles) {
+		return getConnection(new RolapConnectionPropsR(roles));
 	}
 
 	@Override
@@ -175,8 +180,8 @@ public class BasicContext extends AbstractBasicContext implements RolapContext{
 	}
 
 	@Override
-	public Scenario createScenario() {
-        return getConnection().createScenario();
+	public Scenario createScenario(List<String> roles) {
+        return getConnection(roles).createScenario();
 	}
 
 	@Override

--- a/mondrian/src/test/java/mondrian/olap/HierarchyBugTest.java
+++ b/mondrian/src/test/java/mondrian/olap/HierarchyBugTest.java
@@ -97,7 +97,7 @@ class HierarchyBugTest {
             + "[Store].[All Stores].Children)) ON rows "
             + "from [Sales]";
 
-        Connection conn = foodMartContext.getConnection();
+        Connection conn = foodMartContext.getConnectionWithDefaultRole();
         Query query = conn.parseQuery(queryString);
 
         String failStr = null;
@@ -138,7 +138,7 @@ class HierarchyBugTest {
             + "   [Measures].[Unit Sales] ON COLUMNS,\n"
             + "   [Time].[Time].[Year].Members ON ROWS\n"
             + "FROM [Sales]";
-       Connection conn= foodMartContext.getConnection();
+       Connection conn= foodMartContext.getConnectionWithDefaultRole();
 
 
         Result resultTime = TestUtil.executeQuery(conn, mdxTime);
@@ -182,7 +182,7 @@ TestUtil.flushSchemaCache(conn);
             + "   [Time].[Year].Members ON ROWS\n"
             + "FROM [Sales]";
 
-        Connection conn=foodMartContext.getConnection();
+        Connection conn=foodMartContext.getConnectionWithDefaultRole();
         Result resultTime =TestUtil.executeQuery(conn, mdxTime);
         verifyMemberLevelNamesIdentityMeasureAxis(
             resultTime.getAxes()[0], "[Measures]");
@@ -198,7 +198,7 @@ TestUtil.flushSchemaCache(conn);
             + "   [Time.Weekly].[Year].Members ON ROWS\n"
             + "FROM [Sales]";
 
-        Connection conn=foodMartContext.getConnection();
+        Connection conn=foodMartContext.getConnectionWithDefaultRole();
         Result resultWeekly =TestUtil.executeQuery(conn, mdxWeekly);
 
         verifyMemberLevelNamesIdentityMeasureAxis(
@@ -482,7 +482,7 @@ TestUtil.flushSchemaCache(conn);
     private void verifyLevelMemberNamesIdentityOlap4j(
         String mdx, Context context, String expected)
     {
-    Connection connection =	context.getConnection();
+    Connection connection =	context.getConnectionWithDefaultRole();
         org.eclipse.daanse.olap.api.result.CellSet result = connection.createStatement().executeQuery(mdx);
 
         List<Position> positions =
@@ -496,7 +496,7 @@ TestUtil.flushSchemaCache(conn);
         String yearHierarchyName = year.getHierarchy().getUniqueName();
         assertEquals(year1997HierarchyName, yearHierarchyName);
 
-        TestUtil.flushSchemaCache(context.getConnection());
+        TestUtil.flushSchemaCache(context.getConnectionWithDefaultRole());
     }
 
 

--- a/mondrian/src/test/java/mondrian/olap/IdBatchResolverTest.java
+++ b/mondrian/src/test/java/mondrian/olap/IdBatchResolverTest.java
@@ -451,12 +451,12 @@ class IdBatchResolverTest  {
     }
 
     public IdBatchResolver makeTestBatchResolver(Context context,String mdx) {
-    	TestUtil.flushSchemaCache(context.getConnection());
+    	TestUtil.flushSchemaCache(context.getConnectionWithDefaultRole());
         FactoryImpl factoryImpl = new FactoryImplTestWrapper();
         //MdxParserValidator parser = new JavaccParserValidatorImpl(factoryImpl);
 
         RolapConnection conn = (RolapConnection) spy(
-        		context.getConnection());
+        		context.getConnectionWithDefaultRole());
         when(conn.getQueryProvider()).thenReturn(new QueryProviderWrapper());
         //when(conn.createParser()).thenReturn(parser);
 

--- a/mondrian/src/test/java/mondrian/olap/NullMemberRepresentationTest.java
+++ b/mondrian/src/test/java/mondrian/olap/NullMemberRepresentationTest.java
@@ -34,7 +34,7 @@ class NullMemberRepresentationTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testClosingPeriodMemberLeafWithCustomNullRepresentation(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with member [Measures].[Foo] as ' ClosingPeriod().uniquename '\n"
             + "select {[Measures].[Foo]} on columns,\n"
             + "  {[Time].[1997],\n"
@@ -62,7 +62,7 @@ class NullMemberRepresentationTest {
     void testItemMemberWithCustomNullMemberRepresentation(Context context)
         throws IOException
     {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         assertExprReturns(connection,
             "[Time].[1997].Children.Item(6).UniqueName",
             "[Time].[" + getNullMemberRepresentation() + "]");
@@ -72,7 +72,7 @@ class NullMemberRepresentationTest {
     }
 
     void testNullMemberWithCustomRepresentation(Context context) throws IOException {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         assertExprReturns(connection,
             "[Gender].[All Gender].Parent.UniqueName",
             "[Gender].[" + getNullMemberRepresentation() + "]");

--- a/mondrian/src/test/java/mondrian/olap/QueryTest.java
+++ b/mondrian/src/test/java/mondrian/olap/QueryTest.java
@@ -46,7 +46,7 @@ class QueryTest {
     {
 
         ConnectionBase connection =
-                (ConnectionBase) context.getConnection();
+                (ConnectionBase) context.getConnectionWithDefaultRole();
         final Statement statement =
                 connection.getInternalStatement();
 

--- a/mondrian/src/test/java/mondrian/olap/fun/CachedExistsTest.java
+++ b/mondrian/src/test/java/mondrian/olap/fun/CachedExistsTest.java
@@ -70,7 +70,7 @@ class CachedExistsTest{
             + "{[Education Level].[Graduate Degree], [Product].[Food]}\n"
             + "{[Education Level].[Graduate Degree], [Product].[Drink]}\n" + "Row #0: 55,788\n" + "Row #1: 12,580\n"
             + "Row #2: 49,365\n" + "Row #3: 6,423\n" + "Row #4: 11,255\n" + "Row #5: 1,325\n";
-    TestUtil.assertQueryReturns( context.getConnection(), query, expected );
+    TestUtil.assertQueryReturns( context.getConnectionWithDefaultRole(), query, expected );
   }
 
 	@ParameterizedTest
@@ -99,7 +99,7 @@ class CachedExistsTest{
             + "{[Product].[Non-Consumable].[Periodicals]}\n" + "Row #0: 24,597\n" + "Row #1: 50,236\n"
             + "Row #2: 6,838\n" + "Row #3: 13,573\n" + "Row #4: 4,186\n" + "Row #5: 841\n" + "Row #6: 1,779\n"
             + "Row #7: 16,284\n" + "Row #8: 27,038\n" + "Row #9: 4,294\n";
-    TestUtil.assertQueryReturns( context.getConnection(), query, expected );
+    TestUtil.assertQueryReturns( context.getConnectionWithDefaultRole(), query, expected );
   }
 
 	@ParameterizedTest
@@ -134,7 +134,7 @@ class CachedExistsTest{
             + "{[Product].[Non-Consumable].[Periodicals], [Gender].[M]}\n" + "Row #0: 13,573\n" + "Row #1: 4,186\n"
             + "Row #2: 4,294\n" + "Row #3: 17,759\n" + "Row #4: 4,294\n" + "Row #5: 6,776\n" + "Row #6: 6,797\n"
             + "Row #7: 1,987\n" + "Row #8: 2,199\n" + "Row #9: 2,168\n" + "Row #10: 2,126\n";
-    TestUtil.assertQueryReturns( context.getConnection(), query, expected );
+    TestUtil.assertQueryReturns( context.getConnectionWithDefaultRole(), query, expected );
   }
 
 	@ParameterizedTest
@@ -172,7 +172,7 @@ class CachedExistsTest{
             + "Row #1: 11,890\n" + "Row #2: 5,806\n" + "Row #2: 2,934\n" + "Row #2: 2,872\n" + "Row #3: 6,065\n"
             + "Row #3: 3,042\n" + "Row #3: 3,023\n" + "Row #4: 11,997\n" + "Row #4: 6,144\n" + "Row #4: 5,853\n"
             + "Row #5: 12,399\n" + "Row #5: 6,362\n" + "Row #5: 6,037\n";
-    TestUtil.assertQueryReturns( context.getConnection(), query, expected );
+    TestUtil.assertQueryReturns( context.getConnectionWithDefaultRole(), query, expected );
   }
 
 	@ParameterizedTest
@@ -214,7 +214,7 @@ class CachedExistsTest{
             + "Row #3: 3,892\n"
             + "Row #4: 2,607\n"
             + "Row #5: 2,502\n";
-    TestUtil.assertQueryReturns( context.getConnection(), query, expected );
+    TestUtil.assertQueryReturns( context.getConnectionWithDefaultRole(), query, expected );
   }
 
 	@ParameterizedTest
@@ -286,7 +286,7 @@ class CachedExistsTest{
             + "Row #17: 291\n"
             + "Row #18: 47\n"
             + "Row #19: 319\n";
-    TestUtil.assertQueryReturns( context.getConnection(), query, expected );
+    TestUtil.assertQueryReturns( context.getConnectionWithDefaultRole(), query, expected );
   }
 
 	@ParameterizedTest
@@ -316,7 +316,7 @@ class CachedExistsTest{
         "Axis #0:\n" + "{}\n" + "Axis #1:\n" + "{[Time].[1997], [Measures].[*FORMATTED_MEASURE_0]}\n" + "Axis #2:\n"
             + "{[Product].[Drink], [Education Level].[Bachelors Degree], [Customers].[USA].[WA].[Spokane].[Wildon Cameron]}\n"
             + "Row #0: 47\n";
-    TestUtil.assertQueryReturns( context.getConnection(), query, expected );
+    TestUtil.assertQueryReturns( context.getConnectionWithDefaultRole(), query, expected );
   }
 
 	@ParameterizedTest
@@ -444,7 +444,7 @@ class CachedExistsTest{
 
 
     // Verifies second arg of CachedExists uses a tuple type
-    	TestUtil.assertQueryReturns(context.getConnection(),
+    	TestUtil.assertQueryReturns(context.getConnectionWithDefaultRole(),
         "WITH\n" +
         "SET [*NATIVE_CJ_SET] AS 'NONEMPTYCROSSJOIN([*BASE_MEMBERS__Time_],[*BASE_MEMBERS__Time.Weekly_])'\n" +
         "SET [*SORTED_ROW_AXIS] AS 'ORDER([*CJ_ROW_AXIS],[Time].CURRENTMEMBER.ORDERKEY,BASC,[Time.Weekly].CURRENTMEMBER.ORDERKEY,BASC)'\n" +
@@ -474,7 +474,7 @@ class CachedExistsTest{
             + "Row #2: 266,773\n");
 
     // Verified second arg of CachedExists uses a member type
-    TestUtil.assertQueryReturns(context.getConnection(),
+    TestUtil.assertQueryReturns(context.getConnectionWithDefaultRole(),
         "WITH\n" +
         "SET [*NATIVE_CJ_SET] AS 'NONEMPTYCROSSJOIN([*BASE_MEMBERS__Time.Weekly_],NONEMPTYCROSSJOIN([*BASE_MEMBERS__Time_],[*BASE_MEMBERS__Time.Weekly2_]))'\n" +
         "SET [*SORTED_ROW_AXIS] AS 'ORDER([*CJ_ROW_AXIS],[Time.Weekly].CURRENTMEMBER.ORDERKEY,BASC,[Time].CURRENTMEMBER.ORDERKEY,BASC,[Time.Weekly2].CURRENTMEMBER.ORDERKEY,BASC)'\n" +

--- a/mondrian/src/test/java/mondrian/olap/fun/CrossJoinTest.java
+++ b/mondrian/src/test/java/mondrian/olap/fun/CrossJoinTest.java
@@ -185,7 +185,7 @@ public class CrossJoinTest {
   void testCrossJoinIterCalc_IterationCancellationOnForward(Context foodMartContext) {
    ((TestConfig)foodMartContext.getConfig()).setCheckCancelOrTimeoutInterval(1);
     // Get product members as TupleList
-   Connection con= foodMartContext.getConnection();
+   Connection con= foodMartContext.getConnectionWithDefaultRole();
     RolapCube salesCube =
       (RolapCube) TestUtil.cubeByName( con, SALES_CUBE );
     SchemaReader salesCubeSchemaReader =
@@ -395,7 +395,7 @@ void testResultLimitWithinCrossjoin_1(Context foodMartContext) {
 	@ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testResultLimitWithinCrossjoin(Context foodMartContext) {
    SystemWideProperties.instance().ResultLimit = 1000;
-   Connection connection= foodMartContext.getConnection();
+   Connection connection= foodMartContext.getConnectionWithDefaultRole();
     TestUtil.assertAxisThrows(connection, "Hierarchize(Crossjoin(Union({[Gender].CurrentMember}, [Gender].Children), "
         + "Union({[Product].CurrentMember}, [Product].[Brand Name].Members)))",
       "result (1,539) exceeded limit (1,000)","Sales" );

--- a/mondrian/src/test/java/mondrian/olap/fun/FunctionTest.java
+++ b/mondrian/src/test/java/mondrian/olap/fun/FunctionTest.java
@@ -188,21 +188,21 @@ public class FunctionTest {//extends FoodMartTestCase {
       + "Row #1: \n"
       + "Row #2: \n"
       + "Row #3: \n";
-    TestUtil.assertQueryReturns(context.getConnection(), query, expected );
+    TestUtil.assertQueryReturns(context.getConnectionWithDefaultRole(), query, expected );
   }
 
 
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testNumericLiteral(Context context) {
-    TestUtil.assertExprReturns(context.getConnection(), "2", "2" );
+    TestUtil.assertExprReturns(context.getConnectionWithDefaultRole(), "2", "2" );
     if ( false ) {
       // The test is currently broken because the value 2.5 is formatted
       // as "2". TODO: better default format string
-      TestUtil.assertExprReturns(context.getConnection(),"2.5", "2.5" );
+      TestUtil.assertExprReturns(context.getConnectionWithDefaultRole(),"2.5", "2.5" );
     }
-     TestUtil.assertExprReturns(context.getConnection(), "-10.0", "-10" );
-    TestUtil.assertExprDependsOn(context.getConnection(), "1.5", "{}" );
+     TestUtil.assertExprReturns(context.getConnectionWithDefaultRole(), "-10.0", "-10" );
+    TestUtil.assertExprDependsOn(context.getConnectionWithDefaultRole(), "1.5", "{}" );
   }
 
   @ParameterizedTest
@@ -212,12 +212,12 @@ public class FunctionTest {//extends FoodMartTestCase {
     if ( false ) {
       // TODO: enhance parser so that you can include a quoted string
       //   inside a WITH MEMBER clause
-      TestUtil.assertExprReturns(context.getConnection(), "'foobar'", "foobar" );
+      TestUtil.assertExprReturns(context.getConnectionWithDefaultRole(), "'foobar'", "foobar" );
     }
     // double-quoted string
-    TestUtil.assertExprReturns(context.getConnection(), "\"foobar\"", "foobar" );
+    TestUtil.assertExprReturns(context.getConnectionWithDefaultRole(), "\"foobar\"", "foobar" );
     // literals don't depend on any dimensions
-    TestUtil.assertExprDependsOn(context.getConnection(), "\"foobar\"", "{}" );
+    TestUtil.assertExprDependsOn(context.getConnectionWithDefaultRole(), "\"foobar\"", "{}" );
   }
 
 
@@ -227,29 +227,29 @@ public class FunctionTest {//extends FoodMartTestCase {
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testNullMember(Context context) {
     // MSAS fails here, but Mondrian doesn't.
-    TestUtil.assertExprReturns(context.getConnection(),
+    TestUtil.assertExprReturns(context.getConnectionWithDefaultRole(),
       "[Gender].[All Gender].Parent.Level.UniqueName",
       "[Gender].[(All)]" );
 
     // MSAS fails here, but Mondrian doesn't.
-    TestUtil.assertExprReturns(context.getConnection(),
+    TestUtil.assertExprReturns(context.getConnectionWithDefaultRole(),
       "[Gender].[All Gender].Parent.Hierarchy.UniqueName", "[Gender]" );
 
     // MSAS fails here, but Mondrian doesn't.
-    TestUtil.assertExprReturns(context.getConnection(),
+    TestUtil.assertExprReturns(context.getConnectionWithDefaultRole(),
       "[Gender].[All Gender].Parent.Dimension.UniqueName", "[Gender]" );
 
     // MSAS succeeds too
-    TestUtil.assertExprReturns(context.getConnection(),
+    TestUtil.assertExprReturns(context.getConnectionWithDefaultRole(),
       "[Gender].[All Gender].Parent.Children.Count", "0" );
 
     if ( isDefaultNullMemberRepresentation() ) {
       // MSAS returns "" here.
-      TestUtil.assertExprReturns(context.getConnection(),
+      TestUtil.assertExprReturns(context.getConnectionWithDefaultRole(),
         "[Gender].[All Gender].Parent.UniqueName", "[Gender].[#null]" );
 
       // MSAS returns "" here.
-      TestUtil.assertExprReturns(context.getConnection(),
+      TestUtil.assertExprReturns(context.getConnectionWithDefaultRole(),
         "[Gender].[All Gender].Parent.Name", "#null" );
     }
   }
@@ -260,7 +260,7 @@ public class FunctionTest {//extends FoodMartTestCase {
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testNullValue(Context context) {
-    TestUtil.assertQueryReturns(context.getConnection(),
+    TestUtil.assertQueryReturns(context.getConnectionWithDefaultRole(),
       "with member [Measures].[X] as 'IIF([Measures].[Store Sales]>10000,[Measures].[Store Sales],Null)'\n"
         + "select\n"
         + "{[Measures].[X]} on columns,\n"
@@ -322,7 +322,7 @@ public class FunctionTest {//extends FoodMartTestCase {
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testNullInMultiplication(Context context) {
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     TestUtil.assertExprReturns(connection, "NULL*1", "" );
     TestUtil.assertExprReturns(connection, "1*NULL", "" );
     TestUtil.assertExprReturns(connection, "NULL*NULL", "" );
@@ -331,7 +331,7 @@ public class FunctionTest {//extends FoodMartTestCase {
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testNullInAddition(Context context) {
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     TestUtil.assertExprReturns(connection, "1+NULL", "1" );
     TestUtil.assertExprReturns(connection, "NULL+1", "1" );
   }
@@ -339,7 +339,7 @@ public class FunctionTest {//extends FoodMartTestCase {
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testNullInSubtraction(Context context) {
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     TestUtil.assertExprReturns(connection, "1-NULL", "1" );
     TestUtil.assertExprReturns(connection, "NULL-1", "-1" );
   }
@@ -368,7 +368,7 @@ public class FunctionTest {//extends FoodMartTestCase {
         + "Row #0: 5\n"
         + "Row #0: 4\n";
 
-    TestUtil.assertQueryReturns(context.getConnection(),
+    TestUtil.assertQueryReturns(context.getConnectionWithDefaultRole(),
       "WITH MEMBER [Measures].[Foo] AS 'Iif(IsEmpty([Measures].[Unit Sales]), 5, [Measures].[Unit Sales])'\n"
         + "SELECT {[Store].[USA].[WA].children} on columns\n"
         + "FROM Sales\n"
@@ -378,7 +378,7 @@ public class FunctionTest {//extends FoodMartTestCase {
         + " [Measures].[Foo])",
       desiredResult );
 
-    TestUtil.assertQueryReturns(context.getConnection(),
+    TestUtil.assertQueryReturns(context.getConnectionWithDefaultRole(),
       "WITH MEMBER [Measures].[Foo] AS 'Iif([Measures].[Unit Sales] IS EMPTY, 5, [Measures].[Unit Sales])'\n"
         + "SELECT {[Store].[USA].[WA].children} on columns\n"
         + "FROM Sales\n"
@@ -388,7 +388,7 @@ public class FunctionTest {//extends FoodMartTestCase {
         + " [Measures].[Foo])",
       desiredResult );
 
-    TestUtil.assertQueryReturns(context.getConnection(),
+    TestUtil.assertQueryReturns(context.getConnectionWithDefaultRole(),
       "WITH MEMBER [Measures].[Foo] AS 'Iif([Measures].[Bar] IS EMPTY, 1, [Measures].[Bar])'\n"
         + "MEMBER [Measures].[Bar] AS 'CAST(\"42\" AS INTEGER)'\n"
         + "SELECT {[Measures].[Unit Sales], [Measures].[Foo]} on columns\n"
@@ -406,7 +406,7 @@ public class FunctionTest {//extends FoodMartTestCase {
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testQueryWithoutValidMeasure(Context context) {
-    TestUtil.assertQueryReturns(context.getConnection(),
+    TestUtil.assertQueryReturns(context.getConnectionWithDefaultRole(),
       "with\n"
         + "member measures.[without VM] as ' [measures].[unit sales] '\n"
         + "select {measures.[without VM] } on 0,\n"
@@ -439,7 +439,7 @@ public class FunctionTest {//extends FoodMartTestCase {
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testMultiselectCalculations(Context context) {
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "WITH\n"
         + "MEMBER [Measures].[Declining Stores Count] AS\n"
         + " ' Count(Filter(Descendants(Store.CurrentMember, Store.[Store Name]), [Store Sales] < ([Store Sales],Time"
@@ -467,7 +467,7 @@ public class FunctionTest {//extends FoodMartTestCase {
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testBug715177(Context context) {
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "WITH MEMBER [Product].[Non-Consumable].[Other] AS\n"
         + " 'Sum(Except( [Product].[Product Department].Members,\n"
         + "       TopCount([Product].[Product Department].Members, 3)),\n"
@@ -497,7 +497,7 @@ public class FunctionTest {//extends FoodMartTestCase {
   void testBug714707(Context context) {
     // Same issue as bug 715177 -- "children" returns immutable
     // list, which set operator must make mutable.
-    assertAxisReturns(context.getConnection(),
+    assertAxisReturns(context.getConnectionWithDefaultRole(),
       "{[Store].[USA].[CA].children, [Store].[USA]}",
       "[Store].[USA].[CA].[Alameda]\n"
         + "[Store].[USA].[CA].[Beverly Hills]\n"
@@ -510,7 +510,7 @@ public class FunctionTest {//extends FoodMartTestCase {
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
 	void testTuple(Context context) {
-		assertExprReturns(context.getConnection(),
+		assertExprReturns(context.getConnectionWithDefaultRole(),
 				"([Gender].[M], " + "[Time].[Time].Children.Item(2), " + "[Measures].[Unit Sales])", "33,249");
 		// Calc calls MemberValue with 3 args -- more efficient than
 		// constructing a tuple.
@@ -524,7 +524,7 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
         org.eclipse.daanse.olap.calc.base.constant.ConstantIntegerCalc(type=DecimalType(0), resultStyle=VALUE_NOT_NULL, callCount=0, callMillis=0)
     org.eclipse.daanse.olap.calc.base.constant.ConstantMemberCalc(type=MemberType<member=[Measures].[Unit Sales]>, resultStyle=VALUE_NOT_NULL, callCount=0, callMillis=0)
 							""";
-		assertExprCompilesTo(context.getConnection(), expr, expectedCalc);
+		assertExprCompilesTo(context.getConnectionWithDefaultRole(), expr, expectedCalc);
   }
 
   /**
@@ -536,38 +536,38 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
   void testTupleArgTypes(Context context) {
     // can coerce dimensions (if they have a unique hierarchy) and
     // hierarchies to members
-    assertExprReturns(context.getConnection(),
+    assertExprReturns(context.getConnectionWithDefaultRole(),
       "([Gender], [Time].[Time])",
       "266,773" );
 
     // can coerce hierarchy to member
-    assertExprReturns(context.getConnection(),
+    assertExprReturns(context.getConnectionWithDefaultRole(),
       "([Gender].[M], " + TimeWeekly + ")", "135,215" );
 
     // coerce args (hierarchy, member, member, dimension)
-    assertAxisReturns(context.getConnection(),
+    assertAxisReturns(context.getConnectionWithDefaultRole(),
       "{([Time.Weekly], [Measures].[Store Sales], [Marital Status].[M], [Promotion Media])}",
       "{[Time].[Weekly].[All Weeklys], [Measures].[Store Sales], [Marital Status].[M], [Promotion Media].[All "
         + "Media]}" );
 
     // usage of different hierarchies in the [Time] dimension
-    assertAxisReturns(context.getConnection(),
+    assertAxisReturns(context.getConnectionWithDefaultRole(),
       "{([Time.Weekly], [Measures].[Store Sales], [Marital Status].[M], [Time].[Time])}",
       "{[Time].[Weekly].[All Weeklys], [Measures].[Store Sales], [Marital Status].[M], [Time].[1997]}" );
 
     // two usages of the [Time].[Weekly] hierarchy
     if ( SystemWideProperties.instance().SsasCompatibleNaming ) {
-      assertAxisThrows(context.getConnection(),
+      assertAxisThrows(context.getConnectionWithDefaultRole(),
         "{([Time].[Weekly], [Measures].[Store Sales], [Marital Status].[M], [Time].[Weekly])}",
         "Tuple contains more than one member of hierarchy '[Time].[Weekly]'." );
     } else {
-      assertAxisThrows(context.getConnection(),
+      assertAxisThrows(context.getConnectionWithDefaultRole(),
         "{([Time.Weekly], [Measures].[Store Sales], [Marital Status].[M], [Time.Weekly])}",
         "Tuple contains more than one member of hierarchy '[Time.Weekly]'." );
     }
 
     // cannot coerce integer to member
-    assertAxisThrows(context.getConnection(),
+    assertAxisThrows(context.getConnectionWithDefaultRole(),
       "{([Gender].[M], 123)}",
       "No function matches signature '(<Member>, <Numeric Expression>)'" );
   }
@@ -575,49 +575,49 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testTupleItem(Context context) {
-    assertAxisReturns(context.getConnection(),
+    assertAxisReturns(context.getConnectionWithDefaultRole(),
       "([Time].[1997].[Q1].[1], [Customers].[All Customers].[USA].[OR], [Gender].[All Gender].[M]).item(2)",
       "[Gender].[M]" );
 
-    assertAxisReturns(context.getConnection(),
+    assertAxisReturns(context.getConnectionWithDefaultRole(),
       "([Time].[1997].[Q1].[1], [Customers].[All Customers].[USA].[OR], [Gender].[All Gender].[M]).item(1)",
       "[Customers].[USA].[OR]" );
 
-    assertAxisReturns(context.getConnection(),
+    assertAxisReturns(context.getConnectionWithDefaultRole(),
       "{[Time].[1997].[Q1].[1]}.item(0)",
       "[Time].[1997].[Q1].[1]" );
 
-    assertAxisReturns(context.getConnection(),
+    assertAxisReturns(context.getConnectionWithDefaultRole(),
       "{[Time].[1997].[Q1].[1]}.Item(0).Item(0)",
       "[Time].[1997].[Q1].[1]" );
 
     // given out of bounds index, item returns null
-    assertAxisReturns(context.getConnection(),
+    assertAxisReturns(context.getConnectionWithDefaultRole(),
       "([Time].[1997].[Q1].[1], [Customers].[All Customers].[USA].[OR], [Gender].[All Gender].[M]).item(-1)",
       "" );
 
     // given out of bounds index, item returns null
-    assertAxisReturns(context.getConnection(),
+    assertAxisReturns(context.getConnectionWithDefaultRole(),
       "([Time].[1997].[Q1].[1], [Customers].[All Customers].[USA].[OR], [Gender].[All Gender].[M]).item(500)",
       "" );
 
     // empty set
-    assertExprReturns(context.getConnection(),
+    assertExprReturns(context.getConnectionWithDefaultRole(),
       "Filter([Gender].members, 1 = 0).Item(0)",
       "" );
 
     // empty set of unknown type
-    assertExprReturns(context.getConnection(),
+    assertExprReturns(context.getConnectionWithDefaultRole(),
       "{}.Item(3)",
       "" );
 
     // past end of set
-    assertExprReturns(context.getConnection(),
+    assertExprReturns(context.getConnectionWithDefaultRole(),
       "{[Gender].members}.Item(4)",
       "" );
 
     // negative index
-    assertExprReturns(context.getConnection(),
+    assertExprReturns(context.getConnectionWithDefaultRole(),
       "{[Gender].members}.Item(-50)",
       "" );
   }
@@ -626,7 +626,7 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testTupleAppliedToUnknownHierarchy(Context context) {
     // manifestation of bug 1735821
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "with \n"
         + "member [Product].[Test] as '([Product].[Food],Dimensions(0).defaultMember)' \n"
         + "select \n"
@@ -647,22 +647,22 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testTupleDepends(Context context) {
-    assertMemberExprDependsOn(context.getConnection(),
+    assertMemberExprDependsOn(context.getConnectionWithDefaultRole(),
       "([Store].[USA], [Gender].[F])", "{}" );
 
-    assertMemberExprDependsOn(context.getConnection(),
+    assertMemberExprDependsOn(context.getConnectionWithDefaultRole(),
       "([Store].[USA], [Gender])", "{[Gender]}" );
 
     // in a scalar context, the expression depends on everything except
     // the explicitly stated dimensions
-    assertExprDependsOn(context.getConnection(),
+    assertExprDependsOn(context.getConnectionWithDefaultRole(),
       "([Store].[USA], [Gender])",
       allHiersExcept( "[Store]" ) );
 
     // The result should be all dims except [Gender], but there's a small
     // bug in MemberValueCalc.dependsOn where we escalate 'might depend' to
     // 'depends' and we return that it depends on all dimensions.
-    assertExprDependsOn(context.getConnection(),
+    assertExprDependsOn(context.getConnectionWithDefaultRole(),
       "(Dimensions('Store').CurrentMember, [Gender].[F])",
       allHiers() );
   }
@@ -679,22 +679,22 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
     // is different.
 
     // MSAS returns error here.
-    assertExprReturns(context.getConnection(),
+    assertExprReturns(context.getConnectionWithDefaultRole(),
       "Filter([Gender].members, 1 = 0).Item(0).Dimension.Name",
       "Gender" );
 
     // MSAS returns error here.
-    assertExprReturns(context.getConnection(),
+    assertExprReturns(context.getConnectionWithDefaultRole(),
       "Filter([Gender].members, 1 = 0).Item(0).Parent",
       "" );
-    assertExprReturns(context.getConnection(),
+    assertExprReturns(context.getConnectionWithDefaultRole(),
       "(Filter([Store].members, 0 = 0).Item(0).Item(0),"
         + "Filter([Store].members, 0 = 0).Item(0).Item(0))",
       "266,773" );
 
     if ( isDefaultNullMemberRepresentation() ) {
       // MSAS returns error here.
-      assertExprReturns(context.getConnection(),
+      assertExprReturns(context.getConnectionWithDefaultRole(),
         "Filter([Gender].members, 1 = 0).Item(0).Name",
         "#null" );
     }
@@ -704,7 +704,7 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testTupleNull(Context context) {
     // if a tuple contains any null members, it evaluates to null
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "select {[Measures].[Unit Sales]} on columns,\n"
         + " { ([Gender].[M], [Store]),\n"
         + "   ([Gender].[F], [Store].parent),\n"
@@ -720,7 +720,7 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
 
     // the set function eliminates tuples which are wholly or partially
     // null
-    assertAxisReturns(context.getConnection(),
+    assertAxisReturns(context.getConnectionWithDefaultRole(),
       "([Gender].parent, [Marital Status]),\n" // part null
         + " ([Gender].[M], [Marital Status].parent),\n" // part null
         + " ([Gender].parent, [Marital Status].parent),\n" // wholly null
@@ -731,10 +731,10 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
       // The tuple constructor returns a null tuple if one of its
       // arguments is null -- and the Item function returns null if the
       // tuple is null.
-      assertExprReturns(context.getConnection(),
+      assertExprReturns(context.getConnectionWithDefaultRole(),
         "([Gender].parent, [Marital Status]).Item(0).Name",
         "#null" );
-      assertExprReturns(context.getConnection(),
+      assertExprReturns(context.getConnectionWithDefaultRole(),
         "([Gender].parent, [Marital Status]).Item(1).Name",
         "#null" );
     }
@@ -775,17 +775,17 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
   void testLevelMemberExpressions(Context context) {
 	context.getSchemaCache().clear();
     // Should return Beverly Hills in California.
-    assertAxisReturns(context.getConnection(),
+    assertAxisReturns(context.getConnectionWithDefaultRole(),
       "[Store].[Store City].[Beverly Hills]",
       "[Store].[USA].[CA].[Beverly Hills]" );
 
     // There are two months named "1" in the time dimension: one
     // for 1997 and one for 1998.  <Level>.<Member> should return
     // the first one.
-    assertAxisReturns(context.getConnection(), "[Time].[Month].[1]", "[Time].[1997].[Q1].[1]" );
+    assertAxisReturns(context.getConnectionWithDefaultRole(), "[Time].[Month].[1]", "[Time].[1997].[Q1].[1]" );
 
     // Shouldn't be able to find a member named "Q1" on the month level.
-    assertAxisThrows(context.getConnection(),
+    assertAxisThrows(context.getConnectionWithDefaultRole(),
       "[Time].[Month].[Q1]",
       "MDX object '[Time].[Month].[Q1]' not found in cube" );
   }
@@ -793,7 +793,7 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testCaseTestMatch(Context context) {
-    assertExprReturns(context.getConnection(),
+    assertExprReturns(context.getConnectionWithDefaultRole(),
       "CASE WHEN 1=0 THEN \"first\" WHEN 1=1 THEN \"second\" WHEN 1=2 THEN \"third\" ELSE \"fourth\" END",
       "second" );
   }
@@ -801,7 +801,7 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testCaseTestMatchElse(Context context) {
-    assertExprReturns(context.getConnection(),
+    assertExprReturns(context.getConnectionWithDefaultRole(),
       "CASE WHEN 1=0 THEN \"first\" ELSE \"fourth\" END",
       "fourth" );
   }
@@ -809,7 +809,7 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testCaseTestMatchNoElse(Context context) {
-    assertExprReturns(context.getConnection(),
+    assertExprReturns(context.getConnectionWithDefaultRole(),
       "CASE WHEN 1=0 THEN \"first\" END",
       "" );
   }
@@ -820,7 +820,7 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testCaseTestReturnsMemberBug1799391(Context context) {
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "WITH\n"
         + " MEMBER [Product].[CaseTest] AS\n"
         + " 'CASE\n"
@@ -837,12 +837,12 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
         + "{[Gender].[M]}\n"
         + "Row #0: 131,558\n" );
 
-    assertAxisReturns(context.getConnection(),
+    assertAxisReturns(context.getConnectionWithDefaultRole(),
       "CASE WHEN 1+1 = 2 THEN [Gender].[F] ELSE [Gender].[F].Parent END",
       "[Gender].[F]" );
 
     // try case match for good measure
-    assertAxisReturns(context.getConnection(),
+    assertAxisReturns(context.getConnectionWithDefaultRole(),
       "CASE 1 WHEN 2 THEN [Gender].[F] ELSE [Gender].[F].Parent END",
       "[Gender].[All Gender]" );
   }
@@ -850,7 +850,7 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testCaseMatch(Context context) {
-    assertExprReturns(context.getConnection(),
+    assertExprReturns(context.getConnectionWithDefaultRole(),
       "CASE 2 WHEN 1 THEN \"first\" WHEN 2 THEN \"second\" WHEN 3 THEN \"third\" ELSE \"fourth\" END",
       "second" );
   }
@@ -858,7 +858,7 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testCaseMatchElse(Context context) {
-    assertExprReturns(context.getConnection(),
+    assertExprReturns(context.getConnectionWithDefaultRole(),
       "CASE 7 WHEN 1 THEN \"first\" ELSE \"fourth\" END",
       "fourth" );
   }
@@ -866,7 +866,7 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testCaseMatchNoElse(Context context) {
-    assertExprReturns(context.getConnection(),
+    assertExprReturns(context.getConnectionWithDefaultRole(),
       "CASE 8 WHEN 0 THEN \"first\" END",
       "" );
   }
@@ -875,19 +875,19 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testCaseTypeMismatch(Context context) {
     // type mismatch between case and else
-    assertAxisThrows(context.getConnection(),
+    assertAxisThrows(context.getConnectionWithDefaultRole(),
       "CASE 1 WHEN 1 THEN 2 ELSE \"foo\" END",
       "No function matches signature" );
     // type mismatch between case and case
-    assertAxisThrows(context.getConnection(),
+    assertAxisThrows(context.getConnectionWithDefaultRole(),
       "CASE 1 WHEN 1 THEN 2 WHEN 2 THEN \"foo\" ELSE 3 END",
       "No function matches signature" );
     // type mismatch between value and case
-    assertAxisThrows(context.getConnection(),
+    assertAxisThrows(context.getConnectionWithDefaultRole(),
       "CASE 1 WHEN \"foo\" THEN 2 ELSE 3 END",
       "No function matches signature" );
     // non-boolean condition
-    assertAxisThrows(context.getConnection(),
+    assertAxisThrows(context.getConnectionWithDefaultRole(),
       "CASE WHEN 1 = 2 THEN 3 WHEN 4 THEN 5 ELSE 6 END",
       "No function matches signature" );
   }
@@ -907,14 +907,14 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
     // get the type deduction right, the MDX exp compiler will handle the
     // rest.
     if ( false ) {
-      assertExprReturns(context.getConnection(),
+      assertExprReturns(context.getConnectionWithDefaultRole(),
         "case 1 when 0 then 1.5\n"
           + " else ([Gender].[M], [Measures].[Unit Sales]) end",
         "135,215" );
     }
 
     // "case when" variant always worked
-    assertExprReturns(context.getConnection(),
+    assertExprReturns(context.getConnectionWithDefaultRole(),
       "case when 1=0 then 1.5\n"
         + " else ([Gender].[M], [Measures].[Unit Sales]) end",
       "135,215" );
@@ -923,7 +923,7 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
     // to deduce that the result type is tuple-type<member-type<Gender>,
     // member-type<Measures>>.
     if ( false ) {
-      assertExprReturns(context.getConnection(),
+      assertExprReturns(context.getConnectionWithDefaultRole(),
         "case when 1=0 then ([Gender].[M], [Measures].[Store Sales])\n"
           + " else ([Gender].[M], [Measures].[Unit Sales]) end",
         "xxx" );
@@ -932,7 +932,7 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
     // case 3: mixture of member & tuple. Should be able to deduce that
     // result type is an expression.
     if ( false ) {
-      assertExprReturns(context.getConnection(),
+      assertExprReturns(context.getConnectionWithDefaultRole(),
         "case when 1=0 then ([Measures].[Store Sales])\n"
           + " else ([Gender].[M], [Measures].[Unit Sales]) end",
         "xxx" );
@@ -944,24 +944,24 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
   void testMod(Context context) {
     // the following tests are consistent with excel xp
 
-    assertExprReturns(context.getConnection(), "mod(11, 3)", "2" );
-    assertExprReturns(context.getConnection(), "mod(-12, 3)", "0" );
+    assertExprReturns(context.getConnectionWithDefaultRole(), "mod(11, 3)", "2" );
+    assertExprReturns(context.getConnectionWithDefaultRole(), "mod(-12, 3)", "0" );
 
     // can handle non-ints, using the formula MOD(n, d) = n - d * INT(n / d)
-    assertExprReturns(context.getConnection(), "mod(7.2, 3)", 1.2, 0.0001 );
-    assertExprReturns(context.getConnection(), "mod(7.2, 3.2)", .8, 0.0001 );
-    assertExprReturns(context.getConnection(), "mod(7.2, -3.2)", -2.4, 0.0001 );
+    assertExprReturns(context.getConnectionWithDefaultRole(), "mod(7.2, 3)", 1.2, 0.0001 );
+    assertExprReturns(context.getConnectionWithDefaultRole(), "mod(7.2, 3.2)", .8, 0.0001 );
+    assertExprReturns(context.getConnectionWithDefaultRole(), "mod(7.2, -3.2)", -2.4, 0.0001 );
 
     // per Excel doc "sign of result is same as divisor"
-    assertExprReturns(context.getConnection(), "mod(3, 2)", "1" );
-    assertExprReturns(context.getConnection(), "mod(-3, 2)", "1" );
-    assertExprReturns(context.getConnection(), "mod(3, -2)", "-1" );
-    assertExprReturns(context.getConnection(), "mod(-3, -2)", "-1" );
+    assertExprReturns(context.getConnectionWithDefaultRole(), "mod(3, 2)", "1" );
+    assertExprReturns(context.getConnectionWithDefaultRole(), "mod(-3, 2)", "1" );
+    assertExprReturns(context.getConnectionWithDefaultRole(), "mod(3, -2)", "-1" );
+    assertExprReturns(context.getConnectionWithDefaultRole(), "mod(-3, -2)", "-1" );
 
-    assertExprThrows(context.getConnection(),
+    assertExprThrows(context.getConnectionWithDefaultRole(),
       "mod(4, 0)",
       "java.lang.ArithmeticException: / by zero" );
-    assertExprThrows(context.getConnection(),
+    assertExprThrows(context.getConnectionWithDefaultRole(),
       "mod(0, 0)",
       "java.lang.ArithmeticException: / by zero" );
   }
@@ -972,7 +972,7 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
   void testString(Context context) {
     // The String(Integer,Char) function requires us to implicitly cast a
     // string to a char.
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "with member measures.x as 'String(3, \"yahoo\")'\n"
         + "select measures.x on 0 from [Sales]",
       "Axis #0:\n"
@@ -981,24 +981,24 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
         + "{[Measures].[x]}\n"
         + "Row #0: yyy\n" );
     // String is converted to char by taking first character
-    assertExprReturns(context.getConnection(), "String(3, \"yahoo\")", "yyy" ); // SSAS agrees
+    assertExprReturns(context.getConnectionWithDefaultRole(), "String(3, \"yahoo\")", "yyy" ); // SSAS agrees
     // Integer is converted to char by converting to string and taking first
     // character
     if ( Bug.Ssas2005Compatible ) {
       // SSAS2005 can implicitly convert an integer (32) to a string, and
       // then to a char by taking the first character. Mondrian requires
       // an explicit cast.
-      assertExprReturns(context.getConnection(), "String(3, 32)", "333" );
-      assertExprReturns(context.getConnection(), "String(8, -5)", "--------" );
+      assertExprReturns(context.getConnectionWithDefaultRole(), "String(3, 32)", "333" );
+      assertExprReturns(context.getConnectionWithDefaultRole(), "String(8, -5)", "--------" );
     } else {
-      assertExprReturns(context.getConnection(), "String(3, Cast(32 as string))", "333" );
-      assertExprReturns(context.getConnection(), "String(8, Cast(-5 as string))", "--------" );
+      assertExprReturns(context.getConnectionWithDefaultRole(), "String(3, Cast(32 as string))", "333" );
+      assertExprReturns(context.getConnectionWithDefaultRole(), "String(8, Cast(-5 as string))", "--------" );
     }
     // Error if length<0
-    assertExprReturns(context.getConnection(), "String(0, 'x')", "" ); // SSAS agrees
-    assertExprThrows(context.getConnection(),
+    assertExprReturns(context.getConnectionWithDefaultRole(), "String(0, 'x')", "" ); // SSAS agrees
+    assertExprThrows(context.getConnectionWithDefaultRole(),
       "String(-1, 'x')", "NegativeArraySizeException" ); // SSAS agrees
-    assertExprThrows(context.getConnection(),
+    assertExprThrows(context.getConnectionWithDefaultRole(),
       "String(-200, 'x')", "NegativeArraySizeException" ); // SSAS agrees
   }
 
@@ -1092,7 +1092,7 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
     // -- jhyde, 2006/9/3
 
     // From double to integer.  MONDRIAN-1631
-    Cell cell = executeExprRaw(context.getConnection(), "Cast(1.4 As Integer)" );
+    Cell cell = executeExprRaw(context.getConnectionWithDefaultRole(), "Cast(1.4 As Integer)" );
     assertEquals(Integer.class, cell.getValue().getClass(),
             "Cast to Integer resulted in wrong datatype\n"
                     + cell.getValue().getClass().toString());
@@ -1100,31 +1100,31 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
 
     // From integer
     // To integer (trivial)
-    assertExprReturns(context.getConnection(), "0 + Cast(1 + 2 AS Integer)", "3" );
+    assertExprReturns(context.getConnectionWithDefaultRole(), "0 + Cast(1 + 2 AS Integer)", "3" );
     // To String
-    assertExprReturns(context.getConnection(), "'' || Cast(1 + 2 AS String)", "3.0" );
+    assertExprReturns(context.getConnectionWithDefaultRole(), "'' || Cast(1 + 2 AS String)", "3.0" );
     // To Boolean
-    assertExprReturns(context.getConnection(), "1=1 AND Cast(1 + 2 AS Boolean)", "true" );
-    assertExprReturns(context.getConnection(), "1=1 AND Cast(1 - 1 AS Boolean)", "false" );
+    assertExprReturns(context.getConnectionWithDefaultRole(), "1=1 AND Cast(1 + 2 AS Boolean)", "true" );
+    assertExprReturns(context.getConnectionWithDefaultRole(), "1=1 AND Cast(1 - 1 AS Boolean)", "false" );
 
 
     // From boolean
     // To String
-    assertExprReturns(context.getConnection(), "'' || Cast((1 = 1 AND 1 = 2) AS String)", "false" );
+    assertExprReturns(context.getConnectionWithDefaultRole(), "'' || Cast((1 = 1 AND 1 = 2) AS String)", "false" );
 
     // This case demonstrates the relative precedence of 'AS' in 'CAST'
     // and 'AS' for creating inline named sets. See also bug MONDRIAN-648.
 //    discard( Bug.BugMondrian648Fixed );
-    assertExprReturns(context.getConnection(),
+    assertExprReturns(context.getConnectionWithDefaultRole(),
       "'xxx' || Cast(1 = 1 AND 1 = 2 AS String)",
       "xxxfalse" );
 
     // To boolean (trivial)
-    assertExprReturns(context.getConnection(),
+    assertExprReturns(context.getConnectionWithDefaultRole(),
       "1=1 AND Cast((1 = 1 AND 1 = 2) AS Boolean)",
       "false" );
 
-    assertExprReturns(context.getConnection(),
+    assertExprReturns(context.getConnectionWithDefaultRole(),
       "1=1 OR Cast(1 = 1 AND 1 = 2 AS Boolean)",
       "true" );
 
@@ -1134,31 +1134,31 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
     // To Integer : Expect to return NULL
 
     // Expect to return NULL
-    assertExprReturns(context.getConnection(), "0 * Cast(NULL AS Integer)", "" );
+    assertExprReturns(context.getConnectionWithDefaultRole(), "0 * Cast(NULL AS Integer)", "" );
 
     // To Numeric : Expect to return NULL
     // Expect to return NULL
-    assertExprReturns(context.getConnection(), "0 * Cast(NULL AS Numeric)", "" );
+    assertExprReturns(context.getConnectionWithDefaultRole(), "0 * Cast(NULL AS Numeric)", "" );
 
     // To String : Expect to return "null"
-    assertExprReturns(context.getConnection(), "'' || Cast(NULL AS String)", "null" );
+    assertExprReturns(context.getConnectionWithDefaultRole(), "'' || Cast(NULL AS String)", "null" );
 
     // To Boolean : Expect to return NULL, but since FunUtil.BooleanNull
     // does not implement three-valued boolean logic yet, this will return
     // false
-    assertExprReturns(context.getConnection(), "1=1 AND Cast(NULL AS Boolean)", "false" );
+    assertExprReturns(context.getConnectionWithDefaultRole(), "1=1 AND Cast(NULL AS Boolean)", "false" );
 
     // Double is not allowed as a type
-    assertExprThrows(context.getConnection(),
+    assertExprThrows(context.getConnectionWithDefaultRole(),
       "Cast(1 AS Double)",
       "Unknown type 'Double'; values are NUMERIC, STRING, BOOLEAN" );
 
     // An integer constant is not allowed as a type
-    assertExprThrows(context.getConnection(),
+    assertExprThrows(context.getConnectionWithDefaultRole(),
       "Cast(1 AS 5)",
       "Encountered an error at (or somewhere around) input:1:11" );
 
-    assertExprReturns(context.getConnection(), "Cast('tr' || 'ue' AS boolean)", "true" );
+    assertExprReturns(context.getConnectionWithDefaultRole(), "Cast('tr' || 'ue' AS boolean)", "true" );
   }
 
   @ParameterizedTest
@@ -1167,7 +1167,7 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
 	    // To Boolean : Expect to return NULL, but since FunUtil.BooleanNull
 	    // does not implement three-valued boolean logic yet, this will return
 	    // false
-	    assertExprReturns(context.getConnection(), "1=1 AND Cast(NULL AS Boolean)", "false" );
+	    assertExprReturns(context.getConnectionWithDefaultRole(), "1=1 AND Cast(NULL AS Boolean)", "false" );
   }
 
   @ParameterizedTest
@@ -1176,7 +1176,7 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
 	    // To Boolean : Expect to return NULL, but since FunUtil.BooleanNull
 	    // does not implement three-valued boolean logic yet, this will return
 	    // false
-	    assertExprReturns(context.getConnection(), "Cast(NULL AS Boolean)", "false" );
+	    assertExprReturns(context.getConnectionWithDefaultRole(), "Cast(NULL AS Boolean)", "false" );
   }
   /**
    * Testcase for bug <a href="http://jira.pentaho.com/browse/MONDRIAN-524"> MONDRIAN-524, "VB functions: expected
@@ -1185,7 +1185,7 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testCastBug524(Context context) {
-    assertExprReturns(context.getConnection(),
+    assertExprReturns(context.getConnectionWithDefaultRole(),
       "Cast(Int([Measures].[Store Sales] / 3600) as String)",
       "157" );
   }
@@ -1206,7 +1206,7 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testLeftFunctionWithValidArguments(Context context) {
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "select filter([Store].MEMBERS,"
         + "Left([Store].CURRENTMEMBER.Name, 4)=\"Bell\") on 0 from sales",
       "Axis #0:\n"
@@ -1219,7 +1219,7 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testLeftFunctionWithLengthValueZero(Context context) {
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "select filter([Store].MEMBERS,"
         + "Left([Store].CURRENTMEMBER.Name, 0)=\"\" And "
         + "[Store].CURRENTMEMBER.Name = \"Bellingham\") on 0 from sales",
@@ -1233,7 +1233,7 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testLeftFunctionWithLengthValueEqualToStringLength(Context context) {
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "select filter([Store].MEMBERS,"
         + "Left([Store].CURRENTMEMBER.Name, 10)=\"Bellingham\") "
         + "on 0 from sales",
@@ -1247,7 +1247,7 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testLeftFunctionWithLengthMoreThanStringLength(Context context) {
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "select filter([Store].MEMBERS,"
         + "Left([Store].CURRENTMEMBER.Name, 20)=\"Bellingham\") "
         + "on 0 from sales",
@@ -1261,7 +1261,7 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testLeftFunctionWithZeroLengthString(Context context) {
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "select filter([Store].MEMBERS,Left(\"\", 20)=\"\" "
         + "And [Store].CURRENTMEMBER.Name = \"Bellingham\") "
         + "on 0 from sales",
@@ -1287,7 +1287,7 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testMidFunctionWithValidArguments(Context context) {
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "select filter([Store].MEMBERS,"
         + "[Store].CURRENTMEMBER.Name = \"Bellingham\""
         + "And Mid(\"Bellingham\", 4, 6) = \"lingha\")"
@@ -1302,7 +1302,7 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testMidFunctionWithZeroLengthStringArgument(Context context) {
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "select filter([Store].MEMBERS,"
         + "[Store].CURRENTMEMBER.Name = \"Bellingham\""
         + "And Mid(\"\", 4, 6) = \"\")"
@@ -1317,7 +1317,7 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testMidFunctionWithLengthArgumentLargerThanStringLength(Context context) {
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "select filter([Store].MEMBERS,"
         + "[Store].CURRENTMEMBER.Name = \"Bellingham\""
         + "And Mid(\"Bellingham\", 4, 20) = \"lingham\")"
@@ -1332,7 +1332,7 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testMidFunctionWithStartIndexGreaterThanStringLength(Context context) {
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "select filter([Store].MEMBERS,"
         + "[Store].CURRENTMEMBER.Name = \"Bellingham\""
         + "And Mid(\"Bellingham\", 20, 2) = \"\")"
@@ -1350,7 +1350,7 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
     // Note: SSAS 2005 treats start<=0 as 1, therefore gives different
     // result for this query. We favor the VBA spec over SSAS 2005.
     if ( Bug.Ssas2005Compatible ) {
-      assertQueryReturns(context.getConnection(),
+      assertQueryReturns(context.getConnectionWithDefaultRole(),
         "select filter([Store].MEMBERS,"
           + "[Store].CURRENTMEMBER.Name = \"Bellingham\""
           + "And Mid(\"Bellingham\", 0, 2) = \"Be\")"
@@ -1374,7 +1374,7 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testMidFunctionWithStartIndexOne(Context context) {
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "select filter([Store].MEMBERS,"
         + "[Store].CURRENTMEMBER.Name = \"Bellingham\""
         + "And Mid(\"Bellingham\", 1, 2) = \"Be\")"
@@ -1413,7 +1413,7 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testMidFunctionWithoutLength(Context context) {
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "select filter([Store].MEMBERS,"
         + "[Store].CURRENTMEMBER.Name = \"Bellingham\""
         + "And Mid(\"Bellingham\", 2) = \"ellingham\")"
@@ -1428,7 +1428,7 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testLenFunctionWithNonEmptyString(Context context) {
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "select filter([Store].MEMBERS, "
         + "Len([Store].CURRENTMEMBER.Name) = 3) on 0 from sales",
       "Axis #0:\n"
@@ -1441,7 +1441,7 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testLenFunctionWithAnEmptyString(Context context) {
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "select filter([Store].MEMBERS,Len(\"\")=0 "
         + "And [Store].CURRENTMEMBER.Name = \"Bellingham\") "
         + "on 0 from sales",
@@ -1455,7 +1455,7 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testInStrFunctionWithValidArguments(Context context) {
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "select filter([Store].MEMBERS,InStr(\"Bellingham\", \"ingha\")=5 "
         + "And [Store].CURRENTMEMBER.Name = \"Bellingham\") "
         + "on 0 from sales",
@@ -1470,7 +1470,7 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testInStrFunctionWithEmptyString1(Context context) {
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "select filter([Store].MEMBERS,InStr(\"\", \"ingha\")=0 "
         + "And [Store].CURRENTMEMBER.Name = \"Bellingham\") "
         + "on 0 from sales",
@@ -1484,7 +1484,7 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testInStrFunctionWithEmptyString2(Context context) {
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "select filter([Store].MEMBERS,InStr(\"Bellingham\", \"\")=1 "
         + "And [Store].CURRENTMEMBER.Name = \"Bellingham\") "
         + "on 0 from sales",
@@ -1508,23 +1508,23 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testVbaBasic(Context context) {
     // Exp is a simple function: one arg.
-    assertExprReturns(context.getConnection(), "exp(0)", "1" );
-    assertExprReturns(context.getConnection(), "exp(1)", Math.E, 0.00000001 );
-    assertExprReturns(context.getConnection(), "exp(-2)", 1d / ( Math.E * Math.E ), 0.00000001 );
+    assertExprReturns(context.getConnectionWithDefaultRole(), "exp(0)", "1" );
+    assertExprReturns(context.getConnectionWithDefaultRole(), "exp(1)", Math.E, 0.00000001 );
+    assertExprReturns(context.getConnectionWithDefaultRole(), "exp(-2)", 1d / ( Math.E * Math.E ), 0.00000001 );
 
     }
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testVbaBasic1(Context context) {
 	  // If any arg is null, result is null.
-	    assertExprReturns(context.getConnection(), "exp(null)", "" );
+	    assertExprReturns(context.getConnectionWithDefaultRole(), "exp(null)", "" );
 
   }
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testVbaBasic2(Context context) {
 	  // If any arg is null, result is null.
-	    assertExprReturns(context.getConnection(), "exp(cast(null as numeric))", "" );
+	    assertExprReturns(context.getConnectionWithDefaultRole(), "exp(cast(null as numeric))", "" );
 
   }
 
@@ -1532,16 +1532,16 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testVbaOverloading(Context context) {
-    assertExprReturns(context.getConnection(), "replace('xyzxyz', 'xy', 'a')", "azaz" );
-    assertExprReturns(context.getConnection(), "replace('xyzxyz', 'xy', 'a', 2)", "xyzaz" );
-    assertExprReturns(context.getConnection(), "replace('xyzxyz', 'xy', 'a', 1, 1)", "azxyz" );
+    assertExprReturns(context.getConnectionWithDefaultRole(), "replace('xyzxyz', 'xy', 'a')", "azaz" );
+    assertExprReturns(context.getConnectionWithDefaultRole(), "replace('xyzxyz', 'xy', 'a', 2)", "xyzaz" );
+    assertExprReturns(context.getConnectionWithDefaultRole(), "replace('xyzxyz', 'xy', 'a', 1, 1)", "azxyz" );
   }
 
   // Test VBA exception handling
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testVbaExceptions(Context context) {
-    assertExprThrows(context.getConnection(),
+    assertExprThrows(context.getConnectionWithDefaultRole(),
       "right(\"abc\", -4)",
       Util.IBM_JVM
         ? "StringIndexOutOfBoundsException: null"
@@ -1552,25 +1552,25 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testVbaDateTime(Context context) {
     // function which returns date
-    assertExprReturns(context.getConnection(),
+    assertExprReturns(context.getConnectionWithDefaultRole(),
       "Format(DateSerial(2006, 4, 29), \"Long Date\")",
       "Saturday, April 29, 2006" );
     // function with date parameter
-    assertExprReturns(context.getConnection(), "Year(DateSerial(2006, 4, 29))", "2,006" );
+    assertExprReturns(context.getConnectionWithDefaultRole(), "Year(DateSerial(2006, 4, 29))", "2,006" );
   }
 
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testExcelPi(Context context) {
     // The PI function is defined in the Excel class.
-    assertExprReturns(context.getConnection(), "Pi()", "3" );
+    assertExprReturns(context.getConnectionWithDefaultRole(), "Pi()", "3" );
   }
 
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testExcelPower(Context context) {
-    assertExprReturns(context.getConnection(), "Power(8, 0.333333)", 2.0, 0.01 );
-    assertExprReturns(context.getConnection(), "Power(-2, 0.5)", Double.NaN, 0.001 );
+    assertExprReturns(context.getConnectionWithDefaultRole(), "Power(8, 0.333333)", 2.0, 0.01 );
+    assertExprReturns(context.getConnectionWithDefaultRole(), "Power(-2, 0.5)", Double.NaN, 0.001 );
   }
 
   // Comment from the bug: the reason for this is that in AbstractExpCompiler
@@ -1580,7 +1580,7 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testBug1881739(Context context) {
-    assertExprReturns(context.getConnection(), "LEFT(\"TEST\", LEN(\"TEST\"))", "TEST" );
+    assertExprReturns(context.getConnectionWithDefaultRole(), "LEFT(\"TEST\", LEN(\"TEST\"))", "TEST" );
   }
 
   /**
@@ -1590,28 +1590,28 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testCubeTimeDimensionFails(Context context) {
-    assertQueryThrows(context.getConnection(),
+    assertQueryThrows(context.getConnectionWithDefaultRole(),
       "select LastPeriods(1) on columns from [Store]",
       "'LastPeriods', no time dimension" );
-    assertQueryThrows(context.getConnection(),
+    assertQueryThrows(context.getConnectionWithDefaultRole(),
       "select OpeningPeriod() on columns from [Store]",
       "'OpeningPeriod', no time dimension" );
-    assertQueryThrows(context.getConnection(),
+    assertQueryThrows(context.getConnectionWithDefaultRole(),
       "select OpeningPeriod([Store Type]) on columns from [Store]",
       "'OpeningPeriod', no time dimension" );
-    assertQueryThrows(context.getConnection(),
+    assertQueryThrows(context.getConnectionWithDefaultRole(),
       "select ClosingPeriod() on columns from [Store]",
       "'ClosingPeriod', no time dimension" );
-    assertQueryThrows(context.getConnection(),
+    assertQueryThrows(context.getConnectionWithDefaultRole(),
       "select ClosingPeriod([Store Type]) on columns from [Store]",
       "'ClosingPeriod', no time dimension" );
-    assertQueryThrows(context.getConnection(),
+    assertQueryThrows(context.getConnectionWithDefaultRole(),
       "select ParallelPeriod() on columns from [Store]",
       "'ParallelPeriod', no time dimension" );
-    assertQueryThrows(context.getConnection(),
+    assertQueryThrows(context.getConnectionWithDefaultRole(),
       "select PeriodsToDate() on columns from [Store]",
       "'PeriodsToDate', no time dimension" );
-    assertQueryThrows(context.getConnection(),
+    assertQueryThrows(context.getConnectionWithDefaultRole(),
       "select Mtd() on columns from [Store]",
       "'Mtd', no time dimension" );
   }
@@ -1637,7 +1637,7 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
         + "Row #2: 135,215\n";
 
     // hand written case
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "select\n"
         + "   [Measures].[Unit Sales] on 0,\n"
         + "   Distinct({\n"
@@ -1671,7 +1671,7 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
     if ( false ) {
       System.out.println( buf.toString().length() + ": " + buf.toString() );
     }
-    assertQueryReturns(context.getConnection(), buf.toString(), expected );
+    assertQueryReturns(context.getConnectionWithDefaultRole(), buf.toString(), expected );
   }
 
   /**
@@ -1734,7 +1734,7 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
       + "Row #0: 266,773\n"
       + "Row #1: 131,558\n"
       + "Row #2: 135,215\n";
-    assertQueryReturns(context.getConnection(), query, expected );
+    assertQueryReturns(context.getConnectionWithDefaultRole(), query, expected );
   }
 
   @ParameterizedTest
@@ -1765,7 +1765,7 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
         + "Row #3: 853\n"
         + "Row #4: 273\n"
         + "Row #5: 909\n";
-    assertQueryReturns(context.getConnection(), query, expectedResult );
+    assertQueryReturns(context.getConnectionWithDefaultRole(), query, expectedResult );
   }
 
   @ParameterizedTest
@@ -1805,7 +1805,7 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
         + "Row #3: 1,237\n"
         + "Row #4: 394\n"
         + "Row #5: 1,277\n";
-    assertQueryReturns(context.getConnection(), query, expectedResult );
+    assertQueryReturns(context.getConnectionWithDefaultRole(), query, expectedResult );
   }
 
   @ParameterizedTest
@@ -1847,7 +1847,7 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
         + "Row #3: 1,237\n"
         + "Row #4: 394\n"
         + "Row #5: 1,277\n";
-    assertQueryReturns(context.getConnection(), query, expectedResult );
+    assertQueryReturns(context.getConnectionWithDefaultRole(), query, expectedResult );
   }
 
   @ParameterizedTest
@@ -1889,7 +1889,7 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
         + "Row #3: 1,237\n"
         + "Row #4: 394\n"
         + "Row #5: 1,277\n";
-    assertQueryReturns(context.getConnection(), query, expectedResult );
+    assertQueryReturns(context.getConnectionWithDefaultRole(), query, expectedResult );
   }
 
   @ParameterizedTest
@@ -1916,7 +1916,7 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
         + "Axis #1:\n"
         + "{[Measures].[Customer Count]}\n"
         + "Row #0: 394\n";
-    assertQueryReturns(context.getConnection(), query, expectedResult );
+    assertQueryReturns(context.getConnectionWithDefaultRole(), query, expectedResult );
   }
 
   @ParameterizedTest
@@ -1948,7 +1948,7 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
         + "Axis #1:\n"
         + "{[Measures].[Customer Count]}\n"
         + "Row #0: 1,671\n";
-    assertQueryReturns(context.getConnection(), query, expectedResult );
+    assertQueryReturns(context.getConnectionWithDefaultRole(), query, expectedResult );
   }
 
 
@@ -1977,7 +1977,7 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
         + "Axis #1:\n"
         + "{[Measures].[Customer Count]}\n"
         + "Row #0: 278\n";
-    assertQueryReturns(context.getConnection(), query, expectedResult );
+    assertQueryReturns(context.getConnectionWithDefaultRole(), query, expectedResult );
   }
 
   @ParameterizedTest
@@ -2005,7 +2005,7 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
         + "Axis #1:\n"
         + "{[Measures].[Customer Count]}\n"
         + "Row #0: 394\n";
-    assertQueryReturns(context.getConnection(), query, expectedResult );
+    assertQueryReturns(context.getConnectionWithDefaultRole(), query, expectedResult );
   }
 
   @ParameterizedTest
@@ -2036,7 +2036,7 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
         + "Axis #1:\n"
         + "{[Measures].[Customer Count]}\n"
         + "Row #0: 1,671\n";
-    assertQueryReturns(context.getConnection(), query, expectedResult );
+    assertQueryReturns(context.getConnectionWithDefaultRole(), query, expectedResult );
   }
 
   @ParameterizedTest
@@ -2065,7 +2065,7 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
         + "Axis #1:\n"
         + "{[Measures].[Customer Count]}\n"
         + "Row #0: 394\n";
-    assertQueryReturns(context.getConnection(), query, expectedResult );
+    assertQueryReturns(context.getConnectionWithDefaultRole(), query, expectedResult );
   }
 
   @ParameterizedTest
@@ -2088,7 +2088,7 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
         + "Axis #1:\n"
         + "{[Measures].[Customer Count]}\n"
         + "Row #0: 1,671\n";
-    assertQueryReturns(context.getConnection(), query, expectedResult );
+    assertQueryReturns(context.getConnectionWithDefaultRole(), query, expectedResult );
   }
 
   @ParameterizedTest
@@ -2117,7 +2117,7 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
         + "Axis #1:\n"
         + "{[Measures].[Customer Count]}\n"
         + "Row #0: 394\n";
-    assertQueryReturns(context.getConnection(), query, expectedResult );
+    assertQueryReturns(context.getConnectionWithDefaultRole(), query, expectedResult );
   }
 
   @ParameterizedTest
@@ -2148,7 +2148,7 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
         + "Axis #1:\n"
         + "{[Measures].[Customer Count]}\n"
         + "Row #0: 1,671\n";
-    assertQueryReturns(context.getConnection(), query, expectedResult );
+    assertQueryReturns(context.getConnectionWithDefaultRole(), query, expectedResult );
   }
 
   @ParameterizedTest
@@ -2186,7 +2186,7 @@ mondrian.calc.impl.MemberArrayValueCalc(type=SCALAR, resultStyle=VALUE, callCoun
         + "{[Time].[1997].[Q1]}\n"
         + "Row #0: 1,671\n"
         + "Row #1: 1,173\n";
-    assertQueryReturns(context.getConnection(), query, expectedResult );
+    assertQueryReturns(context.getConnectionWithDefaultRole(), query, expectedResult );
   }
 
   @Disabled //TODO need investigate

--- a/mondrian/src/test/java/mondrian/olap/fun/NativizeSetFunDefTest.java
+++ b/mondrian/src/test/java/mondrian/olap/fun/NativizeSetFunDefTest.java
@@ -1253,7 +1253,7 @@ class NativizeSetFunDefTest extends BatchTestCase {
 
         SystemWideProperties.instance().EnableNonEmptyOnAllAxis = false;
 
-        assertQueryIsReWritten(context.getConnection(),
+        assertQueryIsReWritten(context.getConnectionWithDefaultRole(),
             "SELECT NativizeSet({Gender.M,Gender.F}) on 0 from sales",
             "select "
             + "NativizeSet({[Gender].[M], [Gender].[F]}) "
@@ -1268,7 +1268,7 @@ class NativizeSetFunDefTest extends BatchTestCase {
 
         SystemWideProperties.instance().EnableNonEmptyOnAllAxis = false;
 
-        assertQueryIsReWritten(context.getConnection(),
+        assertQueryIsReWritten(context.getConnectionWithDefaultRole(),
             "select NativizeSet({[Marital Status].[Marital Status].members}) "
             + "on 0 from sales",
             "select NativizeSet({[Marital Status].[Marital Status].Members}) "
@@ -1283,7 +1283,7 @@ class NativizeSetFunDefTest extends BatchTestCase {
 
         SystemWideProperties.instance().EnableNonEmptyOnAllAxis = false;
 
-        assertQueryIsReWritten(context.getConnection(),
+        assertQueryIsReWritten(context.getConnectionWithDefaultRole(),
             "select NativizeSet(CrossJoin({Gender.M,Gender.F},{[Marital Status].[Marital Status].members})) "
             + "on 0 from sales",
             "with member [Marital Status].[_Nativized_Member_Marital Status_Marital Status_] as '[Marital Status].DefaultMember'\n"
@@ -1303,7 +1303,7 @@ class NativizeSetFunDefTest extends BatchTestCase {
 
         SystemWideProperties.instance().EnableNonEmptyOnAllAxis = false;
 
-        assertQueryIsReWritten(context.getConnection(),
+        assertQueryIsReWritten(context.getConnectionWithDefaultRole(),
             "WITH SET [COG_OQP_INT_s4] AS 'CROSSJOIN({[Education Level].[Graduate Degree]},"
             + " [COG_OQP_INT_s3])'"
             + " SET [COG_OQP_INT_s3] AS 'CROSSJOIN({[Marital Status].[S]}, [COG_OQP_INT_s2])'"
@@ -1337,7 +1337,7 @@ class NativizeSetFunDefTest extends BatchTestCase {
 
         SystemWideProperties.instance().EnableNonEmptyOnAllAxis = false;
 
-        assertQueryIsReWritten(context.getConnection(),
+        assertQueryIsReWritten(context.getConnectionWithDefaultRole(),
             "WITH MEMBER [Product].[COG_OQP_INT_umg1] AS "
             + "'IIF([Measures].CURRENTMEMBER IS [Measures].[Unit Sales], ([Product].[COG_OQP_INT_m2], [Measures].[Unit Sales]),"
             + " AGGREGATE({[Product].[Product Name].MEMBERS}))', SOLVE_ORDER = 4 "
@@ -1401,7 +1401,7 @@ class NativizeSetFunDefTest extends BatchTestCase {
         // Use fresh connection -- unique names are baked in when schema is
         // loaded, depending the Ssas setting at that time.
         //Context context = getTestContext().withFreshConnection();
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         try {
             assertQueryIsReWritten(
                 connection,
@@ -1428,7 +1428,7 @@ class NativizeSetFunDefTest extends BatchTestCase {
         SystemWideProperties.instance().EnableNonEmptyOnAllAxis = false;
 
         // Ssas compatible: [time.weekly].week
-        assertQueryIsReWritten(context.getConnection(),
+        assertQueryIsReWritten(context.getConnectionWithDefaultRole(),
             "select nativizeSet(crossjoin( [time.weekly].week.members, { gender.m })) on 0 "
             + "from sales",
             "with member [Time].[_Nativized_Member_Time_Weekly_Week_] as '[Time].DefaultMember'\n"
@@ -1495,7 +1495,7 @@ class NativizeSetFunDefTest extends BatchTestCase {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testTopCountDoesNotGetTransformed(Context context) {
         ((TestConfig)context.getConfig()).setNativizeMinThreshold(0);
-        assertQueryIsReWritten(context.getConnection(),
+        assertQueryIsReWritten(context.getConnectionWithDefaultRole(),
             "select "
             + "   NativizeSet(Crossjoin([Gender].[Gender].members,"
             + "TopCount({[Marital Status].[Marital Status].members},1,[Measures].[Unit Sales]))"
@@ -1514,7 +1514,7 @@ class NativizeSetFunDefTest extends BatchTestCase {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCrossjoinWithFilter(Context context) {
         ((TestConfig)context.getConfig()).setNativizeMinThreshold(0);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select\n"
             + "NON EMPTY {[Measures].[Unit Sales]} ON COLUMNS,   \n"
             + "NON EMPTY NativizeSet(Crossjoin({[Time].[1997]}, "
@@ -1549,7 +1549,7 @@ class NativizeSetFunDefTest extends BatchTestCase {
             + "from [Warehouse and Sales] "
             + "where [Marital Status].[Marital Status].[S]";
         assertQuerySqlOrNot(
-            context.getConnection(), mdxQuery, patterns, true, false, true);
+            context.getConnectionWithDefaultRole(), mdxQuery, patterns, true, false, true);
     }
 
     @ParameterizedTest
@@ -1596,7 +1596,7 @@ class NativizeSetFunDefTest extends BatchTestCase {
             + "from [Sales] \n"
             + "where [Time].[1997]";
         assertQuerySqlOrNot(
-            context.getConnection(), query, patterns, true, false, true);
+            context.getConnectionWithDefaultRole(), query, patterns, true, false, true);
     }
 
     @ParameterizedTest
@@ -1706,7 +1706,7 @@ class NativizeSetFunDefTest extends BatchTestCase {
             + " NativizeSet(Crossjoin("
             + "[Gender].[Gender].members,[Marital Status].[Marital Status].members"
             + ")) on 0 from Sales";
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         connection.execute(connection.parseQuery(mdxQuery));
         assertQuerySqlOrNot(
                 connection, mdxQuery, patterns, true, false, false);
@@ -1750,7 +1750,7 @@ class NativizeSetFunDefTest extends BatchTestCase {
             + "\"fname\" || ' ' || \"lname\" ASC NULLS LAST";
         SqlPattern oraclePattern =
             new SqlPattern(DatabaseProduct.ORACLE, sql, sql.length());
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         assertQuerySql(connection, mdx1, new SqlPattern[]{oraclePattern});
         assertQuerySql(connection, mdx2, new SqlPattern[]{oraclePattern});
     }
@@ -1759,13 +1759,13 @@ class NativizeSetFunDefTest extends BatchTestCase {
 
     private void checkNotNative(Context context, String mdx) {
         final String mdx2 = removeNativize(mdx);
-        final Result result = executeQuery(mdx2, context.getConnection());
+        final Result result = executeQuery(mdx2, context.getConnectionWithDefaultRole());
         checkNotNative(context, mdx, result);
     }
 
     private void checkNative(Context context, String mdx) {
         final String mdx2 = removeNativize(mdx);
-        final Result result = executeQuery(mdx2, context.getConnection());
+        final Result result = executeQuery(mdx2, context.getConnectionWithDefaultRole());
         checkNative(context, mdx, result);
     }
 

--- a/mondrian/src/test/java/mondrian/olap/fun/PropertiesFunctionTest.java
+++ b/mondrian/src/test/java/mondrian/olap/fun/PropertiesFunctionTest.java
@@ -137,7 +137,7 @@ class PropertiesFunctionTest {
   }
 
   private void verifyMemberCaptionPropertyFunction(Context context, String propertyQuery, DataType expectedCategory, Type expectedReturnType, String expectedResult ) {
-	connection = context.getConnection();
+	connection = context.getConnectionWithDefaultRole();
     query = connection.parseQuery( generateQueryString( propertyQuery ) );
     assertNotNull( query );
     resolvedFun = query.getFormulas()[0].getExpression();
@@ -146,13 +146,13 @@ class PropertiesFunctionTest {
     assertEquals( expectedCategory, resolvedFun.getCategory() );
     assertEquals( expectedReturnType, resolvedFun.getType() );
 
-    result = context.getConnection().execute( query );
+    result = context.getConnectionWithDefaultRole().execute( query );
     assertNotNull( result );
     assertEquals( expectedResult, result.getCell( ZERO_POS ).getFormattedValue() );
   }
 
   private void verifyGenerateWithMemberCaptionPropertyFunction( Context context,  String functionQuery, DataType expectedCategory, Type expectedReturnType, String expectedResult ) {
-    connection = context.getConnection();
+    connection = context.getConnectionWithDefaultRole();
     try {
       query = connection.parseQuery( generateQueryString( functionQuery ) );
     } catch ( OlapRuntimeException e ) {
@@ -166,7 +166,7 @@ class PropertiesFunctionTest {
     assertEquals( expectedCategory, resolvedFun.getCategory() );
     assertEquals( expectedReturnType, resolvedFun.getType() );
 
-    result = context.getConnection().execute( query );
+    result = context.getConnectionWithDefaultRole().execute( query );
     assertNotNull( result );
     assertEquals( expectedResult, result.getCell( ZERO_POS ).getFormattedValue() );
   }

--- a/mondrian/src/test/java/mondrian/olap/fun/SetFunDefTest.java
+++ b/mondrian/src/test/java/mondrian/olap/fun/SetFunDefTest.java
@@ -34,7 +34,7 @@ class SetFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testSetWithMembersFromDifferentHierarchies(Context context) {
-        assertQueryFailsInSetValidation(context.getConnection(),
+        assertQueryFailsInSetValidation(context.getConnectionWithDefaultRole(),
             "with member store.x as "
             + "'{[Gender].[M],[Store].[USA].[CA]}' "
             + " SELECT store.x on 0, [measures].[customer count] on 1 from sales");
@@ -43,7 +43,7 @@ class SetFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testSetWith2TuplesWithDifferentHierarchies(Context context) {
-        assertQueryFailsInSetValidation(context.getConnection(),
+        assertQueryFailsInSetValidation(context.getConnectionWithDefaultRole(),
             "with member store.x as '{([Gender].[M],[Store].[All Stores].[USA].[CA]),"
             + "([Store].[USA].[OR],[Gender].[F])}'\n"
             + " SELECT store.x on 0, [measures].[customer count] on 1 from sales");

--- a/mondrian/src/test/java/mondrian/olap/fun/SortTest.java
+++ b/mondrian/src/test/java/mondrian/olap/fun/SortTest.java
@@ -78,7 +78,7 @@ class SortTest {
   void testOrderDesc(Context context) {
     // In MSAS, NULLs collate last (or almost last, along with +inf and
     // NaN) whereas in Mondrian NULLs collate least (that is, before -inf).
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "with"
         + "   member [Measures].[Foo] as '\n"
         + "      Iif([Promotion Media].CurrentMember IS [Promotion Media].[TV], 1.0 / 0.0,\n"
@@ -127,7 +127,7 @@ class SortTest {
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testOrderAndRank(Context context) {
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "with "
         + "   member [Measures].[Foo] as '\n"
         + "      Iif([Promotion Media].CurrentMember IS [Promotion Media].[TV], 1.0 / 0.0,\n"
@@ -196,7 +196,7 @@ class SortTest {
   void testListTuplesExceedsCellEvalLimit(Context context) {
     // cell eval performed within the sort, so cycles to retrieve all cells.
       ((TestConfig)(context.getConfig())).setCellBatchSize(2);
-    assertAxisReturns(context.getConnection(),
+    assertAxisReturns(context.getConnectionWithDefaultRole(),
       "ORDER(GENERATE(CROSSJOIN({[Customers].[USA].[WA].Children},{[Product].[Food]}),\n"
         + "{([Customers].CURRENTMEMBER,[Product].CURRENTMEMBER)}), [Measures].[Store Sales], BASC, [Customers]"
         + ".CURRENTMEMBER.ORDERKEY,BASC)",
@@ -229,7 +229,7 @@ class SortTest {
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testNonBreakingAscendingComparator(Context context) {
     // more than one non-breaking sortkey, where first is ascending
-    assertAxisReturns(context.getConnection(),
+    assertAxisReturns(context.getConnectionWithDefaultRole(),
       "ORDER(GENERATE(CROSSJOIN({[Customers].[USA].[WA].Children},{[Product].[Food]}),\n"
         + "{([Customers].CURRENTMEMBER,[Product].CURRENTMEMBER)}), [Measures].[Unit Sales], DESC, [Measures].[Store "
         + "Sales], ASC)",
@@ -262,7 +262,7 @@ class SortTest {
   void testMultiLevelBrkSort(Context context) {
     // first 2 sort keys depend on Customers hierarchy only.
     // 3rd requires both Customer and Product
-    assertQueryReturns(context.getConnection(), "WITH\n"
+    assertQueryReturns(context.getConnectionWithDefaultRole(), "WITH\n"
       + "SET [*NATIVE_CJ_SET] AS 'NONEMPTYCROSSJOIN([*BASE_MEMBERS__Customers_],[*BASE_MEMBERS__Product_])'\n"
       + "SET [*SORTED_ROW_AXIS] AS 'ORDER([*CJ_ROW_AXIS],[Customers].CURRENTMEMBER.ORDERKEY,BASC,ANCESTOR"
       + "([Customers].CURRENTMEMBER,[Customers].[City]).ORDERKEY,BASC,[Measures].[*SORTED_MEASURE],BASC)'\n"
@@ -313,7 +313,7 @@ class SortTest {
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testAttributesWithShowsRowsColumnsWithMeasureData(Context context) {
     // Sort on Attributes with Shows rows/columns with measure data.   Most common use case.
-    assertQueryReturns(context.getConnection(), "WITH\n"
+    assertQueryReturns(context.getConnectionWithDefaultRole(), "WITH\n"
       + "SET [*NATIVE_CJ_SET_WITH_SLICER] AS 'NONEMPTYCROSSJOIN([*BASE_MEMBERS__Store_],NONEMPTYCROSSJOIN"
       + "([*BASE_MEMBERS__Education Level_],NONEMPTYCROSSJOIN([*BASE_MEMBERS__Product_],NONEMPTYCROSSJOIN"
       + "([*BASE_MEMBERS__Yearly Income_],[*BASE_MEMBERS__Store Type_]))))'\n"
@@ -377,7 +377,7 @@ class SortTest {
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testSortOnMeasureWithShowRowsColumnsWithMeasureData(Context context) {
-    assertQueryReturns(context.getConnection(), "WITH\n"
+    assertQueryReturns(context.getConnectionWithDefaultRole(), "WITH\n"
       + "SET [*NATIVE_CJ_SET_WITH_SLICER] AS 'NONEMPTYCROSSJOIN([*BASE_MEMBERS__Education Level_],NONEMPTYCROSSJOIN"
       + "([*BASE_MEMBERS__Product_],NONEMPTYCROSSJOIN([*BASE_MEMBERS__Yearly Income_],NONEMPTYCROSSJOIN"
       + "([*BASE_MEMBERS__Store_],[*BASE_MEMBERS__Store Type_]))))'\n"
@@ -445,7 +445,7 @@ class SortTest {
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testSortOnAttributesWithShowsRowsColumnsWithMeasureAndCalculatedMeasureData(Context context) {
-    assertQueryReturns(context.getConnection(), "WITH\n"
+    assertQueryReturns(context.getConnectionWithDefaultRole(), "WITH\n"
       + "SET [*NATIVE_CJ_SET_WITH_SLICER] AS '[*BASE_MEMBERS__Store Type_]'\n"
       + "SET [*NATIVE_CJ_SET] AS 'CROSSJOIN([*BASE_MEMBERS__Education Level_],CROSSJOIN([*BASE_MEMBERS__Product_],"
       + "[*BASE_MEMBERS__Yearly Income_]))'\n"
@@ -496,7 +496,7 @@ class SortTest {
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testSortOnMeasureWithShowsRowsColumnsWithShowAllEvenBlank(Context context) {
-    assertQueryReturns(context.getConnection(), "WITH\n"
+    assertQueryReturns(context.getConnectionWithDefaultRole(), "WITH\n"
       + "SET [*NATIVE_CJ_SET_WITH_SLICER] AS '[*BASE_MEMBERS__Store Type_]'\n"
       + "SET [*NATIVE_CJ_SET] AS 'CROSSJOIN([*BASE_MEMBERS__Education Level_],CROSSJOIN([*BASE_MEMBERS__Product_],"
       + "[*BASE_MEMBERS__Yearly Income_]))'\n"

--- a/mondrian/src/test/java/mondrian/olap/fun/UnionFunDefTest.java
+++ b/mondrian/src/test/java/mondrian/olap/fun/UnionFunDefTest.java
@@ -149,7 +149,7 @@ class UnionFunDefTest {
         + "{[Customers].[USA].[WA], [Time].[1997].[Q3], [Gender].[F], [Marital Status].[M]}\n"
         + "{[Customers].[USA].[WA], [Time].[1997].[Q4], [Gender].[F], [Marital Status].[M]}";
 
-    assertAxisReturns(context.getConnection(), "Union( " + tupleSet + ", " + tupleSet + ")", expected);
+    assertAxisReturns(context.getConnectionWithDefaultRole(), "Union( " + tupleSet + ", " + tupleSet + ")", expected);
   }
 
   @ParameterizedTest
@@ -164,7 +164,7 @@ class UnionFunDefTest {
         + "{[Customers].[Canada].[BC], [Time].[1997].[Q4], [Education Level].[High School Degree], [Gender].[F], [Marital Status].[M]}\n"
         + "{[Customers].[Canada].[BC], [Time].[1997].[Q4], [Education Level].[Partial College], [Gender].[F], [Marital Status].[M]}\n"
         + "{[Customers].[Canada].[BC], [Time].[1997].[Q4], [Education Level].[Partial High School], [Gender].[F], [Marital Status].[M]}";
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     assertAxisReturns(connection, tupleSet, expected);
 
     assertAxisReturns(connection, "Union( " + tupleSet + ", " + tupleSet + ")", expected);
@@ -182,7 +182,7 @@ class UnionFunDefTest {
         + "{[Customers].[Canada].[BC], [Time].[1998].[Q1], [Education Level].[Partial College], [Gender].[F], [Marital Status].[M]}\n"
         + "{[Customers].[Canada].[BC], [Time].[1998].[Q1], [Education Level].[Partial High School], [Gender].[F], [Marital Status].[M]}";
 
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     assertAxisReturns(connection, tupleSet, expected);
 
     assertAxisReturns(connection,
@@ -206,7 +206,7 @@ class UnionFunDefTest {
 
     String tupleSet1Expected =
         "{[Customers].[Canada].[BC], [Time].[1997].[Q1], [Education Level].[Partial High School], [Yearly Income].[$90K - $110K], [Gender].[F], [Marital Status].[M]}";
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     assertAxisReturns(connection, tupleSet1, tupleSet1Expected);
 
     String tupleSet2Expected =
@@ -242,7 +242,7 @@ class UnionFunDefTest {
 
     String tupleSet1Expected =
         "{[Customers].[Canada].[BC], [Time].[1997].[Q1], [Education Level].[Partial High School], [Yearly Income].[$90K - $110K], [Gender].[F], [Marital Status].[M]}";
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     assertAxisReturns(connection, tupleSet1, tupleSet1Expected);
 
     String tupleSet2Expected =

--- a/mondrian/src/test/java/mondrian/olap/fun/ValidMeasureFunDefTest.java
+++ b/mondrian/src/test/java/mondrian/olap/fun/ValidMeasureFunDefTest.java
@@ -86,14 +86,14 @@ class ValidMeasureFunDefTest {
         + "{[Measures].[TestValid]}\n" + "Axis #2:\n"
         + "{[Product.BrandOnly].[ADJ]}\n" + "Row #0: 266,773\n";
 
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
         query, expected);
   }
 
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testValidMeasureWithNullTuple(Context context) {
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
         "with member measures.vm as "
         + "'ValidMeasure((Measures.[Unit Sales], Store.[All Stores].Parent))' "
         + "select measures.vm on 0 from [warehouse and sales]",

--- a/mondrian/src/test/java/mondrian/olap/fun/VisualTotalsTest.java
+++ b/mondrian/src/test/java/mondrian/olap/fun/VisualTotalsTest.java
@@ -96,7 +96,7 @@ class VisualTotalsTest {
 	@ParameterizedTest
 	@ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testDrillthroughVisualTotal(Context foodMartContext) throws SQLException {
-        Connection conn = foodMartContext.getConnection();
+        Connection conn = foodMartContext.getConnectionWithDefaultRole();
         CellSet cellSet =
     		TestUtil.executeQueryWithCellSetResult(conn,
                 "select {[Measures].[Unit Sales]} on columns, "
@@ -136,7 +136,7 @@ class VisualTotalsTest {
 	@ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testVisualTotalCaptionBug(Context foodMartContext) throws SQLException {
         CellSet cellSet =
-    		TestUtil.executeQueryWithCellSetResult(foodMartContext.getConnection(),
+    		TestUtil.executeQueryWithCellSetResult(foodMartContext.getConnectionWithDefaultRole(),
                 "select {[Measures].[Unit Sales]} on columns, "
                 + "VisualTotals("
                 + "    {[Product].[Food].[Baked Goods].[Bread],"
@@ -164,7 +164,7 @@ class VisualTotalsTest {
 	@ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testVisualTotalsAggregatedMemberBug(Context foodMartContext) throws SQLException {
         CellSet cellSet =
-    		TestUtil.executeQueryWithCellSetResult(foodMartContext.getConnection(),
+    		TestUtil.executeQueryWithCellSetResult(foodMartContext.getConnectionWithDefaultRole(),
                 " with  member [Gender].[YTD] as 'AGGREGATE(YTD(),[Gender].[M])'"
             	+ "  select "
             	+ " {[Time].[1997],"

--- a/mondrian/src/test/java/mondrian/olap/type/TypeTest.java
+++ b/mondrian/src/test/java/mondrian/olap/type/TypeTest.java
@@ -64,7 +64,7 @@ class TypeTest {
 	@ParameterizedTest
 	@ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testConversions(Context foodMartContext) {
-        final Connection connection = foodMartContext.getConnection();
+        final Connection connection = foodMartContext.getConnectionWithDefaultRole();
         Cube salesCube =
             getCubeWithName("Sales", connection.getSchema().getCubes());
         assertTrue(salesCube != null);
@@ -195,7 +195,7 @@ class TypeTest {
 	@ParameterizedTest
 	@ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testCommonTypeWhenSetTypeHavingMemberTypeAndTupleType(Context foodMartContext) {
-        Connection connection=	foodMartContext.getConnection();
+        Connection connection=	foodMartContext.getConnectionWithDefaultRole();
         MemberType measureMemberType =
             getMemberTypeHavingMeasureInIt(getUnitSalesMeasure(connection));
 
@@ -226,7 +226,7 @@ class TypeTest {
 	@ParameterizedTest
 	@ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testCommonTypeOfMemberandTupleTypeIsTupleType(Context foodMartContext) {
-        Connection connection=	foodMartContext.getConnection();
+        Connection connection=	foodMartContext.getConnectionWithDefaultRole();
         MemberType measureMemberType =
             getMemberTypeHavingMeasureInIt(getUnitSalesMeasure(connection));
 
@@ -252,7 +252,7 @@ class TypeTest {
 	@ParameterizedTest
 	@ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testCommonTypeBetweenTuplesOfDifferentSizesIsATupleType(Context foodMartContext) {
-    Connection connection=	foodMartContext.getConnection();
+    Connection connection=	foodMartContext.getConnectionWithDefaultRole();
         MemberType measureMemberType =
             getMemberTypeHavingMeasureInIt(getUnitSalesMeasure(connection));
 

--- a/mondrian/src/test/java/mondrian/rolap/BatchTestCase.java
+++ b/mondrian/src/test/java/mondrian/rolap/BatchTestCase.java
@@ -832,10 +832,10 @@ public class BatchTestCase{
         String mdx,
         String expectedResult)
     {
-        context.getConnection().getCacheControl(null).flushSchemaCache();
+        context.getConnectionWithDefaultRole().getCacheControl(null).flushSchemaCache();
         //Connection con =
         //    getTestContext().withSchemaPool(false).getConnection();
-        Connection con = context.getConnection();
+        Connection con = context.getConnectionWithDefaultRole();
         RolapNativeRegistry reg = getRegistry(con);
         reg.setListener(
             new Listener() {
@@ -930,7 +930,7 @@ public class BatchTestCase{
             return;
         }
 
-        context.getConnection().getCacheControl(null).flushSchemaCache();
+        context.getConnectionWithDefaultRole().getCacheControl(null).flushSchemaCache();
         try {
             LoggerFactory.getLogger(getClass()).debug("*** Native: " + mdx);
             boolean reuseConnection = !freshConnection;
@@ -938,7 +938,7 @@ public class BatchTestCase{
             //    getTestContext()
             //        .withSchemaPool(reuseConnection)
             //        .getConnection();
-            Connection con = context.getConnection();
+            Connection con = context.getConnectionWithDefaultRole();
             RolapNativeRegistry reg = getRegistry(con);
             reg.useHardCache(true);
             TestListener listener = new TestListener();
@@ -967,9 +967,9 @@ public class BatchTestCase{
 
             LoggerFactory.getLogger(getClass()).debug("*** Interpreter: " + mdx);
 
-            context.getConnection().getCacheControl(null).flushSchemaCache();
+            context.getConnectionWithDefaultRole().getCacheControl(null).flushSchemaCache();
             //con = getTestContext().withSchemaPool(false).getConnection();
-            con = context.getConnection();
+            con = context.getConnectionWithDefaultRole();
             reg = getRegistry(con);
             listener.setFoundEvaluator(false);
             reg.setListener(listener);
@@ -1005,7 +1005,7 @@ public class BatchTestCase{
                     + "interpreter; MDX=" + mdx);
             }
         } finally {
-            Connection con = context.getConnection();
+            Connection con = context.getConnectionWithDefaultRole();
             RolapNativeRegistry reg = getRegistry(con);
             reg.setEnabled(true);
             reg.useHardCache(false);

--- a/mondrian/src/test/java/mondrian/rolap/CacheControlTest.java
+++ b/mondrian/src/test/java/mondrian/rolap/CacheControlTest.java
@@ -254,7 +254,7 @@ class CacheControlTest {
     void testCreateCellRegion(Context context) {
         // Execute a query.
         final RolapConnection connection =
-            ((RolapConnection) context.getConnection());
+            ((RolapConnection) context.getConnectionWithDefaultRole());
         final CacheControl cacheControl = new CacheControlImpl(connection);
         final CellRegion region =
             createCellRegion(connection, cacheControl);
@@ -268,7 +268,7 @@ class CacheControlTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testNormalize2(Context context) {
         // Execute a query.
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         final CacheControl cacheControl = connection.getCacheControl(null);
 
         final CellRegion region =
@@ -296,7 +296,7 @@ class CacheControlTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testFlush(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         assertQueryReturns(connection,
             "SELECT {[Product].[Product Department].MEMBERS} ON AXIS(0),\n"
             + "{{[Gender].[Gender].MEMBERS}, {[Gender].[All Gender]}} ON AXIS(1)\n"
@@ -450,7 +450,7 @@ class CacheControlTest {
         if (context.getConfig().disableCaching()) {
             return;
         }
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         flushCache(connection);
 
         // Execute a query.
@@ -519,7 +519,7 @@ class CacheControlTest {
             return;
         }
 
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         final StringWriter sw = new StringWriter();
         final PrintWriter pw = new PrintWriter(sw);
         final CacheControl cacheControl =
@@ -557,7 +557,7 @@ class CacheControlTest {
             return;
         }
 
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         flushCache(connection);
 
         // Execute a query.
@@ -871,7 +871,7 @@ class CacheControlTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testNegative(Context context) {
-        final Connection connection = context.getConnection();
+        final Connection connection = context.getConnectionWithDefaultRole();
         final Cube salesCube = connection.getSchema().lookupCube("Sales", true);
         final SchemaReader schemaReader = salesCube.getSchemaReader(null);
         final CacheControl cacheControl = connection.getCacheControl(null);
@@ -1017,7 +1017,7 @@ class CacheControlTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCrossjoin(Context context) {
-        final Connection connection = context.getConnection();
+        final Connection connection = context.getConnectionWithDefaultRole();
         final Cube salesCube = connection.getSchema().lookupCube("Sales", true);
         final CacheControl cacheControl = connection.getCacheControl(null);
 
@@ -1143,7 +1143,7 @@ class CacheControlTest {
         //          [Gender].[F])
         //       [Time].[1997].[Q1])
         //
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         final CacheControl cacheControl =
             new CacheControlImpl(
                 (RolapConnection) connection);
@@ -1199,7 +1199,7 @@ class CacheControlTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testFlushNonPrimedContent(Context context) throws Exception {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         flushCache(connection);
         final CacheControl cacheControl = connection.getCacheControl(null);
         final Cube cube =
@@ -1223,7 +1223,7 @@ class CacheControlTest {
             "select NON EMPTY {[Measures].[Unit Sales]} ON COLUMNS, \n"
             + "NON EMPTY {[Store].[All Stores].Children} ON ROWS \n"
             + "from [Sales] \n";
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         flushCache(connection);
 
         assertQueryReturns(connection,

--- a/mondrian/src/test/java/mondrian/rolap/CancellationTest.java
+++ b/mondrian/src/test/java/mondrian/rolap/CancellationTest.java
@@ -66,7 +66,7 @@ class CancellationTest {
         CrossJoinFunDefTester crossJoinFunDef =
                 new CrossJoinFunDefTester(new CrossJoinTest.NullFunDef().getFunctionMetaData());
         Result result =
-            executeQuery(context.getConnection(), "select store.[store name].members on 0 from sales");
+            executeQuery(context.getConnectionWithDefaultRole(), "select store.[store name].members on 0 from sales");
         Evaluator eval = ((RolapResult) result).getEvaluator(new int[]{0});
         TupleList list = new UnaryTupleList();
         for (Position pos : result.getAxes()[0].getPositions()) {
@@ -86,7 +86,7 @@ class CancellationTest {
         // tests that cancellation/timeout is checked in
         // CrossJoinFunDef.mutableCrossJoin
         ((TestConfig)context.getConfig()).setCheckCancelOrTimeoutInterval(1);
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         RolapCube salesCube = (RolapCube) cubeByName(
              connection,
             "Sales");

--- a/mondrian/src/test/java/mondrian/rolap/CellKeyTest.java
+++ b/mondrian/src/test/java/mondrian/rolap/CellKeyTest.java
@@ -482,7 +482,7 @@ class CellKeyTest  {
             }
         }
         withSchema(context, TestCellLookupModifier::new);
-        assertQueryReturns(context.getConnection(), query, result);
+        assertQueryReturns(context.getConnectionWithDefaultRole(), query, result);
     }
 
     void testSize() {

--- a/mondrian/src/test/java/mondrian/rolap/FastBatchingCellReaderTest.java
+++ b/mondrian/src/test/java/mondrian/rolap/FastBatchingCellReaderTest.java
@@ -103,7 +103,7 @@ class FastBatchingCellReaderTest extends BatchTestCase{
   }
 
   private void prepareContext(Context context) {
-    connection = context.getConnection();
+    connection = context.getConnectionWithDefaultRole();
     connection.getCacheControl( null ).flushSchemaCache();
     final Statement statement = ((Connection) connection).getInternalStatement();
     e = new ExecutionImpl( statement, Optional.empty() );
@@ -131,7 +131,7 @@ class FastBatchingCellReaderTest extends BatchTestCase{
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testMissingSubtotalBugMetricFilter(Context context) {
     prepareContext(context);
-    assertQueryReturns(context.getConnection(), "With " + "Set [*NATIVE_CJ_SET] as " + "'NonEmptyCrossJoin({[Time].[Year].[1997]},"
+    assertQueryReturns(context.getConnectionWithDefaultRole(), "With " + "Set [*NATIVE_CJ_SET] as " + "'NonEmptyCrossJoin({[Time].[Year].[1997]},"
         + "                   NonEmptyCrossJoin({[Product].[All Products].[Drink]},{[Education Level].[All Education Levels].[Bachelors Degree]}))' "
         + "Set [*METRIC_CJ_SET] as 'Filter([*NATIVE_CJ_SET],[Measures].[*Unit Sales_SEL~SUM] > 1000.0)' "
         + "Set [*METRIC_MEMBERS_Education Level] as 'Generate([*METRIC_CJ_SET], {[Education Level].CurrentMember})' "
@@ -150,7 +150,7 @@ class FastBatchingCellReaderTest extends BatchTestCase{
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testMissingSubtotalBugMultiLevelMetricFilter(Context context) {
     prepareContext(context);
-    assertQueryReturns(context.getConnection(), "With "
+    assertQueryReturns(context.getConnectionWithDefaultRole(), "With "
         + "Set [*NATIVE_CJ_SET] as 'NonEmptyCrossJoin([*BASE_MEMBERS_Product],[*BASE_MEMBERS_Education Level])' "
         + "Set [*METRIC_CJ_SET] as 'Filter([*NATIVE_CJ_SET],[Measures].[*Store Cost_SEL~SUM] > 1000.0)' "
         + "Set [*BASE_MEMBERS_Product] as '{[Product].[All Products].[Drink].[Beverages],[Product].[All Products].[Food].[Baked Goods]}' "
@@ -210,7 +210,7 @@ class FastBatchingCellReaderTest extends BatchTestCase{
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testDoesDBSupportGroupingSets(Context context) {
     prepareContext(context);
-    final Dialect dialect = getDialect(context.getConnection());
+    final Dialect dialect = getDialect(context.getConnectionWithDefaultRole());
     FastBatchingCellReader fbcr = new FastBatchingCellReader( e, salesCube, aggMgr ) {
       @Override
 	Dialect getDialect() {
@@ -237,7 +237,7 @@ class FastBatchingCellReaderTest extends BatchTestCase{
   void testGroupBatchesForNonGroupableBatchesWithSorting(Context context) {
     prepareContext(context);
     final BatchLoader fbcr = createFbcr( null, salesCube );
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     BatchLoader.Batch genderBatch =
         fbcr.new Batch( createRequest(connection, cubeNameSales, measureUnitSales, "customer", "gender", "F" ) );
     BatchLoader.Batch maritalStatusBatch =
@@ -260,7 +260,7 @@ class FastBatchingCellReaderTest extends BatchTestCase{
     compoundMembers.add( new String[] { "USA", "CA" } );
     compoundMembers.add( new String[] { "Canada", "BC" } );
     CellRequestConstraint constraint = makeConstraintCountryState( compoundMembers );
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     BatchLoader.Batch genderBatch =
         fbcr.new Batch( createRequest(connection, cubeNameSales, measureUnitSales, "customer", "gender", "F", constraint ) );
     BatchLoader.Batch maritalStatusBatch =
@@ -280,7 +280,7 @@ class FastBatchingCellReaderTest extends BatchTestCase{
   void testGroupBatchesForGroupableBatches(Context context) {
     prepareContext(context);
     final BatchLoader fbcr = createFbcr( null, salesCube );
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     BatchLoader.Batch genderBatch =
         fbcr.new Batch( createRequest(connection, cubeNameSales, measureUnitSales, "customer", "gender", "F" ) ) {
           @Override
@@ -310,7 +310,7 @@ class FastBatchingCellReaderTest extends BatchTestCase{
   void testGroupBatchesForGroupableBatchesAndNonGroupableBatches(Context context) {
     prepareContext(context);
     final BatchLoader fbcr = createFbcr( null, salesCube );
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     final BatchLoader.Batch group1Agg2 =
         fbcr.new Batch( createRequest(connection, cubeNameSales, measureUnitSales, "customer", "gender", "F" ) ) {
           @Override
@@ -378,7 +378,7 @@ class FastBatchingCellReaderTest extends BatchTestCase{
     String tableWarehouse = "warehouse";
 
     final BatchLoader fbcr = createFbcr( null, salesCube );
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     BatchLoader.Batch batch1RollupOnGender =
         createBatch(connection, fbcr, new String[] { tableTime, tableStore, tableProductClass }, new String[] { fieldYear,
           fieldStoreType, fieldProductFamily }, new String[][] { fieldValuesYear, fieldValuesStoreType,
@@ -451,7 +451,7 @@ class FastBatchingCellReaderTest extends BatchTestCase{
   void testAddToCompositeBatchForBothBatchesNotPartOfCompositeBatch(Context context) {
     prepareContext(context);
     final BatchLoader fbcr = createFbcr( null, salesCube );
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     BatchLoader.Batch batch1 =
         fbcr.new Batch( createRequest(connection, cubeNameSales, measureUnitSales, "customer", "country", "F" ) );
     BatchLoader.Batch batch2 =
@@ -472,7 +472,7 @@ class FastBatchingCellReaderTest extends BatchTestCase{
 	prepareContext(context);
     final BatchLoader fbcr = createFbcr( null, salesCube );
     prepareContext(context);
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     BatchLoader.Batch detailedBatch =
         fbcr.new Batch( createRequest(connection, cubeNameSales, measureUnitSales, "customer", "country", "F" ) );
     BatchLoader.Batch aggBatch1 =
@@ -500,7 +500,7 @@ class FastBatchingCellReaderTest extends BatchTestCase{
   void testAddToCompositeBatchForAggregationBatchAlreadyPartOfACompositeBatch(Context context) {
     prepareContext(context);
     final BatchLoader fbcr = createFbcr( null, salesCube );
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     BatchLoader.Batch detailedBatch =
         fbcr.new Batch( createRequest(connection, cubeNameSales, measureUnitSales, "customer", "country", "F" ) );
     BatchLoader.Batch aggBatchToAddToDetailedBatch =
@@ -528,7 +528,7 @@ class FastBatchingCellReaderTest extends BatchTestCase{
   void testAddToCompositeBatchForBothBatchAlreadyPartOfACompositeBatch(Context context) {
     prepareContext(context);
     final BatchLoader fbcr = createFbcr( null, salesCube );
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     BatchLoader.Batch detailedBatch =
         fbcr.new Batch( createRequest(connection, cubeNameSales, measureUnitSales, "customer", "country", "F" ) );
     BatchLoader.Batch aggBatchToAddToDetailedBatch =
@@ -568,7 +568,7 @@ class FastBatchingCellReaderTest extends BatchTestCase{
   void testCanBatchForSuperSet(Context context) {
     prepareContext(context);
     final BatchLoader fbcr = createFbcr( null, salesCube );
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     BatchLoader.Batch aggregationBatch =
         createBatch(connection, fbcr, new String[] { tableTime, tableProductClass, tableProductClass }, new String[] { fieldYear,
           fieldProductFamily, fieldProductDepartment }, new String[][] { fieldValuesYear, fieldValuesProductFamily,
@@ -593,7 +593,7 @@ class FastBatchingCellReaderTest extends BatchTestCase{
     compoundMembers.add( new String[] { "USA", "CA" } );
     compoundMembers.add( new String[] { "Canada", "BC" } );
     CellRequestConstraint constraint = makeConstraintCountryState( compoundMembers );
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     BatchLoader.Batch aggregationBatch =
         createBatch(connection, fbcr, new String[] { tableTime, tableProductClass, tableProductClass }, new String[] { fieldYear,
           fieldProductFamily, fieldProductDepartment }, new String[][] { fieldValuesYear, fieldValuesProductFamily,
@@ -614,7 +614,7 @@ class FastBatchingCellReaderTest extends BatchTestCase{
   void testCanBatchForBatchWithConstraint2(Context context) {
     prepareContext(context);
     final BatchLoader fbcr = createFbcr( null, salesCube );
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     List<String[]> compoundMembers1 = new ArrayList<>();
     compoundMembers1.add( new String[] { "USA", "CA" } );
     compoundMembers1.add( new String[] { "Canada", "BC" } );
@@ -649,7 +649,7 @@ class FastBatchingCellReaderTest extends BatchTestCase{
       return;
     }
     final BatchLoader fbcr = createFbcr( null, salesCube );
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     BatchLoader.Batch aggregationBatch =
         createBatch(connection, fbcr, new String[] { tableTime, tableProductClass, tableProductClass }, new String[] { fieldYear,
           fieldProductFamily, fieldProductDepartment }, new String[][] { fieldValuesYear, fieldValuesProductFamily,
@@ -672,7 +672,7 @@ class FastBatchingCellReaderTest extends BatchTestCase{
       return;
     }
     final BatchLoader fbcr = createFbcr( null, salesCube );
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     BatchLoader.Batch aggregationBatch =
         createBatch(connection, fbcr, new String[] { tableTime, tableProductClass, tableProductClass }, new String[] { fieldYear,
           fieldProductFamily, fieldProductDepartment }, new String[][] { fieldValuesYear, fieldValuesProductFamily,
@@ -695,7 +695,7 @@ class FastBatchingCellReaderTest extends BatchTestCase{
       return;
     }
     final BatchLoader fbcr = createFbcr( null, salesCube );
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     BatchLoader.Batch aggregationBatch =
         createBatch(connection, fbcr, new String[] { tableTime }, new String[] { fieldYear }, new String[][] { fieldValuesYear },
             cubeNameSales, "[Measures].[Customer Count]" );
@@ -718,7 +718,7 @@ class FastBatchingCellReaderTest extends BatchTestCase{
   void testNonSuperSet(Context context) {
     prepareContext(context);
     final BatchLoader fbcr = createFbcr( null, salesCube );
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     BatchLoader.Batch aggregationBatch =
         createBatch(connection, fbcr, new String[] { tableTime, tableProductClass, tableProductClass }, new String[] { fieldYear,
           fieldProductFamily, fieldProductDepartment }, new String[][] { fieldValuesYear, fieldValuesProductFamily,
@@ -742,7 +742,7 @@ class FastBatchingCellReaderTest extends BatchTestCase{
   void testSuperSetAndNotAllValues(Context context) {
     prepareContext(context);
     final BatchLoader fbcr = createFbcr( null, salesCube );
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     BatchLoader.Batch aggregationBatch =
         createBatch(connection, fbcr, new String[] { tableTime, tableProductClass, tableProductClass }, new String[] { fieldYear,
           fieldProductFamily, fieldProductDepartment }, new String[][] { fieldValuesYear, fieldValuesProductFamily,
@@ -763,7 +763,7 @@ class FastBatchingCellReaderTest extends BatchTestCase{
   void testCanBatchForBatchesFromSameAggregationButDifferentRollupOption(Context context) {
     prepareContext(context);
     final BatchLoader fbcr = createFbcr( null, salesCube );
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     BatchLoader.Batch batch1 =
         createBatch(connection, fbcr, new String[] { tableTime }, new String[] { fieldYear }, new String[][] { fieldValuesYear },
             cubeNameSales, measureUnitSales );
@@ -796,7 +796,7 @@ class FastBatchingCellReaderTest extends BatchTestCase{
   void testSuperSetDifferentValues(Context context) {
     prepareContext(context);
     final BatchLoader fbcr = createFbcr( null, salesCube );
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     BatchLoader.Batch aggregationBatch =
         createBatch(connection, fbcr, new String[] { tableTime, tableProductClass, tableProductClass }, new String[] { fieldYear,
           fieldProductFamily, fieldProductDepartment }, new String[][] { new String[] { "1997" },
@@ -816,7 +816,7 @@ class FastBatchingCellReaderTest extends BatchTestCase{
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testCanBatchForBatchWithDifferentAggregationTable(Context context) {
     prepareContext(context);
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     final Dialect dialect = getDialect(connection);
     final DatabaseProduct product = getDatabaseProduct(dialect.getDialectName());
     switch ( product ) {
@@ -851,7 +851,7 @@ class FastBatchingCellReaderTest extends BatchTestCase{
   void testCannotBatchTwoBatchesAtTheSameLevel(Context context) {
     prepareContext(context);
     final BatchLoader fbcr = createFbcr( null, salesCube );
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     BatchLoader.Batch firstBatch =
         createBatch(connection, fbcr, new String[] { tableTime, tableProductClass, tableProductClass }, new String[] { fieldYear,
           fieldProductFamily, fieldProductDepartment }, new String[][] { fieldValuesYear, new String[] { "Food" },
@@ -870,7 +870,7 @@ class FastBatchingCellReaderTest extends BatchTestCase{
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testCompositeBatchLoadAggregation(Context context) throws Exception {
     prepareContext(context);
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     if ( !getDialect(connection).supportsGroupingSets() ) {
       return;
     }
@@ -949,7 +949,7 @@ class FastBatchingCellReaderTest extends BatchTestCase{
     prepareContext(context);
     // Some databases cannot handle scalar subqueries inside
     // count(distinct).
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     final Dialect dialect = getDialect(connection);
     switch ( getDatabaseProduct(dialect.getDialectName()) ) {
       case ORACLE:
@@ -1112,7 +1112,7 @@ class FastBatchingCellReaderTest extends BatchTestCase{
             + "Row #4: 4\n" + "Row #5: 0\n" + "Row #5: 1\n" + "Row #5: 3\n" + "Row #5: 8\n" + "Row #5: 8\n"
             + "Row #5: 8\n";
 
-    assertQueryReturns(context.getConnection(), query, desiredResult );
+    assertQueryReturns(context.getConnectionWithDefaultRole(), query, desiredResult );
 
     String loadCountDistinct_luciddb1 =
         "select " + "\"store\".\"store_type\" as \"c0\", " + "count(distinct "
@@ -1172,7 +1172,7 @@ class FastBatchingCellReaderTest extends BatchTestCase{
 
           new SqlPattern( DatabaseProduct.MYSQL, load_mysql, load_mysql ), };
 
-    assertQuerySql(context.getConnection(), query, patterns );
+    assertQuerySql(context.getConnectionWithDefaultRole(), query, patterns );
   }
 
   @ParameterizedTest
@@ -1181,7 +1181,7 @@ class FastBatchingCellReaderTest extends BatchTestCase{
     prepareContext(context);
     // solve_order=1 says to aggregate [CA] and [OR] before computing their
     // sums
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
         "WITH MEMBER [Time].[Time].[1997 Q1 plus Q2] AS 'AGGREGATE({[Time].[1997].[Q1], [Time].[1997].[Q2]})', solve_order=1\n"
             + "SELECT {[Measures].[Customer Count]} ON COLUMNS,\n"
             + "      {[Time].[1997].[Q1], [Time].[1997].[Q2], [Time].[1997 Q1 plus Q2]} ON ROWS\n" + "FROM Sales\n"
@@ -1199,7 +1199,7 @@ class FastBatchingCellReaderTest extends BatchTestCase{
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testAggregateDistinctCount2(Context context) {
     prepareContext(context);
-    assertQueryReturns(context.getConnection(), "WITH MEMBER [Time].[Time].[1997 Q1 plus July] AS\n"
+    assertQueryReturns(context.getConnectionWithDefaultRole(), "WITH MEMBER [Time].[Time].[1997 Q1 plus July] AS\n"
         + " 'AGGREGATE({[Time].[1997].[Q1], [Time].[1997].[Q3].[7]})', solve_order=1\n"
         + "SELECT {[Measures].[Unit Sales], [Measures].[Customer Count]} ON COLUMNS,\n"
         + "      {[Time].[1997].[Q1],\n" + "       [Time].[1997].[Q2],\n" + "       [Time].[1997].[Q3].[7],\n"
@@ -1221,7 +1221,7 @@ class FastBatchingCellReaderTest extends BatchTestCase{
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testAggregateDistinctCount3(Context context) {
     prepareContext(context);
-    assertQueryReturns(context.getConnection(), "WITH\n"
+    assertQueryReturns(context.getConnectionWithDefaultRole(), "WITH\n"
         + "  MEMBER [Promotion Media].[TV plus Radio] AS 'AGGREGATE({[Promotion Media].[TV], [Promotion Media].[Radio]})', solve_order=1\n"
         + "  MEMBER [Time].[Time].[1997 Q1 plus July] AS 'AGGREGATE({[Time].[1997].[Q1], [Time].[1997].[Q3].[7]})', solve_order=1\n"
         + "SELECT {[Promotion Media].[TV plus Radio],\n" + "        [Promotion Media].[TV],\n"
@@ -1283,7 +1283,7 @@ class FastBatchingCellReaderTest extends BatchTestCase{
             + "\"promotion\".\"media_type\" in ('Radio', 'TV') " + "group by "
             + "\"time_by_day\".\"the_year\", \"time_by_day\".\"quarter\", " + "\"promotion\".\"media_type\"";
 
-    assertQuerySql(context.getConnection(), "WITH\n"
+    assertQuerySql(context.getConnectionWithDefaultRole(), "WITH\n"
         + "  MEMBER [Promotion Media].[TV plus Radio] AS 'AGGREGATE({[Promotion Media].[TV], [Promotion Media].[Radio]})', solve_order=1\n"
         + "  MEMBER [Time].[Time].[1997 Q1 plus July] AS 'AGGREGATE({[Time].[1997].[Q1], [Time].[1997].[Q3].[7]})', solve_order=1\n"
         + "SELECT {[Promotion Media].[TV plus Radio],\n" + "        [Promotion Media].[TV],\n"
@@ -1322,7 +1322,7 @@ class FastBatchingCellReaderTest extends BatchTestCase{
             + "Row #0: 3,505\n" + "Row #0: 112,347\n" + "Row #1: 1,386\n" + "Row #1: 22,293\n" + "Row #2: 3,505\n"
             + "Row #2: 90,054\n" + "Row #3: 2,981\n" + "Row #3: 83,181\n" + "Row #4: 1,462\n" + "Row #4: 29,166\n";
 
-    assertQueryReturns(context.getConnection(), mdxQuery, result );
+    assertQueryReturns(context.getConnectionWithDefaultRole(), mdxQuery, result );
   }
 
   /**
@@ -1364,7 +1364,7 @@ class FastBatchingCellReaderTest extends BatchTestCase{
         { new SqlPattern( DatabaseProduct.DERBY, derbySql, derbySql ), new SqlPattern(
             DatabaseProduct.MYSQL, mysqlSql, mysqlSql ) };
 
-     assertQuerySql(context.getConnection(), query, patterns );
+     assertQuerySql(context.getConnectionWithDefaultRole(), query, patterns );
   }
 
   // Test for multiple members on different levels within the same hierarchy.
@@ -1393,7 +1393,7 @@ class FastBatchingCellReaderTest extends BatchTestCase{
             + "Row #0: 3,753\n" + "Row #0: 229,496\n" + "Row #1: 1,877\n" + "Row #1: 36,177\n" + "Row #2: 845\n"
             + "Row #2: 13,123\n" + "Row #3: 2,073\n" + "Row #3: 37,789\n" + "Row #4: 3,753\n" + "Row #4: 142,407\n";
 
-    assertQueryReturns(context.getConnection(), mdxQuery, result );
+    assertQueryReturns(context.getConnectionWithDefaultRole(), mdxQuery, result );
   }
 
   /**
@@ -1415,7 +1415,7 @@ class FastBatchingCellReaderTest extends BatchTestCase{
             + "NonEmptyCrossJoin([*BASE_MEMBERS_Store],{([Product].[*CTX_MEMBER_SEL~SUM])})\n" + "on rows\n"
             + "From [Sales]\n" + "where ([Time].[1997])";
 
-    assertQueryReturns(context.getConnection(), query, "Axis #0:\n" + "{[Time].[1997]}\n" + "Axis #1:\n" + "{[Measures].[Customer Count]}\n"
+    assertQueryReturns(context.getConnectionWithDefaultRole(), query, "Axis #0:\n" + "{[Time].[1997]}\n" + "Axis #1:\n" + "{[Measures].[Customer Count]}\n"
         + "Axis #2:\n" + "{[Store].[USA].[WA], [Product].[*CTX_MEMBER_SEL~SUM]}\n" + "Row #0: 889\n" );
 
     String mysqlSql =
@@ -1462,7 +1462,7 @@ class FastBatchingCellReaderTest extends BatchTestCase{
             DatabaseProduct.DERBY, derbySql, derbySql ), new SqlPattern( DatabaseProduct.MYSQL,
                 mysqlSql, mysqlSql ) };
 
-     assertQuerySql(context.getConnection(), query, patterns );
+     assertQuerySql(context.getConnectionWithDefaultRole(), query, patterns );
   }
 
   @ParameterizedTest
@@ -1474,7 +1474,7 @@ class FastBatchingCellReaderTest extends BatchTestCase{
             + "member [Measures].[foo] as '([Product].[x],[Measures].[Customer Count])'\n"
             + "select Filter([Gender].members,(Not IsEmpty([Measures].[foo]))) on 0 " + "from Sales";
 
-    assertQueryReturns(context.getConnection(), query, "Axis #0:\n" + "{}\n" + "Axis #1:\n" + "{[Gender].[All Gender]}\n" + "{[Gender].[F]}\n"
+    assertQueryReturns(context.getConnectionWithDefaultRole(), query, "Axis #0:\n" + "{}\n" + "Axis #1:\n" + "{[Gender].[All Gender]}\n" + "{[Gender].[F]}\n"
         + "{[Gender].[M]}\n" + "Row #0: 266,773\n" + "Row #0: 131,558\n" + "Row #0: 135,215\n" );
 
     String mysqlSql =
@@ -1502,7 +1502,7 @@ class FastBatchingCellReaderTest extends BatchTestCase{
             DatabaseProduct.DERBY, derbySql, derbySql ), new SqlPattern( DatabaseProduct.MYSQL,
                 mysqlSql, mysqlSql ) };
 
-    assertQuerySql(context.getConnection(), query, patterns );
+    assertQuerySql(context.getConnectionWithDefaultRole(), query, patterns );
   }
 
   @ParameterizedTest
@@ -1602,13 +1602,13 @@ class FastBatchingCellReaderTest extends BatchTestCase{
         "with member Store.agg as " + "'aggregate({[Store].[USA].[CA],[Store].[USA].[OR]}, "
             + "           measures.[Customer Count])'" + " select Store.agg on 0 from [2CountDistincts] where "
             + "measures.[Unit Sales] ";
-    assertQueriesReturnSimilarResults(context.getConnection(), queryStoreCountInContext, queryUnitSalesInContext);
+    assertQueriesReturnSimilarResults(context.getConnectionWithDefaultRole(), queryStoreCountInContext, queryUnitSalesInContext);
 
     final String queryCAORRollup =
         "with member measures.agg as " + "'aggregate({[Store].[USA].[CA],[Store].[USA].[OR]}, "
             + "           measures.[Customer Count])'" + " select {measures.agg, measures.[Customer Count]} on 0,  "
             + " [Product].[All Products].children on 1 " + "from [2CountDistincts] ";
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     assertQueryReturns(connection, queryCAORRollup, "Axis #0:\n" + "{}\n" + "Axis #1:\n" + "{[Measures].[agg]}\n"
         + "{[Measures].[Customer Count]}\n" + "Axis #2:\n" + "{[Product].[Drink]}\n" + "{[Product].[Food]}\n"
         + "{[Product].[Non-Consumable]}\n" + "Row #0: 2,243\n" + "Row #0: 3,485\n" + "Row #1: 3,711\n"
@@ -1638,7 +1638,7 @@ class FastBatchingCellReaderTest extends BatchTestCase{
     // the evaluator is restored. The query below would return
     // the [Unit Sales] value instead of [Store Sales] if context was
     // not restored.
-    assertQueryReturns(context.getConnection(), "with \n" + "member Store.cond as 'iif( \n"
+    assertQueryReturns(context.getConnectionWithDefaultRole(), "with \n" + "member Store.cond as 'iif( \n"
         + "aggregate({[Store].[All Stores].[USA]}, measures.[unit sales])\n"
         + " > 70000, (Store.[All Stores], measures.currentMember), 0)'\n" + "select Store.cond on 0 from sales\n"
         + "where measures.[store sales]\n", "Axis #0:\n" + "{[Measures].[Store Sales]}\n" + "Axis #1:\n"
@@ -1656,7 +1656,7 @@ class FastBatchingCellReaderTest extends BatchTestCase{
             + "Filter([States], not IsEmpty([Measures].[Customer Count])) on rows, "
             + "{[Measures].[Customer Count]} on columns " + "From [Sales] " + "Where ([Product].[Selected Products])";
 
-    assertQueryReturns(context.getConnection(), query, "Axis #0:\n" + "{[Product].[Selected Products]}\n" + "Axis #1:\n"
+    assertQueryReturns(context.getConnectionWithDefaultRole(), query, "Axis #0:\n" + "{[Product].[Selected Products]}\n" + "Axis #1:\n"
         + "{[Measures].[Customer Count]}\n" + "Axis #2:\n" + "{[Store].[USA].[CA]}\n" + "{[Store].[USA].[OR]}\n"
         + "Row #0: 2,692\n" + "Row #1: 1,036\n" );
 
@@ -1692,7 +1692,7 @@ class FastBatchingCellReaderTest extends BatchTestCase{
         { new SqlPattern( DatabaseProduct.DERBY, derbySql, derbySql ), new SqlPattern(
             DatabaseProduct.MYSQL, mysqlSql, mysqlSql ) };
 
-     assertQuerySql(context.getConnection(), query, patterns );
+     assertQuerySql(context.getConnectionWithDefaultRole(), query, patterns );
   }
 
   public static class MyDelegatingInvocationHandler extends DelegatingInvocationHandler {

--- a/mondrian/src/test/java/mondrian/rolap/FilterTest.java
+++ b/mondrian/src/test/java/mondrian/rolap/FilterTest.java
@@ -461,7 +461,7 @@ class FilterTest extends BatchTestCase {
         + "(('Q1', 1997), ('Q3', 1998))) or (`time_by_day`.`quarter` is null or "
         + "`time_by_day`.`the_year` is null)) "
         + "group by `customer`.`country`, `time_by_day`.`the_year`, `time_by_day`.`quarter` "
-        + ( getDialect(context.getConnection()).requiresOrderByAlias()
+        + ( getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
         ? "order by ISNULL(`c0`) ASC, "
         + "`c0` ASC, ISNULL(`c1`) ASC, "
         + "`c1` ASC, ISNULL(`c2`) ASC, "
@@ -478,7 +478,7 @@ class FilterTest extends BatchTestCase {
         DatabaseProduct.MYSQL, necjSqlMySql, necjSqlMySql )
     };
 
-    assertQuerySql(context.getConnection(), query, patterns );
+    assertQuerySql(context.getConnectionWithDefaultRole(), query, patterns );
   }
 
   /**
@@ -534,7 +534,7 @@ class FilterTest extends BatchTestCase {
         + "(`time_by_day`.`quarter` is null)) or (not "
         + "(`time_by_day`.`the_year` = 1997) or (`time_by_day`.`the_year` "
         + "is null))) group by `customer`.`country`, `time_by_day`.`the_year`, `time_by_day`.`quarter` "
-        + (getDialect(context.getConnection()).requiresOrderByAlias()
+        + (getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
         ? "order by ISNULL(`c0`) ASC, "
         + "`c0` ASC, ISNULL(`c1`) ASC, "
         + "`c1` ASC, ISNULL(`c2`) ASC, "
@@ -551,7 +551,7 @@ class FilterTest extends BatchTestCase {
         DatabaseProduct.MYSQL, necjSqlMySql, necjSqlMySql )
     };
 
-    assertQuerySql(context.getConnection(), query, patterns );
+    assertQuerySql(context.getConnectionWithDefaultRole(), query, patterns );
   }
 
   /**
@@ -766,7 +766,7 @@ class FilterTest extends BatchTestCase {
     withSchema(context, schema);
     */
       withSchema(context, TestNotInMultiLevelMemberConstraintMixedNullNonNullParentModifier::new);
-      assertQuerySql(context.getConnection(), query, patterns );
+      assertQuerySql(context.getConnectionWithDefaultRole(), query, patterns );
   }
 
   /**
@@ -973,7 +973,7 @@ class FilterTest extends BatchTestCase {
     withSchema(context, schema);
     */
       withSchema(context, TestNotInMultiLevelMemberConstraintSingleNullParentModifier::new);
-      assertQuerySql(context.getConnection(), query, patterns);
+      assertQuerySql(context.getConnectionWithDefaultRole(), query, patterns);
   }
 
   @ParameterizedTest
@@ -1171,7 +1171,7 @@ class FilterTest extends BatchTestCase {
     // Get a fresh connection; Otherwise the mondrian property setting
     // is not refreshed for this parameter.
     //final TestContext context = getTestContext().withFreshConnection();
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     try {
       assertQueryReturns(connection,
         "select Filter([Store].[Store Name].members, "
@@ -1289,7 +1289,7 @@ class FilterTest extends BatchTestCase {
         + ".`store_name`, `store`.`store_type`, `store`.`store_manager`, `store`.`store_sqft`, `store`"
         + ".`grocery_sqft`, `store`.`frozen_sqft`, `store`.`meat_sqft`, `store`.`coffee_bar`, `store`"
         + ".`store_street_address` having NOT((sum(`store`.`store_sqft`) is null)) "
-        + ( getDialect(context.getConnection()).requiresOrderByAlias()
+        + ( getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
         ? "order by ISNULL(`c0`) ASC, `c0` ASC, "
         + "ISNULL(`c1`) ASC, `c1` ASC, "
         + "ISNULL(`c2`) ASC, `c2` ASC, "
@@ -1304,7 +1304,7 @@ class FilterTest extends BatchTestCase {
         + "('CA', 'OR')) and ((`store`.`store_id`, `store`.`store_city`, `store`.`store_state`) in ((11, 'Portland', "
         + "'OR'), (14, 'San Francisco', 'CA'))) group by `store`.`store_country`, `store`.`store_state`, `store`"
         + ".`store_city`, `store`.`store_id`, `store`.`store_name` having NOT((sum(`store`.`store_sqft`) is null)) "
-        + ( getDialect(context.getConnection()).requiresOrderByAlias()
+        + ( getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
         ? " order by ISNULL(`c0`) ASC, `c0` ASC, "
         + "ISNULL(`c1`) ASC, `c1` ASC, "
         + "ISNULL(`c2`) ASC, `c2` ASC, "
@@ -1367,10 +1367,10 @@ class FilterTest extends BatchTestCase {
           + "  </Dimension>\n" ));
      */
     withSchema(context, SchemaModifiers.FilterTestModifier::new);
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     assertQuerySqlOrNot(connection, mdx, badPatterns, true, true, true );
     TestUtil.flushSchemaCache(connection);
-    assertQuerySqlOrNot(context.getConnection(), mdx, goodPatterns, false, true, true );
+    assertQuerySqlOrNot(context.getConnectionWithDefaultRole(), mdx, goodPatterns, false, true, true );
     assertQueryReturns(connection,
       mdx,
       "Axis #0:\n"
@@ -1456,8 +1456,8 @@ class FilterTest extends BatchTestCase {
         + "Row #15: 6,884\n"
         + "Row #16: 5,262\n";
 
-    assertQueryReturns(context.getConnection(), query1, expectedResult1);
-    assertQueryReturns(context.getConnection(), query2, expectedResult2);
+    assertQueryReturns(context.getConnectionWithDefaultRole(), query1, expectedResult1);
+    assertQueryReturns(context.getConnectionWithDefaultRole(), query2, expectedResult2);
   }
 
   /**
@@ -1478,7 +1478,7 @@ class FilterTest extends BatchTestCase {
     }
 
     String sql;
-    if ( !getDialect(context.getConnection()).supportsMultiValueInExpr() ) {
+    if ( !getDialect(context.getConnectionWithDefaultRole()).supportsMultiValueInExpr() ) {
       sql = "select `agg_g_ms_pcat_sales_fact_1997`.`product_family` "
         + "as `c0`,"
         + " `agg_g_ms_pcat_sales_fact_1997`.`product_department` as "
@@ -1550,7 +1550,7 @@ class FilterTest extends BatchTestCase {
       + "   gender.gender.members\n"
       + ")\n"
       + "on 0 from sales\n";
-    assertQuerySql(context.getConnection(),
+    assertQuerySql(context.getConnectionWithDefaultRole(),
       mdx,
       new SqlPattern[] {
         new SqlPattern( DatabaseProduct.MYSQL, sql, null )

--- a/mondrian/src/test/java/mondrian/rolap/GroupingSetQueryTest.java
+++ b/mondrian/src/test/java/mondrian/rolap/GroupingSetQueryTest.java
@@ -68,7 +68,7 @@ class GroupingSetQueryTest extends BatchTestCase{
         //
         // ACCESS
         // ORACLE
-        final Dialect dialect = getDialect(context.getConnection());
+        final Dialect dialect = getDialect(context.getConnectionWithDefaultRole());
         if (context.getConfig().warnIfNoPatternForDialect().equals("ANY")
                 || getDatabaseProduct(dialect.getDialectName()) == DatabaseProduct.ACCESS
                 || getDatabaseProduct(dialect.getDialectName()) == DatabaseProduct.ORACLE)
@@ -87,7 +87,7 @@ class GroupingSetQueryTest extends BatchTestCase{
     void testGroupingSetsWithAggregateOverDefaultMember(Context context) {
         pripareContext(context);
         // testcase for MONDRIAN-705
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         if (getDialect(connection).supportsGroupingSets()) {
             ((TestConfig)context.getConfig()).setEnableGroupingSets(true);
         }
@@ -116,7 +116,7 @@ class GroupingSetQueryTest extends BatchTestCase{
     void testGroupingSetForSingleColumnConstraint(Context context) {
         pripareContext(context);
         ((TestConfig)context.getConfig()).setDisableCaching(false);
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         CellRequest request1 = createRequest(connection,
             cubeNameSales2, measureUnitSales, tableCustomer, fieldGender, "M");
 
@@ -172,7 +172,7 @@ class GroupingSetQueryTest extends BatchTestCase{
         };
 
         ((TestConfig)context.getConfig()).setEnableGroupingSets(true);
-        connection = context.getConnection();
+        connection = context.getConnectionWithDefaultRole();
 
         if (context.getConfig().readAggregates() && context.getConfig().useAggregates()) {
             assertRequestSql(connection,
@@ -206,7 +206,7 @@ class GroupingSetQueryTest extends BatchTestCase{
             return;
         }
 
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         CellRequest request1 = createRequest(connection,
             cubeNameSales,
             measureUnitSales, tableCustomer, fieldGender, "M");
@@ -237,7 +237,7 @@ class GroupingSetQueryTest extends BatchTestCase{
                 + "group by \"agg_g_ms_pcat_sales_fact_1997\".\"gender\"",
                 26)
         };
-        assertRequestSql(context.getConnection(),
+        assertRequestSql(context.getConnectionWithDefaultRole(),
             new CellRequest[] {request3, request1, request2},
             patternsWithoutGsets);
     }
@@ -249,7 +249,7 @@ class GroupingSetQueryTest extends BatchTestCase{
         if (context.getConfig().readAggregates() && context.getConfig().useAggregates()) {
             return;
         }
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         ((TestConfig)context.getConfig()).setEnableGroupingSets(true);
         CellRequest request1 = createRequest(connection,
             cubeNameSales2,
@@ -300,7 +300,7 @@ class GroupingSetQueryTest extends BatchTestCase{
             return;
         }
         ((TestConfig)context.getConfig()).setEnableGroupingSets(true);
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         CellRequest request1 = createRequest(connection,
             cubeNameSales2,
             measureUnitSales, tableCustomer, fieldGender, "M");
@@ -368,7 +368,7 @@ class GroupingSetQueryTest extends BatchTestCase{
             return;
         }
         ((TestConfig)context.getConfig()).setEnableGroupingSets(true);
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         CellRequest request1 = createRequest(connection,
             cubeNameSales2,
             measureUnitSales, tableCustomer, fieldGender, "M");
@@ -441,7 +441,7 @@ class GroupingSetQueryTest extends BatchTestCase{
             return;
         }
         ((TestConfig)context.getConfig()).setEnableGroupingSets(true);
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         CellRequest request1 = createRequest(connection,
             cubeNameSales2,
             measureUnitSales, new String[]{tableCustomer, tableTime},
@@ -529,7 +529,7 @@ class GroupingSetQueryTest extends BatchTestCase{
         compoundMembers.add(new String[] {"CANADA", "BC"});
         CellRequestConstraint constraint =
             makeConstraintCountryState(compoundMembers);
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         CellRequest request1 = createRequest(connection,
             cubeNameSales2,
             measureCustomerCount, new String[]{tableCustomer, tableTime},
@@ -585,7 +585,7 @@ class GroupingSetQueryTest extends BatchTestCase{
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testBug2004202(Context context) {
         pripareContext(context);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with member store.allbutwallawalla as\n"
             + " 'aggregate(\n"
             + "    except(\n"

--- a/mondrian/src/test/java/mondrian/rolap/IndexedValuesTest.java
+++ b/mondrian/src/test/java/mondrian/rolap/IndexedValuesTest.java
@@ -45,7 +45,7 @@ class IndexedValuesTest {
             + "{[Employees].[Sheri Nowmer]}\n"
             + "Row #0: $39,431.67\n"
             + "Row #0: 7,392\n";
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         // Query using name
         assertQueryReturns(connection,
             "SELECT {[Measures].[Org Salary], [Measures].[Count]} "

--- a/mondrian/src/test/java/mondrian/rolap/MemberCacheControlTest.java
+++ b/mondrian/src/test/java/mondrian/rolap/MemberCacheControlTest.java
@@ -108,7 +108,7 @@ class MemberCacheControlTest {
     }
 
     private void prepareTestContext(Context context) {
-        final RolapConnection conn = (RolapConnection) context.getConnection();
+        final RolapConnection conn = (RolapConnection) context.getConnectionWithDefaultRole();
         final Statement statement = conn.getInternalStatement();
         final ExecutionImpl execution = new ExecutionImpl(statement, Optional.empty());
         //locus = new Locus(execution, getName(), null);
@@ -306,7 +306,7 @@ class MemberCacheControlTest {
     void testFilter(Context context) {
     	context.getSchemaCache().clear();
         prepareTestContext(context);
-        final Connection conn = context.getConnection();
+        final Connection conn = context.getConnectionWithDefaultRole();
         final DiffRepository dr = getDiffRepos();
         final CacheControl cc = conn.getCacheControl(null);
 
@@ -327,7 +327,7 @@ class MemberCacheControlTest {
     	context.getSchemaCache().clear();
         SystemWideProperties.instance().EnableRolapCubeMemberCache = true;
         prepareTestContext(context);
-        final Connection conn = context.getConnection();
+        final Connection conn = context.getConnectionWithDefaultRole();
         final CacheControl cc = conn.getCacheControl(null);
         final MemberEditCommand command =
             cc.createDeleteCommand(findMember(conn, "Sales", "Retail", "OR"));
@@ -351,7 +351,7 @@ class MemberCacheControlTest {
     void testSetPropertyCommandOnLeafMember(Context context) {
     	context.getSchemaCache().clear();
     	prepareTestContext(context);
-        final Connection conn = context.getConnection();
+        final Connection conn = context.getConnectionWithDefaultRole();
         final DiffRepository dr = getDiffRepos();
         final CacheControl cc = conn.getCacheControl(null);
 
@@ -409,7 +409,7 @@ class MemberCacheControlTest {
     void testSetPropertyCommandOnNonLeafMember(Context context) {
     	context.getSchemaCache().clear();
     	prepareTestContext(context);
-        final Connection conn = context.getConnection();
+        final Connection conn = context.getConnectionWithDefaultRole();
         final DiffRepository dr = getDiffRepos();
         final CacheControl cc = conn.getCacheControl(null);
 
@@ -476,7 +476,7 @@ class MemberCacheControlTest {
     void testAddCommand(Context context) {
     	context.getSchemaCache().clear();
         prepareTestContext(context);
-        final Connection conn = context.getConnection();
+        final Connection conn = context.getConnectionWithDefaultRole();
         final CacheControl cc = conn.getCacheControl(null);
         final RolapCubeMember caCubeMember =
             (RolapCubeMember) findMember(conn, "Sales", "Retail", "CA");
@@ -695,7 +695,7 @@ class MemberCacheControlTest {
     void testDeleteCommand(Context context) {
     	context.getSchemaCache().clear();
         prepareTestContext(context);
-        final Connection conn = context.getConnection();
+        final Connection conn = context.getConnectionWithDefaultRole();
         final CacheControl cc = conn.getCacheControl(null);
         final RolapCubeMember sfCubeMember =
             (RolapCubeMember) findMember(
@@ -771,7 +771,7 @@ class MemberCacheControlTest {
     void testMoveCommand(Context context) {
     	context.getSchemaCache().clear();
         prepareTestContext(context);
-        final Connection conn = context.getConnection();
+        final Connection conn = context.getConnectionWithDefaultRole();
         final CacheControl cc = conn.getCacheControl(null);
         final RolapCubeMember caCubeMember =
             (RolapCubeMember) findMember(conn, "Sales", "Retail", "CA");
@@ -859,7 +859,7 @@ class MemberCacheControlTest {
     void testMoveFailBadLevel(Context context) {
     	context.getSchemaCache().clear();
         prepareTestContext(context);
-        final Connection conn = context.getConnection();
+        final Connection conn = context.getConnectionWithDefaultRole();
         final CacheControl cc = conn.getCacheControl(null);
         final RolapCubeMember caCubeMember =
             (RolapCubeMember) findMember(conn, "Sales", "Retail", "CA");
@@ -942,7 +942,7 @@ class MemberCacheControlTest {
     void testAddCommandNegative(Context context) {
     	context.getSchemaCache().clear();
         prepareTestContext(context);
-        final Connection conn = context.getConnection();
+        final Connection conn = context.getConnectionWithDefaultRole();
         final CacheControl cc = conn.getCacheControl(null);
 
         MemberEditCommand command;
@@ -1055,11 +1055,11 @@ class MemberCacheControlTest {
     void testFlushHierarchy(Context context) {
     	context.getSchemaCache().clear();
         prepareTestContext(context);
-        flushCache(context.getConnection());
+        flushCache(context.getConnectionWithDefaultRole());
         final CacheControl cacheControl =
-            context.getConnection().getCacheControl(null);
+            context.getConnectionWithDefaultRole().getCacheControl(null);
         final Cube salesCube =
-                context.getConnection()
+                context.getConnectionWithDefaultRole()
                 .getSchema().lookupCube("Sales", true);
 
         final Logger logger = RolapUtil.SQL_LOGGER;
@@ -1084,7 +1084,7 @@ class MemberCacheControlTest {
                 };
 
             final Result result =
-                executeQuery(context.getConnection(),
+                executeQuery(context.getConnectionWithDefaultRole(),
                     "select [Store].[Mexico].[Yucatan] on 0 from [Sales]");
             final Member storeYucatanMember =
                 result.getAxes()[0].getPositions().get(0).get(0);
@@ -1106,7 +1106,7 @@ class MemberCacheControlTest {
 					public void run() {
                         // Check that <Member>.Children uses cache when applied
                         // to an 'all' member.
-                        assertAxisReturns(context.getConnection(),
+                        assertAxisReturns(context.getConnectionWithDefaultRole(),
                             "[Store].Children",
                             "[Store].[Canada]\n"
                             + "[Store].[Mexico]\n"
@@ -1120,7 +1120,7 @@ class MemberCacheControlTest {
 					public void run() {
                         // Check that <Member>.Children uses cache when applied
                         // to regular member.
-                        assertAxisReturns(context.getConnection(),
+                        assertAxisReturns(context.getConnectionWithDefaultRole(),
                             "[Store].[USA].[CA].Children",
                             "[Store].[USA].[CA].[Alameda]\n"
                             + "[Store].[USA].[CA].[Beverly Hills]\n"
@@ -1139,7 +1139,7 @@ class MemberCacheControlTest {
 					public void run() {
                         // Check that <Member>.Children uses cache when applied
                         // to regular member.
-                        assertAxisReturns(context.getConnection(),
+                        assertAxisReturns(context.getConnectionWithDefaultRole(),
                             "[Store].[USA].[CA].Children",
                             "[Store].[USA].[CA].[Alameda]\n"
                             + "[Store].[USA].[CA].[Beverly Hills]\n"
@@ -1154,7 +1154,7 @@ class MemberCacheControlTest {
                     @Override
 					public void run() {
                         // Check that <Hierarchy>.Members uses cache.
-                        assertExprReturns(context.getConnection(),
+                        assertExprReturns(context.getConnectionWithDefaultRole(),
                             "Count([Store].Members)", "63");
                     }
                 });
@@ -1163,7 +1163,7 @@ class MemberCacheControlTest {
                     @Override
 					public void run() {
                         // Check that <Level>.Members uses cache.
-                        assertExprReturns(context.getConnection(),
+                        assertExprReturns(context.getConnectionWithDefaultRole(),
                             "Count([Store].[Store Name].Members)", "25");
                     }
                 });
@@ -1192,7 +1192,7 @@ class MemberCacheControlTest {
                     @Override
 					public void run() {
                         // Check that <Level>.Members uses cache.
-                        assertExprReturns(context.getConnection(),
+                        assertExprReturns(context.getConnectionWithDefaultRole(),
                             "Count([Time].[Month].Members)",
                             "24");
                     }
@@ -1203,7 +1203,7 @@ class MemberCacheControlTest {
                     @Override
 					public void run() {
                         // Check that <Level>.Members uses cache.
-                        assertAxisReturns(context.getConnection(),
+                        assertAxisReturns(context.getConnectionWithDefaultRole(),
                             "[Time].[1997].[Q2].Children",
                             "[Time].[1997].[Q2].[4]\n"
                             + "[Time].[1997].[Q2].[5]\n"

--- a/mondrian/src/test/java/mondrian/rolap/NativeEvalVirtualCubeTest.java
+++ b/mondrian/src/test/java/mondrian/rolap/NativeEvalVirtualCubeTest.java
@@ -45,7 +45,7 @@ class NativeEvalVirtualCubeTest extends BatchTestCase {
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testSimpleFullyJoiningCJ(Context context) {
-    verifySameNativeAndNot(context.getConnection(),
+    verifySameNativeAndNot(context.getConnectionWithDefaultRole(),
         "select {measures.[unit sales], measures.[warehouse sales]} on 0, "
         + " nonemptycrossjoin( Gender.Gender.members, product.[product category].members) on 1 "
         + "from [warehouse and sales]",
@@ -59,8 +59,8 @@ class NativeEvalVirtualCubeTest extends BatchTestCase {
       + " NON EMPTY Crossjoin ( Gender.gender.members, product.[product category].members) on 1 "
       + " from [warehouse and sales]";
 
-      verifySameNativeAndNot(context.getConnection(), query, "");
-      assertQueryReturns(context.getConnection(),
+      verifySameNativeAndNot(context.getConnectionWithDefaultRole(), query, "");
+      assertQueryReturns(context.getConnectionWithDefaultRole(),
           query,
           "Axis #0:\n"
           + "{}\n"
@@ -75,7 +75,7 @@ class NativeEvalVirtualCubeTest extends BatchTestCase {
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testOneFullyJoiningCube(Context context) {
-    verifySameNativeAndNot(context.getConnection(),
+    verifySameNativeAndNot(context.getConnectionWithDefaultRole(),
         "select {measures.[unit sales], measures.[warehouse sales]} on 0, "
         + " nonemptycrossjoin( Gender.Gender.members, product.[product category].members) on 1 "
         + "from [warehouse and sales]",
@@ -83,7 +83,7 @@ class NativeEvalVirtualCubeTest extends BatchTestCase {
   }
 
   void testNoApplicableCube(Context context) {
-    verifySameNativeAndNot(context.getConnection(),
+    verifySameNativeAndNot(context.getConnectionWithDefaultRole(),
         "select {measures.[unit sales]} on 0, "
         + " nonemptycrossjoin( Gender.Gender.members, [Warehouse].[All Warehouses].children) on 1 "
         + "from [warehouse and sales]",
@@ -98,7 +98,7 @@ class NativeEvalVirtualCubeTest extends BatchTestCase {
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testShouldBeFullyJoiningCJ(Context context) {
-    verifySameNativeAndNot(context.getConnection(),
+    verifySameNativeAndNot(context.getConnectionWithDefaultRole(),
         "select measures.[warehouse Sales] on 0, "
         + " nonemptycrossjoin( Gender.[All Gender], "
         + "product.[product category].members)"
@@ -109,7 +109,7 @@ class NativeEvalVirtualCubeTest extends BatchTestCase {
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testMeasureChangesContextOfInapplicableDimension(Context context) {
-      verifySameNativeAndNot(context.getConnection(),
+      verifySameNativeAndNot(context.getConnectionWithDefaultRole(),
           "with member [Measures].[allW] as \n"
           + "'([Measures].[Unit Sales], [Warehouse].[All Warehouses])'\n"
           + "select NON EMPTY Crossjoin(\n"
@@ -132,8 +132,8 @@ class NativeEvalVirtualCubeTest extends BatchTestCase {
         + "{ [Measures].[allW]}\n"
         + "ON ROWS\n"
         + "from [Warehouse and Sales]";
-    verifySameNativeAndNot(context.getConnection(), query, "");
-    assertQueryReturns(context.getConnection(),
+    verifySameNativeAndNot(context.getConnectionWithDefaultRole(), query, "");
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
         query,
         "Axis #0:\n"
         + "{}\n"
@@ -176,7 +176,7 @@ class NativeEvalVirtualCubeTest extends BatchTestCase {
         + "{ [Measures].[validUS]}\n"
         + "ON ROWS\n"
         + "from [Warehouse and Sales]";
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
         query,
         "Axis #0:\n"
         + "{}\n"
@@ -207,7 +207,7 @@ class NativeEvalVirtualCubeTest extends BatchTestCase {
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testDisjointDimensionCJ(Context context) {
     // No fully joining dimensions.
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
         "with member measures.vmWS as 'ValidMeasure(measures.[Warehouse Sales])'"
         + " select NON EMPTY Crossjoin(\n"
         + "{[Warehouse].[State Province].members}, {Gender.[All Gender].children} ) \n"
@@ -244,7 +244,7 @@ class NativeEvalVirtualCubeTest extends BatchTestCase {
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testWarehouseForcedToAllLevel(Context context) {
-    verifySameNativeAndNot(context.getConnection(),
+    verifySameNativeAndNot(context.getConnectionWithDefaultRole(),
         "with member [Measures].[validUS] as \n"
         + "'ValidMeasure([Measures].[Unit Sales])'\n"
         + "select NON EMPTY Crossjoin(\n"
@@ -258,7 +258,7 @@ class NativeEvalVirtualCubeTest extends BatchTestCase {
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testMdxCJOfApplicableAndNonApplicable(Context context) {
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
         "WITH\n"
         + "MEMBER Measures.[ValidM Unit Sales] as 'ValidMeasure([Measures].[Unit Sales])' "
         + "SET [*NATIVE_CJ_SET_WITH_SLICER] AS 'NONEMPTYCROSSJOIN([*BASE_MEMBERS__Warehouse_],[*BASE_MEMBERS__Gender_])"
@@ -297,7 +297,7 @@ class NativeEvalVirtualCubeTest extends BatchTestCase {
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testAllMemberTupleInapplicableDim(Context context) {
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
         "WITH\n"
         + "SET [*NATIVE_CJ_SET_WITH_SLICER] AS 'NONEMPTYCROSSJOIN([*BASE_MEMBERS__Warehouse_],"
         + "[*BASE_MEMBERS__Gender_])'\n"
@@ -355,7 +355,7 @@ class NativeEvalVirtualCubeTest extends BatchTestCase {
     // and marital status are
     // natively evaluated in a cj, with warehouse evaluated in a separate
     // group.  The sets need to be reassembled and projected correctly).
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
         "with member measures.vmUS as 'ValidMeasure(Measures.[Unit Sales])' "
         + "select non empty crossjoin(crossjoin(gender.gender.members, warehouse.[USA].[CA]), [marital status].[marital status].members) on 0, "
         + " measures.vmUS on 1 from [warehouse and sales]",
@@ -382,8 +382,8 @@ class NativeEvalVirtualCubeTest extends BatchTestCase {
     // cache results from the first query, since it *does* use VM.
     executeQuery(
         "select non empty crossjoin(gender.gender.members, warehouse.[USA].[CA]) on 0, "
-        + "measures.[unit sales] on 1 from [warehouse and sales]", context.getConnection());
-    assertQueryReturns(context.getConnection(),
+        + "measures.[unit sales] on 1 from [warehouse and sales]", context.getConnectionWithDefaultRole());
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
         "with member measures.vm as 'validmeasure(measures.[unit sales])' "
         + "select non empty crossjoin(gender.gender.members, warehouse.[USA].[CA]) on 0, "
         + "measures.vm on 1 from [warehouse and sales]",
@@ -521,13 +521,13 @@ class NativeEvalVirtualCubeTest extends BatchTestCase {
             + "FROM [Warehouse and Sales]";
     // first MDX with a fresh query should result in product_family,
     //product_department and the_year query.
-    assertQuerySqlOrNot(context.getConnection(),
+    assertQuerySqlOrNot(context.getConnectionWithDefaultRole(),
         mdx, new SqlPattern[]{ mysqlPatternMembers }, false, false, false);
     // rerun the MDX, since the previous assert aborts when it hits the SQL.
-    executeQuery(mdx, context.getConnection());
+    executeQuery(mdx, context.getConnectionWithDefaultRole());
     // Subsequent query should pull from cache, not rerun product_family,
     //product_department and the_year query.
-    assertQuerySqlOrNot(context.getConnection(),
+    assertQuerySqlOrNot(context.getConnectionWithDefaultRole(),
         mdx, new SqlPattern[]{ mysqlPatternMembers }, true, false, false);
     //The MDX with added Warehouse Sales measure
     //that belongs to the regulr [Warehouse].
@@ -546,7 +546,7 @@ class NativeEvalVirtualCubeTest extends BatchTestCase {
             + "FROM [Warehouse and Sales]";
     // Subsequent query should pull from cache, not rerun product_family,
     //product_department and the_year query.
-    assertQuerySqlOrNot(context.getConnection(),
+    assertQuerySqlOrNot(context.getConnectionWithDefaultRole(),
         mdx1, new SqlPattern[]{ mysqlPatternMembers }, true, false, false);
   }
 }

--- a/mondrian/src/test/java/mondrian/rolap/NativeFilterAgainstAggTableTest.java
+++ b/mondrian/src/test/java/mondrian/rolap/NativeFilterAgainstAggTableTest.java
@@ -92,7 +92,7 @@ class NativeFilterAgainstAggTableTest extends BatchTestCase {
             + "Row #0: 1,959\n"
             + "Row #0: 4,090\n";
 
-        doTestFilteringOnAggregatedBy(context.getConnection(), "COUNT", query, expectedResult);
+        doTestFilteringOnAggregatedBy(context.getConnectionWithDefaultRole(), "COUNT", query, expectedResult);
     }
 
     @ParameterizedTest
@@ -121,7 +121,7 @@ class NativeFilterAgainstAggTableTest extends BatchTestCase {
             + "Row #0: 101,261.32\n"
             + "Row #0: 26,781.23\n";
 
-        doTestFilteringOnAggregatedBy(context.getConnection(), "SUM", query, expectedResult);
+        doTestFilteringOnAggregatedBy(context.getConnectionWithDefaultRole(), "SUM", query, expectedResult);
     }
 
     private void doTestFilteringOnAggregatedBy(
@@ -166,7 +166,7 @@ class NativeFilterAgainstAggTableTest extends BatchTestCase {
             + "    `agg_c_10_sales_fact_1997`.`the_year`,\n"
             + "    `agg_c_10_sales_fact_1997`.`quarter`\n"
             + "order by\n"
-            + (getDialect(context.getConnection()).requiresOrderByAlias()
+            + (getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
                 ? "    ISNULL(`c0`) ASC, `c0` ASC,\n"
                 + "    ISNULL(`c1`) ASC, `c1` ASC"
                 : "    ISNULL(`agg_c_10_sales_fact_1997`.`the_year`) ASC, `agg_c_10_sales_fact_1997`.`the_year` ASC,\n"
@@ -177,11 +177,11 @@ class NativeFilterAgainstAggTableTest extends BatchTestCase {
         // This query should hit the agg_c_10_sales_fact_1997 agg table,
         // which has [unit sales] but not [store count], so should
         // not include the filter condition in the having.
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         TestUtil.flushCache(connection);
         TestUtil.flushSchemaCache(connection);
         assertQuerySqlOrNot(
-             context.getConnection(),
+             context.getConnectionWithDefaultRole(),
             "select filter(Time.[1997].children,  "
             + "measures.[Sales Count] +  measures.[unit sales] > 0) on 0 "
             + "from [sales]",
@@ -201,7 +201,7 @@ class NativeFilterAgainstAggTableTest extends BatchTestCase {
             + "having\n"
             + "    ((sum(`agg_c_10_sales_fact_1997`.`store_sales`) + sum(`agg_c_10_sales_fact_1997`.`unit_sales`)) > 0)\n"
             + "order by\n"
-            + (getDialect(context.getConnection()).requiresOrderByAlias()
+            + (getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
                 ? "    ISNULL(`c0`) ASC, `c0` ASC,\n"
                 + "    ISNULL(`c1`) ASC, `c1` ASC"
                 : "    ISNULL(`agg_c_10_sales_fact_1997`.`the_year`) ASC, `agg_c_10_sales_fact_1997`.`the_year` ASC,\n"
@@ -212,7 +212,7 @@ class NativeFilterAgainstAggTableTest extends BatchTestCase {
         // both measures are present on the agg table, so this one *should*
         // include having.
         assertQuerySqlOrNot(
-            context.getConnection(),
+            context.getConnectionWithDefaultRole(),
             "select filter(Time.[1997].children,  "
             + "measures.[Store Sales] +  measures.[unit sales] > 0) on 0 "
             + "from [sales]",

--- a/mondrian/src/test/java/mondrian/rolap/NativeFilterMatchingTest.java
+++ b/mondrian/src/test/java/mondrian/rolap/NativeFilterMatchingTest.java
@@ -90,7 +90,7 @@ class NativeFilterMatchingTest extends BatchTestCase {
             "select \"customer\".\"country\" as \"c0\", \"customer\".\"state_province\" as \"c1\", \"customer\".\"city\" as \"c2\", \"customer\".\"customer_id\" as \"c3\", fullname as \"c4\", fullname as \"c5\", \"customer\".\"gender\" as \"c6\", \"customer\".\"marital_status\" as \"c7\", \"customer\".\"education\" as \"c8\", \"customer\".\"yearly_income\" as \"c9\" from \"customer\" as \"customer\" group by \"customer\".\"country\", \"customer\".\"state_province\", \"customer\".\"city\", \"customer\".\"customer_id\", fullname, \"customer\".\"gender\", \"customer\".\"marital_status\", \"customer\".\"education\", \"customer\".\"yearly_income\" having cast(fullname as text) is not null and cast(fullname as text) ~ '(?i).*jeanne.*'  order by \"customer\".\"country\" ASC NULLS LAST, \"customer\".\"state_province\" ASC NULLS LAST, \"customer\".\"city\" ASC NULLS LAST, fullname ASC NULLS LAST";
         final String sqlMysql =
             "select `customer`.`country` as `c0`, `customer`.`state_province` as `c1`, `customer`.`city` as `c2`, `customer`.`customer_id` as `c3`, CONCAT(`customer`.`fname`, ' ', `customer`.`lname`) as `c4`, CONCAT(`customer`.`fname`, ' ', `customer`.`lname`) as `c5`, `customer`.`gender` as `c6`, `customer`.`marital_status` as `c7`, `customer`.`education` as `c8`, `customer`.`yearly_income` as `c9` from `customer` as `customer` group by `customer`.`country`, `customer`.`state_province`, `customer`.`city`, `customer`.`customer_id`, CONCAT(`customer`.`fname`, ' ', `customer`.`lname`), `customer`.`gender`, `customer`.`marital_status`, `customer`.`education`, `customer`.`yearly_income` having c5 IS NOT NULL AND UPPER(c5) REGEXP '.*JEANNE.*' order by "
-                + (getDialect(context.getConnection()).requiresOrderByAlias()
+                + (getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
                     ? "ISNULL(`c0`) ASC, `c0` ASC, "
                     + "ISNULL(`c1`) ASC, `c1` ASC, "
                     + "ISNULL(`c2`) ASC, `c2` ASC, "
@@ -147,17 +147,17 @@ class NativeFilterMatchingTest extends BatchTestCase {
             + "CrossJoin([*SORTED_COL_AXIS],[*BASE_MEMBERS_Measures]) on columns\n"
             + "From [Sales]";
         assertQuerySqlOrNot(
-            context.getConnection(),
+            context.getConnectionWithDefaultRole(),
             query,
             patterns,
             false,
             true,
             true);
         assertQueryReturns(
-            context.getConnection(),
+            context.getConnectionWithDefaultRole(),
             query,
             queryResults);
-        verifySameNativeAndNot(context.getConnection(), query, null);
+        verifySameNativeAndNot(context.getConnectionWithDefaultRole(), query, null);
     }
 
     @ParameterizedTest
@@ -175,7 +175,7 @@ class NativeFilterMatchingTest extends BatchTestCase {
             "select \"customer\".\"country\" as \"c0\", \"customer\".\"state_province\" as \"c1\", \"customer\".\"city\" as \"c2\", \"customer\".\"customer_id\" as \"c3\", fullname as \"c4\", fullname as \"c5\", \"customer\".\"gender\" as \"c6\", \"customer\".\"marital_status\" as \"c7\", \"customer\".\"education\" as \"c8\", \"customer\".\"yearly_income\" as \"c9\" from \"customer\" as \"customer\" group by \"customer\".\"country\", \"customer\".\"state_province\", \"customer\".\"city\", \"customer\".\"customer_id\", fullname, \"customer\".\"gender\", \"customer\".\"marital_status\", \"customer\".\"education\", \"customer\".\"yearly_income\" having NOT(cast(fullname as text) is not null and cast(fullname as text) ~ '(?i).*jeanne.*')  order by \"customer\".\"country\" ASC NULLS LAST, \"customer\".\"state_province\" ASC NULLS LAST, \"customer\".\"city\" ASC NULLS LAST, fullname ASC NULLS LAST";
         final String sqlMysql =
             "select `customer`.`country` as `c0`, `customer`.`state_province` as `c1`, `customer`.`city` as `c2`, `customer`.`customer_id` as `c3`, CONCAT(`customer`.`fname`, ' ', `customer`.`lname`) as `c4`, CONCAT(`customer`.`fname`, ' ', `customer`.`lname`) as `c5`, `customer`.`gender` as `c6`, `customer`.`marital_status` as `c7`, `customer`.`education` as `c8`, `customer`.`yearly_income` as `c9` from `customer` as `customer` group by `customer`.`country`, `customer`.`state_province`, `customer`.`city`, `customer`.`customer_id`, CONCAT(`customer`.`fname`, ' ', `customer`.`lname`), `customer`.`gender`, `customer`.`marital_status`, `customer`.`education`, `customer`.`yearly_income` having NOT(c5 IS NOT NULL AND UPPER(c5) REGEXP '.*JEANNE.*')  order by "
-                + (getDialect(context.getConnection()).requiresOrderByAlias()
+                + (getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
                     ? "ISNULL(`c0`) ASC, `c0` ASC, "
                     + "ISNULL(`c1`) ASC, `c1` ASC, "
                     + "ISNULL(`c2`) ASC, `c2` ASC, "
@@ -209,17 +209,17 @@ class NativeFilterMatchingTest extends BatchTestCase {
             + "From [Sales]";
 
         assertQuerySqlOrNot(
-            context.getConnection(),
+            context.getConnectionWithDefaultRole(),
             query,
             patterns,
             false,
             true,
             true);
 
-        final Result result = executeQuery(query, context.getConnection());
+        final Result result = executeQuery(query, context.getConnectionWithDefaultRole());
         final String resultString = TestUtil.toString(result);
         assertFalse(resultString.contains("Jeanne"));
-        verifySameNativeAndNot(context.getConnection(), query, null);
+        verifySameNativeAndNot(context.getConnectionWithDefaultRole(), query, null);
     }
 
     /**
@@ -232,7 +232,7 @@ class NativeFilterMatchingTest extends BatchTestCase {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testMatchBugMondrian983(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "With\n"
             + "Set [*NATIVE_CJ_SET] as 'Filter([*BASE_MEMBERS_Product], Not IsEmpty ([Measures].[Unit Sales]))' \n"
             + "Set [*SORTED_ROW_AXIS] as 'Order([*CJ_ROW_AXIS],[Product].CurrentMember.OrderKey,BASC,Ancestor([Product].CurrentMember,[Product].[Product Department]).OrderKey,BASC)' \n"
@@ -262,7 +262,7 @@ class NativeFilterMatchingTest extends BatchTestCase {
         // http://jira.pentaho.com/browse/MONDRIAN-1694
         // In some cases native filter would includes an unnecessary fact table
         // join which incorrectly eliminated some tuples from the set
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         verifySameNativeAndNot(connection,
             "select Filter([Store].[Store Name].Members, Store.CurrentMember.Name matches \"Store.*\") "
             + " on 0 from sales",
@@ -296,7 +296,7 @@ class NativeFilterMatchingTest extends BatchTestCase {
 
         // verify that the RolapNativeSet cached values from NON EMPTY context
         // are not reused when not NON EMPTY.
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         verifySameNativeAndNot(connection,
             "select NON EMPTY Filter([Store].[Store Name].Members, Store.CurrentMember.Name matches \"Store.*\") "
             + " on 0 from sales",
@@ -455,7 +455,7 @@ class NativeFilterMatchingTest extends BatchTestCase {
             && SystemWideProperties.instance().EnableNativeNonEmpty)
         {
             boolean requiresOrderByAlias =
-                    getDialect(context.getConnection()).requiresOrderByAlias();
+                    getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias();
             final String sqlMysql =
                 context.getConfig().useAggregates() == false
                     ? "select\n"
@@ -515,10 +515,10 @@ class NativeFilterMatchingTest extends BatchTestCase {
                         : "    ISNULL(`agg_c_14_sales_fact_1997`.`the_year`) ASC, `agg_c_14_sales_fact_1997`.`the_year` ASC,\n"
                         + "    ISNULL(`agg_c_14_sales_fact_1997`.`quarter`) ASC, `agg_c_14_sales_fact_1997`.`quarter` ASC");
             final SqlPattern[] patterns = mysqlPattern(sqlMysql);
-            context.getConnection().getCacheControl(null).flushSchemaCache();
+            context.getConnectionWithDefaultRole().getCacheControl(null).flushSchemaCache();
             // Make sure the tuples list is using the HAVING clause.
             assertQuerySqlOrNot(
-            	context.getConnection(),
+            	context.getConnectionWithDefaultRole(),
                 mdx,
                 patterns,
                 false,
@@ -526,7 +526,7 @@ class NativeFilterMatchingTest extends BatchTestCase {
                 true);
         }
         // Make sure the numbers are right
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             mdx,
             "Axis #0:\n"
             + "{[Product].[Drink].[Alcoholic Beverages].[Beer and Wine].[Beer].[Good].[Good Imported Beer]}\n"
@@ -575,7 +575,7 @@ class NativeFilterMatchingTest extends BatchTestCase {
                 + "having\n"
                 + "    (sum(`agg_c_14_sales_fact_1997`.`unit_sales`) > 80)\n"
                 + "order by\n"
-                + (getDialect(context.getConnection()).requiresOrderByAlias()
+                + (getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
                     ? "    ISNULL(`c0`) ASC, `c0` ASC,\n"
                     + "    ISNULL(`c1`) ASC, `c1` ASC"
                     : "    ISNULL(`agg_c_14_sales_fact_1997`.`the_year`) ASC, `agg_c_14_sales_fact_1997`.`the_year` ASC,\n"
@@ -583,9 +583,9 @@ class NativeFilterMatchingTest extends BatchTestCase {
             final SqlPattern[] patterns = mysqlPattern(sqlMysql);
 
             // Make sure the tuples list is using the HAVING clause.
-            context.getConnection().getCacheControl(null).flushSchemaCache();
+            context.getConnectionWithDefaultRole().getCacheControl(null).flushSchemaCache();
             assertQuerySqlOrNot(
-                context.getConnection(),
+                context.getConnectionWithDefaultRole(),
                 mdx,
                 patterns,
                 false,
@@ -594,7 +594,7 @@ class NativeFilterMatchingTest extends BatchTestCase {
         }
         // Make sure the numbers are right
         assertQueryReturns(
-            context.getConnection(),
+            context.getConnectionWithDefaultRole(),
             mdx,
             "Axis #0:\n"
             + "{[Product].[Drink].[Alcoholic Beverages].[Beer and Wine].[Beer].[Good].[Good Imported Beer]}\n"
@@ -621,7 +621,7 @@ class NativeFilterMatchingTest extends BatchTestCase {
             && SystemWideProperties.instance().EnableNativeNonEmpty)
         {
             boolean requiresOrderByAlias =
-                    getDialect(context.getConnection()).requiresOrderByAlias();
+                    getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias();
             final String sqlMysql =
                 context.getConfig().useAggregates() == false
                     ? "select\n"
@@ -738,7 +738,7 @@ class NativeFilterMatchingTest extends BatchTestCase {
 
             // Make sure the tuples list is using the HAVING clause.
             assertQuerySqlOrNot(
-                context.getConnection(),
+                context.getConnectionWithDefaultRole(),
                 mdx,
                 patterns,
                 false,
@@ -746,7 +746,7 @@ class NativeFilterMatchingTest extends BatchTestCase {
                 true);
         }
         // Make sure the numbers are right
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             mdx,
             "Axis #0:\n"
             + "{[Product].[Drink].[Alcoholic Beverages].[Beer and Wine].[Beer]}\n"
@@ -759,7 +759,7 @@ class NativeFilterMatchingTest extends BatchTestCase {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testNativeFilterWithCompoundSlicer_2(Context context) {
-        verifySameNativeAndNot(context.getConnection(),
+        verifySameNativeAndNot(context.getConnectionWithDefaultRole(),
             "WITH MEMBER [Measures].[TotalVal] AS 'Aggregate(Filter({[Store].[Store City].members}, ([Measures].[Unit Sales] > 1000 OR ( [Measures].[Unit Sales] > 40 AND [Store].[Store City].CurrentMember.Name = \"San Francisco\" ) ) ) )'\n"
             + "SELECT [Measures].[TotalVal] ON 0, [Product].[All Products].Children on 1 FROM [Sales] WHERE {[Time].[1997].[Q1],[Time].[1997].[Q2]}",
             "Failed.");
@@ -768,7 +768,7 @@ class NativeFilterMatchingTest extends BatchTestCase {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testNativeFilterWithCompoundSlicer_3(Context context) {
-        verifySameNativeAndNot(context.getConnection(),
+        verifySameNativeAndNot(context.getConnectionWithDefaultRole(),
             "WITH MEMBER [Measures].[TotalVal] AS 'Aggregate(Filter({[Store].[Store City].members}, [Measures].[Unit Sales] > 1000 ) )'\n"
             + "SELECT [Measures].[TotalVal] ON 0, [Product].[All Products].Children on 1 FROM [Sales] WHERE {[Time].[1997].[Q1],[Time].[1997].[Q2]}",
             "Failed.");
@@ -777,7 +777,7 @@ class NativeFilterMatchingTest extends BatchTestCase {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testNativeFilterWithCompoundSlicer_4(Context context) {
-        verifySameNativeAndNot(context.getConnection(),
+        verifySameNativeAndNot(context.getConnectionWithDefaultRole(),
             "WITH MEMBER [Measures].[TotalVal] AS 'Aggregate(Filter({[Store].[Store City].members}, ([Measures].[Unit Sales] > 1000 OR ( [Measures].[Unit Sales] > 500 AND [Store].[Store City].CurrentMember.Name = \"San Francisco\" ) ) ) )'\n"
             + "SELECT [Measures].[TotalVal] ON 0, [Product].[All Products].Children on 1 FROM [Sales] WHERE {[Time].[1997].[Q1],[Time].[1997].[Q2]}",
             "Failed.");
@@ -786,7 +786,7 @@ class NativeFilterMatchingTest extends BatchTestCase {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testNativeFilterWithCompoundSlicerDifferentProducts(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with member measures.avgQtrs as 'count(filter(Customers.[Name].members, [Unit Sales] > 0))' "
             + "select measures.avgQtrs on 0 from sales where ( {[Product].[Drink].[Alcoholic Beverages].[Beer and Wine].[Beer], [Product].[Food].[Baked Goods].[Bread].[Muffins]} )",
             "Axis #0:\n"

--- a/mondrian/src/test/java/mondrian/rolap/NonEmptyPropertyForAllAxisTest.java
+++ b/mondrian/src/test/java/mondrian/rolap/NonEmptyPropertyForAllAxisTest.java
@@ -92,7 +92,7 @@ class NonEmptyPropertyForAllAxisTest {
             + "Row #3: \n"
             + "Row #3: \n"
             + "Row #3: \n";
-        assertQueryReturns(context.getConnection(), MDX_QUERY, EXPECTED_RESULT);
+        assertQueryReturns(context.getConnectionWithDefaultRole(), MDX_QUERY, EXPECTED_RESULT);
     }
 
     @ParameterizedTest
@@ -217,7 +217,7 @@ class NonEmptyPropertyForAllAxisTest {
             + "Row #52: \n"
             + "Row #53: \n"
             + "Row #54: 2\n";
-        assertQueryReturns(context.getConnection(), MDX_QUERY, EXPECTED_RESULT);
+        assertQueryReturns(context.getConnectionWithDefaultRole(), MDX_QUERY, EXPECTED_RESULT);
     }
 
     @ParameterizedTest
@@ -227,7 +227,7 @@ class NonEmptyPropertyForAllAxisTest {
         SystemWideProperties.instance().EnableNonEmptyOnAllAxis = true;
         String mdxQuery = "select from [Sales]\n"
             + "where [Time].[1997]\n";
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         Query query = connection.parseQuery(mdxQuery);
         assertEqualsVerbose(mdxQuery, query.toString());
      }

--- a/mondrian/src/test/java/mondrian/rolap/NonEmptyTest.java
+++ b/mondrian/src/test/java/mondrian/rolap/NonEmptyTest.java
@@ -141,7 +141,7 @@ class NonEmptyTest extends BatchTestCase {
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testBugCantRestrictSlicerToCalcMember(Context context) throws Exception {
     ((TestConfig)context.getConfig()).setLevelPreCacheThreshold(0);
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "WITH Member [Time].[Time].[Aggr] AS 'Aggregate({[Time].[1998].[Q1], [Time].[1998].[Q2]})' "
         + "SELECT {[Measures].[Store Sales]} ON COLUMNS, "
         + "NON EMPTY Order(TopCount([Customers].[Name].Members,3,[Measures].[Store Sales]),[Measures].[Store Sales],"
@@ -173,7 +173,7 @@ class NonEmptyTest extends BatchTestCase {
     mondrianProperties.EnableNativeNonEmpty = false;
     mondrianProperties.ResultLimit = 5000000;
 
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "with set [*NATIVE_CJ_SET] as 'NonEmptyCrossJoin([*BASE_MEMBERS_Education Level], NonEmptyCrossJoin"
         + "([*BASE_MEMBERS_Product], NonEmptyCrossJoin([*BASE_MEMBERS_Customers], [*BASE_MEMBERS_Time])))' "
         + "set [*METRIC_CJ_SET] as 'Filter([*NATIVE_CJ_SET], ([Measures].[*TOP_Unit Sales_SEL~SUM] <= 2.0))' "
@@ -632,7 +632,7 @@ class NonEmptyTest extends BatchTestCase {
 @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testBug1961163(Context context) throws Exception {
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "with member [Measures].[AvgRevenue] as 'Avg([Store].[Store Name].Members, [Measures].[Store Sales])' "
         + "select NON EMPTY {[Measures].[Store Sales], [Measures].[AvgRevenue]} ON COLUMNS, "
         + "NON EMPTY Filter([Store].[Store Name].Members, ([Measures].[AvgRevenue] < [Measures].[Store Sales])) ON "
@@ -679,7 +679,7 @@ class NonEmptyTest extends BatchTestCase {
   void testTopCountWithCalcMemberInSlicer(Context context) {
     // Internal error: can not restrict SQL to calculated Members
     ((TestConfig)context.getConfig()).setLevelPreCacheThreshold(0);
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "with member [Time].[Time].[First Term] as 'Aggregate({[Time].[1997].[Q1], [Time].[1997].[Q2]})' "
         + "select {[Measures].[Unit Sales]} ON COLUMNS, "
         + "TopCount([Product].[Product Subcategory].Members, 3, [Measures].[Unit Sales]) ON ROWS "
@@ -706,7 +706,7 @@ class NonEmptyTest extends BatchTestCase {
      * be part of the cache key
      */
     ((TestConfig)context.getConfig()).setLevelPreCacheThreshold(0);
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "select {[Measures].[Unit Sales]} ON COLUMNS, "
         + "TopCount([Product].[Product Subcategory].Members, 2, [Measures].[Unit Sales]) ON ROWS "
         + "from [Sales]",
@@ -720,7 +720,7 @@ class NonEmptyTest extends BatchTestCase {
         + "Row #0: 20,739\n"
         + "Row #1: 11,767\n" );
     // run again with different count
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "select {[Measures].[Unit Sales]} ON COLUMNS, "
         + "TopCount([Product].[Product Subcategory].Members, 3, [Measures].[Unit Sales]) ON ROWS "
         + "from [Sales]",
@@ -810,7 +810,7 @@ class NonEmptyTest extends BatchTestCase {
     withSchema(context, schema);
      */
       withSchema(context, TestStrMeasureModifier::new);
-      assertQueryReturns(context.getConnection(),
+      assertQueryReturns(context.getConnectionWithDefaultRole(),
       "select {[Measures].[Media]} on columns " + "from [StrMeasure]",
       "Axis #0:\n"
         + "{}\n"
@@ -945,7 +945,7 @@ class NonEmptyTest extends BatchTestCase {
     withSchema(context, schema);
      */
     withSchema(context, TestBug1515302Modifier::new);
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "select {[Measures].[Unit Sales]} on columns, "
         + "non empty crossjoin({[Promotions].[Big Promo]}, "
         + "Descendants([Customers].[USA], [City], "
@@ -1005,7 +1005,7 @@ class NonEmptyTest extends BatchTestCase {
     if ( context.getConfig().testExpDependencies() > 0 ) {
       return;
     }
-    TestCase c = new TestCase(context.getConnection(),
+    TestCase c = new TestCase(context.getConnectionWithDefaultRole(),
       99,
       3,
       "select NON EMPTY {[Measures].[Unit Sales], [Measures].[Warehouse Sales]} ON COLUMNS, "
@@ -1022,7 +1022,7 @@ class NonEmptyTest extends BatchTestCase {
       return;
     }
     // ok to use native sql optimization for members on a virtual cube
-    TestCase c = new TestCase(context.getConnection(),
+    TestCase c = new TestCase(context.getConnectionWithDefaultRole(),
       6,
       3,
       "select NON EMPTY {[Measures].[Unit Sales], [Measures].[Warehouse Sales]} ON COLUMNS, "
@@ -1138,7 +1138,7 @@ class NonEmptyTest extends BatchTestCase {
       executeQuery(
         "select "
           + "NonEmptyCrossJoin({[Gender].Children, [Gender].[F]}, {[Store].Children, [Store].[Mexico]}) on columns "
-          + "from [Sales]", context.getConnection() );
+          + "from [Sales]", context.getConnectionWithDefaultRole() );
       fail( "Expected error did not occur" );
     } catch ( Throwable e ) {
       String expectedErrorMsg =
@@ -1462,7 +1462,7 @@ class NonEmptyTest extends BatchTestCase {
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testExpandWithTwoEmptyInputs(Context context) {
     ((TestConfig)context.getConfig()).setLevelPreCacheThreshold(0);
-    context.getConnection().getCacheControl( null ).flushSchemaCache();
+    context.getConnectionWithDefaultRole().getCacheControl( null ).flushSchemaCache();
     ((TestConfig)context.getConfig()).setExpandNonNative(true);
     // Query should return empty result.
     checkNotNative(context,
@@ -1659,7 +1659,7 @@ class NonEmptyTest extends BatchTestCase {
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testNativeTopCount(Context context) {
     ((TestConfig)context.getConfig()).setLevelPreCacheThreshold(0);
-    switch ( getDatabaseProduct(getDialect(context.getConnection()).getDialectName()) ) {
+    switch ( getDatabaseProduct(getDialect(context.getConnectionWithDefaultRole()).getDialectName()) ) {
       case INFOBRIGHT:
         // Hits same Infobright bug as NamedSetTest.testNamedSetOnMember.
         return;
@@ -1689,7 +1689,7 @@ class NonEmptyTest extends BatchTestCase {
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testCmNativeTopCount(Context context) {
     ((TestConfig)context.getConfig()).setLevelPreCacheThreshold(0);
-    switch ( getDatabaseProduct(getDialect(context.getConnection()).getDialectName()) ) {
+    switch ( getDatabaseProduct(getDialect(context.getConnectionWithDefaultRole()).getDialectName()) ) {
       case INFOBRIGHT:
         // Hits same Infobright bug as NamedSetTest.testNamedSetOnMember.
         return;
@@ -1715,7 +1715,7 @@ class NonEmptyTest extends BatchTestCase {
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testMeasureAndAggregateInSlicer(Context context) {
     ((TestConfig)context.getConfig()).setLevelPreCacheThreshold(0);
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "with member [Store Type].[All Store Types].[All Types] as 'Aggregate({[Store Type].[All Store Types].[Deluxe "
         + "Supermarket],  "
         + "[Store Type].[All Store Types].[Gourmet Supermarket],  "
@@ -1748,7 +1748,7 @@ class NonEmptyTest extends BatchTestCase {
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testMeasureInSlicer(Context context) {
     ((TestConfig)context.getConfig()).setLevelPreCacheThreshold(0);
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "select NON EMPTY {[Time].[1997]} ON COLUMNS,   "
         + "NON EMPTY [Store].[All Stores].[USA].[CA].Children ON ROWS  "
         + "from [Sales]  "
@@ -1803,7 +1803,7 @@ class NonEmptyTest extends BatchTestCase {
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testCmInSlicerResults(Context context) {
     ((TestConfig)context.getConfig()).setLevelPreCacheThreshold(0);
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "with member [Time].[Time].[Jan] as  "
         + "'Aggregate({[Time].[1998].[Q1].[1], [Time].[1997].[Q1].[1]})'  "
         + "select NON EMPTY {[Measures].[Unit Sales]} ON columns,  "
@@ -1826,7 +1826,7 @@ class NonEmptyTest extends BatchTestCase {
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testSetInSlicerResults(Context context) {
     ((TestConfig)context.getConfig()).setLevelPreCacheThreshold(0);
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "select NON EMPTY {[Measures].[Unit Sales]} ON columns,  "
         + "NON EMPTY [Product].Children ON rows from [Sales] "
         + "where {[Time].[1998].[Q1].[1], [Time].[1997].[Q1].[1]} ",
@@ -2204,7 +2204,7 @@ class NonEmptyTest extends BatchTestCase {
       return;
     }
 
-    TestCase c = new TestCase(context.getConnection(),
+    TestCase c = new TestCase(context.getConnectionWithDefaultRole(),
       8,
       5,
       "select {[Measures].[Unit Sales]} ON COLUMNS, "
@@ -2380,7 +2380,7 @@ class NonEmptyTest extends BatchTestCase {
         + "and (`product_class`.`product_family` = 'Food') "
         + "group by `store`.`store_country`, `store`.`store_state`, `store`.`store_city`, `product_class`"
         + ".`product_family` order by "
-        + ( getDialect(context.getConnection()).requiresOrderByAlias()
+        + ( getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
         ? "ISNULL(`c0`) ASC, `c0` ASC, ISNULL(`c1`) ASC, `c1` ASC, "
         + "ISNULL(`c2`) ASC, `c2` ASC, ISNULL(`c3`) ASC, `c3` ASC"
         :
@@ -2424,7 +2424,7 @@ class NonEmptyTest extends BatchTestCase {
         DatabaseProduct.MYSQL, necjSqlMySql, necjSqlMySql )
     };
 
-    assertQuerySql(context.getConnection(), query, patterns );
+    assertQuerySql(context.getConnectionWithDefaultRole(), query, patterns );
   }
 
   /**
@@ -2501,7 +2501,7 @@ class NonEmptyTest extends BatchTestCase {
         + "    `warehouse`.`warehouse_name`,\n"
         + "    `product_class`.`product_family`\n"
         + "order by\n"
-        + ( getDialect(context.getConnection()).requiresOrderByAlias()
+        + ( getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
         ? "    ISNULL(`c0`) ASC, `c0` ASC,\n"
         + "    ISNULL(`c1`) ASC, `c1` ASC,\n"
         + "    ISNULL(`c2`) ASC, `c2` ASC,\n"
@@ -2608,7 +2608,7 @@ class NonEmptyTest extends BatchTestCase {
         DatabaseProduct.MYSQL, necjSqlMySql, necjSqlMySql )
     };
 
-    assertQuerySql( context.getConnection(), query, patterns );
+    assertQuerySql( context.getConnectionWithDefaultRole(), query, patterns );
   }
 
   /**
@@ -2685,7 +2685,7 @@ class NonEmptyTest extends BatchTestCase {
         + "    `warehouse`.`warehouse_name`,\n"
         + "    `product_class`.`product_family`\n"
         + "order by\n"
-        + ( getDialect(context.getConnection()).requiresOrderByAlias()
+        + ( getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
         ? "    ISNULL(`c0`) ASC, `c0` ASC,\n"
         + "    ISNULL(`c1`) ASC, `c1` ASC,\n"
         + "    ISNULL(`c2`) ASC, `c2` ASC,\n"
@@ -2784,7 +2784,7 @@ class NonEmptyTest extends BatchTestCase {
         DatabaseProduct.MYSQL, necjSqlMySql, necjSqlMySql )
     };
 
-    assertQuerySql(context.getConnection(), query, patterns );
+    assertQuerySql(context.getConnectionWithDefaultRole(), query, patterns );
   }
 
   /**
@@ -2863,7 +2863,7 @@ class NonEmptyTest extends BatchTestCase {
         + "(`product_class`.`product_family` = 'Food') "
         + "group by `warehouse`.`wa_address3`, `warehouse`.`wa_address2`, `warehouse`.`warehouse_fax`, "
         + "`product_class`.`product_family` "
-        + ( getDialect(context.getConnection()).requiresOrderByAlias()
+        + ( getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
         ? "order by ISNULL(`c0`) ASC, `c0` ASC, ISNULL(`c1`) ASC, "
         + "`c1` ASC, ISNULL(`c2`) ASC, `c2` ASC, "
         + "ISNULL(`c3`) ASC, `c3` ASC"
@@ -2969,7 +2969,7 @@ class NonEmptyTest extends BatchTestCase {
         DatabaseProduct.MYSQL, necjSqlMySql, necjSqlMySql )
     };
 
-    assertQuerySql( context.getConnection(), query, patterns );
+    assertQuerySql( context.getConnectionWithDefaultRole(), query, patterns );
   }
 
   @ParameterizedTest
@@ -2989,7 +2989,7 @@ class NonEmptyTest extends BatchTestCase {
         + "       Crossjoin(\n"
         + "         [Customers].[All Customers].[USA].children,\n"
         + "         [Product].[All Products].children) ) )) on rows\n"
-        + "from Sales where ([Time].[1997])", context.getConnection());
+        + "from Sales where ([Time].[1997])", context.getConnectionWithDefaultRole());
     final Axis rowsAxis = result.getAxes()[ 1 ];
     assertEquals( 21, rowsAxis.getPositions().size() );
   }
@@ -3010,12 +3010,12 @@ class NonEmptyTest extends BatchTestCase {
 
     // there currently isn't a cube member to children cache, only
     // a shared cache so use the shared smart member reader
-    SmartMemberReader smr = getSmartMemberReader(context.getConnection(), "Store" );
+    SmartMemberReader smr = getSmartMemberReader(context.getConnectionWithDefaultRole(), "Store" );
     MemberCacheHelper smrch = smr.cacheHelper;
     MemberCacheHelper rcsmrch =
       ( (RolapCubeHierarchy.RolapCubeHierarchyMemberReader) smr )
         .getRolapCubeMemberCacheHelper();
-    SmartMemberReader ssmr = getSharedSmartMemberReader(context.getConnection(), "Store" );
+    SmartMemberReader ssmr = getSharedSmartMemberReader(context.getConnectionWithDefaultRole(), "Store" );
     MemberCacheHelper ssmrch = ssmr.cacheHelper;
     clearAndHardenCache( smrch );
     clearAndHardenCache( rcsmrch );
@@ -3023,7 +3023,7 @@ class NonEmptyTest extends BatchTestCase {
 
     RolapResult result =
       (RolapResult) executeQuery(
-        "select {[Store].[All Stores].[USA].[CA].[San Francisco]} on columns from [Sales]", context.getConnection() );
+        "select {[Store].[All Stores].[USA].[CA].[San Francisco]} on columns from [Sales]", context.getConnectionWithDefaultRole() );
     assertTrue(
       ssmrch.mapKeyToMember.size() <= 5, "no additional members should be read:"
                     + ssmrch.mapKeyToMember.size());
@@ -3056,7 +3056,7 @@ class NonEmptyTest extends BatchTestCase {
     // ok if no exception occurs
     ((TestConfig)context.getConfig()).setLevelPreCacheThreshold(0);
     executeQuery(
-      "SELECT DESCENDANTS([Time].[1997], [Month]) ON COLUMNS FROM [Sales]", context.getConnection() );
+      "SELECT DESCENDANTS([Time].[1997], [Month]) ON COLUMNS FROM [Sales]", context.getConnectionWithDefaultRole() );
   }
 
 
@@ -3076,7 +3076,7 @@ class NonEmptyTest extends BatchTestCase {
     executeQuery(
       "select non empty CrossJoin([Customers].[Name].Members, "
         + "{[Promotions].[All Promotions].[Fantastic Discounts]}) "
-        + "ON COLUMNS FROM [Sales]", context.getConnection());
+        + "ON COLUMNS FROM [Sales]", context.getConnectionWithDefaultRole());
     SystemWideProperties.instance().EnableNativeNonEmpty =
       oldEnableNativeNonEmpty;
   }
@@ -3090,7 +3090,7 @@ class NonEmptyTest extends BatchTestCase {
     ((TestConfig)context.getConfig()).setLevelPreCacheThreshold(0);
     // ok if no exception occurs
     executeQuery(
-      "select {[Store].[USA].[Washington]} on columns from [Sales Ragged]", context.getConnection());
+      "select {[Store].[USA].[Washington]} on columns from [Sales Ragged]", context.getConnectionWithDefaultRole());
   }
 
   /**
@@ -3101,7 +3101,7 @@ class NonEmptyTest extends BatchTestCase {
   void testCalcMemberWithNonEmptyCrossJoin(Context context)  {
     ((TestConfig)context.getConfig()).setLevelPreCacheThreshold(0);
     //etCacheControl( null );
-    flushSchemaCache(context.getConnection());
+    flushSchemaCache(context.getConnectionWithDefaultRole());
     Result result = executeQuery(
       "with member [Measures].[CustomerCount] as \n"
         + "'Count(CrossJoin({[Product].[All Products]}, [Customers].[Name].Members))'\n"
@@ -3110,7 +3110,7 @@ class NonEmptyTest extends BatchTestCase {
         + "NON EMPTY{[Product].[All Products]} ON rows\n"
         + "from [Sales]\n"
         + "where ([Store].[All Stores].[USA].[CA].[San Francisco].[Store 14], [Time].[1997].[Q1].[1])",
-            context.getConnection());
+            context.getConnectionWithDefaultRole());
     Cell c = result.getCell( new int[] { 0, 0 } );
     // we expect 10281 customers, although there are only 20 non-empty ones
     // @see #testLevelMembers
@@ -3126,7 +3126,7 @@ class NonEmptyTest extends BatchTestCase {
       // test.
       return;
     }
-    SmartMemberReader smr = getSmartMemberReader(context.getConnection(), "Customers" );
+    SmartMemberReader smr = getSmartMemberReader(context.getConnectionWithDefaultRole(), "Customers" );
     // use the RolapCubeHierarchy's member cache for levels
     MemberCacheHelper smrch =
       ( (RolapCubeHierarchy.CacheRolapCubeHierarchyMemberReader) smr )
@@ -3136,11 +3136,11 @@ class NonEmptyTest extends BatchTestCase {
     clearAndHardenCache( smrich );
 
     // use the shared member cache for mapMemberToChildren
-    SmartMemberReader ssmr = getSharedSmartMemberReader(context.getConnection(), "Customers" );
+    SmartMemberReader ssmr = getSharedSmartMemberReader(context.getConnectionWithDefaultRole(), "Customers" );
     MemberCacheHelper ssmrch = ssmr.cacheHelper;
     clearAndHardenCache( ssmrch );
 
-    TestCase c = new TestCase(context.getConnection(),
+    TestCase c = new TestCase(context.getConnectionWithDefaultRole(),
       50,
       21,
       "select \n"
@@ -3190,8 +3190,8 @@ class NonEmptyTest extends BatchTestCase {
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testLevelMembersWithoutNonEmpty(Context context)  {
     ((TestConfig)context.getConfig()).setLevelPreCacheThreshold(0);
-	context.getConnection().getCacheControl(null).flushSchemaCache();
-    SmartMemberReader smr = getSmartMemberReader(context.getConnection(), "Customers" );
+	context.getConnectionWithDefaultRole().getCacheControl(null).flushSchemaCache();
+    SmartMemberReader smr = getSmartMemberReader(context.getConnectionWithDefaultRole(), "Customers" );
 
     MemberCacheHelper smrch =
       ( (RolapCubeHierarchy.CacheRolapCubeHierarchyMemberReader) smr )
@@ -3201,7 +3201,7 @@ class NonEmptyTest extends BatchTestCase {
     MemberCacheHelper smrich = smr.cacheHelper;
     clearAndHardenCache( smrich );
 
-    SmartMemberReader ssmr = getSharedSmartMemberReader(context.getConnection(), "Customers" );
+    SmartMemberReader ssmr = getSharedSmartMemberReader(context.getConnectionWithDefaultRole(), "Customers" );
     MemberCacheHelper ssmrch = ssmr.cacheHelper;
     clearAndHardenCache( ssmrch );
 
@@ -3210,7 +3210,7 @@ class NonEmptyTest extends BatchTestCase {
         + "{[Measures].[Unit Sales]} ON columns,\n"
         + "{[Customers].[All Customers], [Customers].[Name].Members} ON rows\n"
         + "from [Sales]\n"
-        + "where ([Store].[All Stores].[USA].[CA].[San Francisco].[Store 14], [Time].[1997].[Q1].[1])", context.getConnection() );
+        + "where ([Store].[All Stores].[USA].[CA].[San Francisco].[Store 14], [Time].[1997].[Q1].[1])", context.getConnectionWithDefaultRole() );
     Level[] levels = smr.getHierarchy().getLevels();
     Level nameLevel = levels[ levels.length - 1 ];
 
@@ -3262,7 +3262,7 @@ class NonEmptyTest extends BatchTestCase {
     // No query should return more than 20 rows. (1 row at 'all' level,
     // 1 row at nation level, 1 at state level, 20 at city level, and 11
     // at customers level = 34.)
-    TestCase c = new TestCase(context.getConnection(),
+    TestCase c = new TestCase(context.getConnectionWithDefaultRole(),
       34,
       34,
       "select \n"
@@ -3280,7 +3280,7 @@ class NonEmptyTest extends BatchTestCase {
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testMemberChildrenOfRolapMember(Context context)  {
     ((TestConfig)context.getConfig()).setLevelPreCacheThreshold(0);
-    TestCase c = new TestCase(context.getConnection(),
+    TestCase c = new TestCase(context.getConnectionWithDefaultRole(),
       50,
       4,
       "select \n"
@@ -3298,7 +3298,7 @@ class NonEmptyTest extends BatchTestCase {
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testMemberChildrenOfAllMember(Context context)  {
     ((TestConfig)context.getConfig()).setLevelPreCacheThreshold(0);
-    TestCase c = new TestCase(context.getConnection(),
+    TestCase c = new TestCase(context.getConnectionWithDefaultRole(),
       50,
       14,
       "select {[Measures].[Unit Sales]} ON columns,\n"
@@ -3333,7 +3333,7 @@ class NonEmptyTest extends BatchTestCase {
     //        `promotion`.`promotion_name`
 
     TestCase c =
-      new TestCase(context.getConnection(),
+      new TestCase(context.getConnectionWithDefaultRole(),
         50,
         48,
         "select {[Measures].[Unit Sales]} ON columns,\n"
@@ -3354,7 +3354,7 @@ class NonEmptyTest extends BatchTestCase {
     if ( context.getConfig().testExpDependencies() > 0 ) {
       return;
     }
-    TestCase c = new TestCase(context.getConnection(),
+    TestCase c = new TestCase(context.getConnectionWithDefaultRole(),
       3,
       1,
       "select "
@@ -3383,7 +3383,7 @@ class NonEmptyTest extends BatchTestCase {
     }
 
     TestCase c =
-      new TestCase(context.getConnection(),
+      new TestCase(context.getConnectionWithDefaultRole(),
         45,
         4,
         "select \n"
@@ -3410,7 +3410,7 @@ class NonEmptyTest extends BatchTestCase {
       return;
     }
 
-    Connection con = context.getConnection();
+    Connection con = context.getConnectionWithDefaultRole();
     SmartMemberReader smr = getSmartMemberReader( con, "Customers" );
     MemberCacheHelper smrch = smr.cacheHelper;
     clearAndHardenCache( smrch );
@@ -3483,7 +3483,7 @@ class NonEmptyTest extends BatchTestCase {
   void testBug1412384(Context context)  {
     ((TestConfig)context.getConfig()).setLevelPreCacheThreshold(0);
     // Bug 1412384 causes a NPE in SqlConstraintUtils.
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "select NON EMPTY {[Time].[1997]} ON COLUMNS,\n"
         + "NON EMPTY Hierarchize(Union({[Customers].[All Customers]},\n"
         + "[Customers].[All Customers].Children)) ON ROWS\n"
@@ -3547,7 +3547,7 @@ class NonEmptyTest extends BatchTestCase {
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testNotNativeVirtualCubeCrossJoin1(Context context)  {
     ((TestConfig)context.getConfig()).setLevelPreCacheThreshold(0);
-    switch ( getDatabaseProduct(getDialect(context.getConnection()).getDialectName()) ) {
+    switch ( getDatabaseProduct(getDialect(context.getConnectionWithDefaultRole()).getDialectName()) ) {
       case INFOBRIGHT:
         // Hits same Infobright bug as NamedSetTest.testNamedSetOnMember.
         return;
@@ -3584,7 +3584,7 @@ class NonEmptyTest extends BatchTestCase {
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testNotNativeVirtualCubeCrossJoinUnsupported(Context context)  {
     ((TestConfig)context.getConfig()).setLevelPreCacheThreshold(0);
-    switch ( getDatabaseProduct(getDialect(context.getConnection()).getDialectName()) ) {
+    switch ( getDatabaseProduct(getDialect(context.getConnectionWithDefaultRole()).getDialectName()) ) {
       case INFOBRIGHT:
         // Hits same Infobright bug as NamedSetTest.testNamedSetOnMember.
         return;
@@ -3924,7 +3924,7 @@ class NonEmptyTest extends BatchTestCase {
       withSchema(context, SchemaModifiers.NonEmptyTestModifier4::new);
     // Check that the grand total is different than when [Time].[1997] is
     // the default member.
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "select from [Sales]",
       "Axis #0:\n"
         + "{}\n"
@@ -3933,7 +3933,7 @@ class NonEmptyTest extends BatchTestCase {
     // Results of this query agree with MSAS 2000 SP1.
     // The query gives the same results if the default member of [Time]
     // is [Time].[1997] or [Time].[1997].[Q1].[1].
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "select\n"
         + "NON EMPTY Crossjoin({[Time].[1997].[Q2].[4]}, [Customers].[Country].members) on columns,\n"
         + "NON EMPTY [Product].[All Products].[Drink].[Alcoholic Beverages].[Beer and Wine].[Beer].[Portsmouth]"
@@ -4098,7 +4098,7 @@ class NonEmptyTest extends BatchTestCase {
     // join will try evaluating the calculated member (when it shouldn't)
     // and the calculated member references the cross join, resulting
     // in the loop
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "With "
         + "Set [*NATIVE_CJ_SET] as "
         + "'NonEmptyCrossJoin([*BASE_MEMBERS_Store], [*BASE_MEMBERS_Products])' "
@@ -4160,7 +4160,7 @@ class NonEmptyTest extends BatchTestCase {
     }
 
     // calculated measure contains a calculated member
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "With Set [*NATIVE_CJ_SET] as "
         + "'NonEmptyCrossJoin([*BASE_MEMBERS_Dates], [*BASE_MEMBERS_Stores])' "
         + "Set [*BASE_MEMBERS_Dates] as '{[Time].[1997].[Q1], [Time].[1997].[Q2]}' "
@@ -4231,7 +4231,7 @@ class NonEmptyTest extends BatchTestCase {
     //
     // A measures member is referenced in the IsEmpty() function.  This
     // shouldn't prevent native cross join from being used.
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "with "
         + "set BM_PRODUCT as {[Product].[All Products].[Drink]} "
         + "set BM_EDU as [Education Level].[Education Level].Members "
@@ -4387,7 +4387,7 @@ class NonEmptyTest extends BatchTestCase {
     // Get a fresh connection; Otherwise the mondrian property setting
     // is not refreshed for this parameter.
     //final TestContext context = getTestContext().withFreshConnection();
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     try {
       assertQueryReturns(connection,
         "with set [p] as '[Product].[Product Family].members' "
@@ -4419,7 +4419,7 @@ class NonEmptyTest extends BatchTestCase {
     // Get a fresh connection; Otherwise the mondrian property setting
     // is not refreshed for this parameter.
     //final TestContext context = getTestContext().withFreshConnection();
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     try {
       assertQueryReturns(connection,
         "with set [p] as '[Product].[Product Family].members' "
@@ -4445,7 +4445,7 @@ class NonEmptyTest extends BatchTestCase {
     // Get a fresh connection; Otherwise the mondrian property setting
     // is not refreshed for this parameter.
     //final TestContext context = getTestContext().withFreshConnection();
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     try {
       assertQueryReturns(connection,
         "with set [p] as '[Product].[Product Family].members' "
@@ -4476,7 +4476,7 @@ class NonEmptyTest extends BatchTestCase {
     //   With NON EMPTY (mondrian.rolap.nonempty) behavior set to true
     //   the following mdx return no result. The same mdx returns valid
     // result when NON EMPTY is turned off.
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "WITH \n"
         + "MEMBER Measures.Calc AS '[Measures].[Profit] * 2', SOLVE_ORDER=1000\n"
         + "MEMBER Product.Conditional as 'Iif (Measures.CurrentMember IS Measures.[Calc], "
@@ -4580,7 +4580,7 @@ class NonEmptyTest extends BatchTestCase {
     try {
       SystemWideProperties.instance().EnableNativeNonEmpty = false;
       SystemWideProperties.instance().EnableNonEmptyOnAllAxis = true;
-      assertQueryReturns(context.getConnection(),
+      assertQueryReturns(context.getConnectionWithDefaultRole(),
         "WITH MEMBER [Measures].[One] AS '1' "
           + "SELECT "
           + "NON EMPTY {[Measures].[One], [Measures].[Store Sales]} ON rows, "
@@ -4625,7 +4625,7 @@ class NonEmptyTest extends BatchTestCase {
 
       if ( Bug.BugMondrian446Fixed ) {
         SystemWideProperties.instance().EnableNativeNonEmpty = true;
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
           "WITH MEMBER [Measures].[One] AS '1' "
             + "SELECT "
             + "NON EMPTY {[Measures].[One], [Measures].[Store Sales]} ON rows, "
@@ -4683,7 +4683,7 @@ class NonEmptyTest extends BatchTestCase {
     // This unit test was failing with a NullPointerException in JPivot
     // after the highcardinality feature was added, I've included it
     // here to make sure it continues to work.
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "select NON EMPTY {[Measures].[Unit Sales], [Measures].[Store Cost]} ON columns, "
         + "NON EMPTY Filter([Product].[Brand Name].Members, ([Measures].[Unit Sales] > 100000.0)) ON rows "
         + "from [Sales] where [Time].[1997]",
@@ -4701,7 +4701,7 @@ class NonEmptyTest extends BatchTestCase {
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testBugMondrian412(Context context)  {
     ((TestConfig)context.getConfig()).setLevelPreCacheThreshold(0);
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "with member [Measures].[AvgRevenue] as 'Avg([Store].[Store Name].Members, [Measures].[Store Sales])' "
         + "select NON EMPTY {[Measures].[Store Sales], [Measures].[AvgRevenue]} ON COLUMNS, "
         + "NON EMPTY Filter([Store].[Store Name].Members, ([Measures].[AvgRevenue] < [Measures].[Store Sales])) ON "
@@ -4746,7 +4746,7 @@ class NonEmptyTest extends BatchTestCase {
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testNonEmpyOnVirtualCubeWithNonJoiningDimension(Context context)  {
     ((TestConfig)context.getConfig()).setLevelPreCacheThreshold(0);
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "select non empty {[Warehouse].[Warehouse name].members} on 0,"
         + "{[Measures].[Units Shipped],[Measures].[Unit Sales]} on 1"
         + " from [Warehouse and Sales]",
@@ -4801,7 +4801,7 @@ class NonEmptyTest extends BatchTestCase {
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testNonEmptyOnNonJoiningValidMeasure(Context context)  {
     ((TestConfig)context.getConfig()).setLevelPreCacheThreshold(0);
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "with member [Measures].[vm] as 'ValidMeasure([Measures].[Unit Sales])'"
         + "select non empty {[Warehouse].[Warehouse name].members} on 0,"
         + "{[Measures].[Units Shipped],[Measures].[vm]} on 1"
@@ -4862,7 +4862,7 @@ class NonEmptyTest extends BatchTestCase {
     // Warehouse to the [All] level when evaluating the [vm] measure,
     // the results should include each [warehouse name] member intersected
     // with the non-empty Gender members.
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "with member [Measures].[vm] as 'ValidMeasure([Measures].[Unit Sales])'\n"
         + "select non empty Crossjoin([Warehouse].[Warehouse Name].members, [Gender].[Gender].members) on 0,\n"
         + "{[Measures].[Units Shipped],[Measures].[vm]} on 1\n"
@@ -4957,7 +4957,7 @@ class NonEmptyTest extends BatchTestCase {
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testCrossjoinWithOneDimensionThatDoesNotJoinToBothBaseCubes(Context context)  {
     ((TestConfig)context.getConfig()).setLevelPreCacheThreshold(0);
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "with member [Measures].[vm] as 'ValidMeasure([Measures].[Units Shipped])'"
         + "select non empty Crossjoin([Store].[Store Name].members, [Gender].[Gender].members) on 0,"
         + "{[Measures].[Unit Sales],[Measures].[vm]} on 1"
@@ -5109,7 +5109,7 @@ class NonEmptyTest extends BatchTestCase {
         + "  [Store Size in SQFT].[All Store Size in SQFTs].[~Missing ]";
 
     // run an mdx query with the default NullMemberRepresentation
-    executeQuery(preMdx, context.getConnection());
+    executeQuery(preMdx, context.getConnectionWithDefaultRole());
 
 
     SystemWideProperties.instance().NullMemberRepresentation =
@@ -5117,7 +5117,7 @@ class NonEmptyTest extends BatchTestCase {
 
     SystemWideProperties.instance().EnableNonEmptyOnAllAxis =
       true;
-    executeQuery(mdx, context.getConnection());
+    executeQuery(mdx, context.getConnectionWithDefaultRole());
   }
 
   /**
@@ -5128,7 +5128,7 @@ class NonEmptyTest extends BatchTestCase {
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testBugMondrian321(Context context)  {
     ((TestConfig)context.getConfig()).setLevelPreCacheThreshold(0);
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "WITH SET [#DataSet#] AS 'Crossjoin({Descendants([Customers].[All Customers], 2)}, {[Product].[All Products]})'"
         + " \n"
         + "SELECT {[Measures].[Unit Sales], [Measures].[Store Sales]} on columns, \n"
@@ -5149,7 +5149,7 @@ class NonEmptyTest extends BatchTestCase {
         + "Row #2: 124,366\n"
         + "Row #2: 263,793.22\n" );
 
-    verifySameNativeAndNot(context.getConnection(),
+    verifySameNativeAndNot(context.getConnectionWithDefaultRole(),
       "WITH SET [#DataSet#] AS 'Crossjoin({Descendants([Customers].[All Customers], 2)}, {[Product].[All Products]})'"
         + " \n"
         + "SELECT {[Measures].[Unit Sales], [Measures].[Store Sales]} on columns, \n"
@@ -5221,7 +5221,7 @@ class NonEmptyTest extends BatchTestCase {
         + "    \"time_by_day\".\"the_year\" ASC NULLS LAST,\n"
         + "    \"promotion\".\"promotion_name\" ASC NULLS LAST",
       611 );
-    assertQuerySql(context.getConnection(), mdx, new SqlPattern[] { oraclePattern } );
+    assertQuerySql(context.getConnectionWithDefaultRole(), mdx, new SqlPattern[] { oraclePattern } );
   }
 
   @ParameterizedTest
@@ -5269,7 +5269,7 @@ class NonEmptyTest extends BatchTestCase {
         + "order by\n"
         + "    \"promotion\".\"promotion_name\" ASC NULLS LAST",
       347 );
-    assertQuerySql(context.getConnection(), mdx, new SqlPattern[] { oraclePattern } );
+    assertQuerySql(context.getConnectionWithDefaultRole(), mdx, new SqlPattern[] { oraclePattern } );
   }
 
   @ParameterizedTest
@@ -5335,7 +5335,7 @@ class NonEmptyTest extends BatchTestCase {
         + "    \"time_by_day\".\"the_year\" ASC NULLS LAST,\n"
         + "    \"promotion\".\"promotion_name\" ASC NULLS LAST",
       611 );
-    assertQuerySql(context.getConnection(), mdx, new SqlPattern[] { pattern } );
+    assertQuerySql(context.getConnectionWithDefaultRole(), mdx, new SqlPattern[] { pattern } );
   }
 
   @ParameterizedTest
@@ -5403,7 +5403,7 @@ class NonEmptyTest extends BatchTestCase {
         + "    \"time_by_day\".\"the_year\" ASC NULLS LAST,\n"
         + "    \"promotion\".\"promotion_name\" ASC NULLS LAST",
       611 );
-    assertQuerySql(context.getConnection(), mdx, new SqlPattern[] { pattern } );
+    assertQuerySql(context.getConnectionWithDefaultRole(), mdx, new SqlPattern[] { pattern } );
   }
 
   @ParameterizedTest
@@ -5445,7 +5445,7 @@ class NonEmptyTest extends BatchTestCase {
         + "\"customer\".\"gender\", \"customer\".\"marital_status\", \"customer\".\"education\", \"customer\""
         + ".\"yearly_income\" order by \"customer\".\"country\" ASC NULLS LAST, \"customer\".\"state_province\" ASC "
         + "NULLS LAST, \"customer\".\"city\" ASC NULLS LAST, \"fname\" || ' ' || \"lname\" ASC NULLS LAST";
-    assertQuerySql(context.getConnection(),
+    assertQuerySql(context.getConnectionWithDefaultRole(),
       mdx,
       new SqlPattern[] {
         new SqlPattern(
@@ -5512,7 +5512,7 @@ class NonEmptyTest extends BatchTestCase {
       DatabaseProduct.ORACLE,
       sqlOracle,
       sqlOracle.length() );
-    assertQuerySql(context.getConnection(), mdx, new SqlPattern[] { pattern } );
+    assertQuerySql(context.getConnectionWithDefaultRole(), mdx, new SqlPattern[] { pattern } );
   }
 
   @ParameterizedTest
@@ -5562,7 +5562,7 @@ class NonEmptyTest extends BatchTestCase {
         + " \"customer\".\"city\" ASC NULLS LAST, "
         + "\"fname\" || ' ' || \"lname\" ASC NULLS LAST",
       852 );
-    assertQuerySql(context.getConnection(), mdx, new SqlPattern[] { pattern } );
+    assertQuerySql(context.getConnectionWithDefaultRole(), mdx, new SqlPattern[] { pattern } );
   }
 
   @ParameterizedTest
@@ -5593,7 +5593,7 @@ class NonEmptyTest extends BatchTestCase {
       sqlOracle,
       sqlOracle.length() );
     assertQuerySqlOrNot(
-      context.getConnection(), mdx, new SqlPattern[] { pattern }, true, false, true );
+      context.getConnectionWithDefaultRole(), mdx, new SqlPattern[] { pattern }, true, false, true );
   }
 
   @ParameterizedTest
@@ -5613,7 +5613,7 @@ class NonEmptyTest extends BatchTestCase {
         + "  non empty "
         + "  [Marital Status].[Marital Status].members on rows"
         + " from sales";
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       mdx,
       "Axis #0:\n"
         + "{}\n"
@@ -5712,7 +5712,7 @@ class NonEmptyTest extends BatchTestCase {
         + " NON EMPTY {[Measures].[Unit Sales]} ON COLUMNS, "
         + " NON EMPTY {[Gender].[Gender].Members} ON ROWS "
         + " from [onlyGender] ";
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       mdx,
       "Axis #0:\n"
         + "{}\n"
@@ -5910,7 +5910,7 @@ class NonEmptyTest extends BatchTestCase {
           + "</Schema>" );
        */
     withSchema(context, TestCalculatedDefaultMeasureOnVirtualCubeNoThrowExceptionModifier::new);
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "select "
         + " [Measures].[Unit Sales] on COLUMNS, "
         + " NON EMPTY {[Store].[Store State].Members} ON ROWS "
@@ -5948,7 +5948,7 @@ class NonEmptyTest extends BatchTestCase {
         + "Level].[All Education Levels], [Gender].[All Gender], [Marital Status].[All Marital Status], [Yearly "
         + "Income].[All Yearly Incomes])}) ON ROWS"
         + " from [Sales]";
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       mdx,
       "Axis #0:\n"
         + "{}\n"
@@ -6077,7 +6077,7 @@ class NonEmptyTest extends BatchTestCase {
       return;
     }
     // children across a snowflake boundary
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "select [Product].[Drink].[Baking Goods].[Dry Goods].[Coffee].Children on 0\n"
         + "from [Sales]",
       "Axis #0:\n"
@@ -6097,14 +6097,14 @@ class NonEmptyTest extends BatchTestCase {
         "select `product_class`.`product_family` as `c0` "
           + "from `product_class` as `product_class` "
           + "group by `product_class`.`product_family` "
-          + ( getDialect(context.getConnection()).requiresOrderByAlias()
+          + ( getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
           ? "order by ISNULL(`c0`) ASC,"
           + " `c0` ASC"
           : "order by ISNULL(`product_class`.`product_family`) ASC,"
           + " `product_class`.`product_family` ASC" ),
         null )
     };
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     try {
       assertQuerySql(
               connection,
@@ -6202,7 +6202,7 @@ class NonEmptyTest extends BatchTestCase {
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testBugMondrian897DoubleNamedSetDefinitions(Context context)  {
     ((TestConfig)context.getConfig()).setLevelPreCacheThreshold(0);
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "WITH SET [CustomerSet] as {[Customers].[Canada].[BC].[Burnaby].[Alexandra Wellington], [Customers].[USA].[WA]"
         + ".[Tacoma].[Eric Coleman]} "
         + "SET [InterestingCustomers] as [CustomerSet] "
@@ -6314,7 +6314,7 @@ class NonEmptyTest extends BatchTestCase {
         + "having\n"
         + "    c1 IS NOT NULL AND UPPER(c1) REGEXP '.*CA.*'\n"
         + "order by\n"
-        + ( getDialect(context.getConnection()).requiresOrderByAlias()
+        + ( getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
         ? "    ISNULL(`c0`) ASC, `c0` ASC,\n"
         + "    ISNULL(`c1`) ASC, `c1` ASC"
         : "    ISNULL(`store`.`store_country`) ASC, `store`.`store_country` ASC,\n"
@@ -6340,7 +6340,7 @@ class NonEmptyTest extends BatchTestCase {
         + "having\n"
         + "    c1 IS NOT NULL AND UPPER(c1) REGEXP '.*CA.*'\n"
         + "order by\n"
-        + ( getDialect(context.getConnection()).requiresOrderByAlias()
+        + ( getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
         ? "    ISNULL(`c0`) ASC, `c0` ASC,\n"
         + "    ISNULL(`c1`) ASC, `c1` ASC"
         : "    ISNULL(`store`.`store_country`) ASC, `store`.`store_country` ASC,\n"
@@ -6405,7 +6405,7 @@ class NonEmptyTest extends BatchTestCase {
     //withSchema(context, schema );
 
     // The filter condition does not require a join to the fact table.
-    assertQuerySql(context.getConnection(), query, patterns );
+    assertQuerySql(context.getConnectionWithDefaultRole(), query, patterns );
     assertQuerySql(((TestContext)context).getConnection(List.of("Role1")), query, patterns );
 
     // in a non-empty context where a role is in effect, the query
@@ -6508,7 +6508,7 @@ class NonEmptyTest extends BatchTestCase {
         + "having\n"
         + "    c1 IS NOT NULL AND UPPER(c1) REGEXP '.*CA.*'\n"
         + "order by\n"
-        + ( getDialect(context.getConnection()).requiresOrderByAlias()
+        + ( getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
         ? "    ISNULL(`c0`) ASC, `c0` ASC,\n"
         + "    ISNULL(`c1`) ASC, `c1` ASC"
         : "    ISNULL(`store`.`store_country`) ASC, `store`.`store_country` ASC,\n"
@@ -6531,7 +6531,7 @@ class NonEmptyTest extends BatchTestCase {
         + "having\n"
         + "    c1 IS NOT NULL AND UPPER(c1) REGEXP '.*CA.*'\n"
         + "order by\n"
-        + ( getDialect(context.getConnection()).requiresOrderByAlias()
+        + ( getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
         ? "    ISNULL(`c0`) ASC, `c0` ASC,\n"
         + "    ISNULL(`c1`) ASC, `c1` ASC"
         : "    ISNULL(`store`.`store_country`) ASC, `store`.`store_country` ASC,\n"
@@ -6591,7 +6591,7 @@ class NonEmptyTest extends BatchTestCase {
     withSchema(context, SchemaModifiers.NonEmptyTestModifier6::new );
 
     // The filter condition does not require a join to the fact table.
-    assertQuerySql(context.getConnection(), query, patterns );
+    assertQuerySql(context.getConnectionWithDefaultRole(), query, patterns );
     assertQuerySql(((TestContext)context).getConnection(List.of("Role1")), query, patterns );
 
     // in a non-empty context where a role is in effect, the query
@@ -6746,7 +6746,7 @@ class NonEmptyTest extends BatchTestCase {
         mysqlNativeCrossJoinQuery,
         triggerSql );
 
-    assertQuerySql(context.getConnection(),  mdx, new SqlPattern[] { mysqlPattern } );
+    assertQuerySql(context.getConnectionWithDefaultRole(),  mdx, new SqlPattern[] { mysqlPattern } );
 
     checkNative(context,
       20,
@@ -6803,7 +6803,7 @@ class NonEmptyTest extends BatchTestCase {
         + "{[Gender].[F], [Time].[1997].[Q2]}\n"
         + "Row #0: 33,381\n"
         + "Row #1: 30,992\n";
-    assertQueryReturns(context.getConnection(), mdx, expected );
+    assertQueryReturns(context.getConnectionWithDefaultRole(), mdx, expected );
   }
 
   @ParameterizedTest
@@ -6824,7 +6824,7 @@ class NonEmptyTest extends BatchTestCase {
     };
 
     for ( String timeMember : referencesToTimeMember ) {
-      assertQueryReturns(context.getConnection(),
+      assertQueryReturns(context.getConnectionWithDefaultRole(),
         "with member [Measures].[YTD Unit Sales] as "
           + "'Sum(Ytd(" + timeMember + "), [Measures].[Unit Sales])'\n"
           + "select\n"
@@ -6861,7 +6861,7 @@ class NonEmptyTest extends BatchTestCase {
     ((TestConfig)context.getConfig()).setLevelPreCacheThreshold(0);
     // the [overrideContext] measure should have a value for the tuple
     // on rows, given it overrides the time member on the axis.
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "WITH  member measures.[overrideContext] as '( measures.[unit sales], Time.[1997].Q1 )'\n"
         + "SELECT measures.[overrideContext] on 0, \n"
         + "NON EMPTY crossjoin( Time.[1998].Q1, [Marital Status].[M]) on 1\n"
@@ -6874,7 +6874,7 @@ class NonEmptyTest extends BatchTestCase {
         + "{[Time].[1998].[Q1], [Marital Status].[M]}\n"
         + "Row #0: 33,101\n" );
     // same thing w/ nonemptycrossjoin().
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "WITH  member measures.[overrideContext] as '( measures.[unit sales], Time.[1997].Q1 )'\n"
         + "SELECT measures.[overrideContext] on 0, \n"
         + "NonEmptyCrossjoin( Time.[1998].Q1, [Marital Status].[M]) on 1\n"
@@ -6900,7 +6900,7 @@ class NonEmptyTest extends BatchTestCase {
     // In this case it would result in
     //    (year = 1997 AND year = 1998)
     // if potential conflicts aren't removed.
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "WITH  member measures.[overrideContext] as '( measures.[unit sales], Time.[1997].Q1 )'\n"
         + "SELECT measures.[overrideContext] on 0, \n"
         + "NON EMPTY [Marital Status].[Marital Status].members on 1,\n"
@@ -6924,7 +6924,7 @@ class NonEmptyTest extends BatchTestCase {
   void testMondrian2202WithAggTopCountSet(Context context)  {
     ((TestConfig)context.getConfig()).setLevelPreCacheThreshold(0);
     // in slicer
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "with member measures.top5Prod as "
         + "'aggregate(topcount("
         + "crossjoin( {time.[1997]}, product.[product name].members), 5, measures.[unit sales]), measures.[unit "
@@ -6941,7 +6941,7 @@ class NonEmptyTest extends BatchTestCase {
         + "Row #0: 398\n"
         + "Row #1: 385\n" );
     // in CJ
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "with member measures.top5Prod as "
         + "'aggregate(topcount("
         + "crossjoin( {time.[1997]}, product.[product name].members), 5, measures.[unit sales]), measures.[unit "
@@ -6963,7 +6963,7 @@ class NonEmptyTest extends BatchTestCase {
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testMondrian2202WithParameter(Context context)  {
     ((TestConfig)context.getConfig()).setLevelPreCacheThreshold(0);
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "WITH "
         + "member measures.[overrideContext] as "
         + "'( measures.[unit sales], "
@@ -6978,7 +6978,7 @@ class NonEmptyTest extends BatchTestCase {
         + "Axis #2:\n"
         + "{[Time].[1998].[Q1], [Marital Status].[M]}\n"
         + "Row #0: 33,101\n" );
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "WITH member Time.param as 'Parameter(\"timeParam\",[Time],[Time].[1997].[Q1],\"?\")' "
         + "member measures.[overrideContext] as '( measures.[unit sales], Time.param )'\n"
         + "SELECT measures.[overrideContext] on 0, \n"
@@ -7001,7 +7001,7 @@ class NonEmptyTest extends BatchTestCase {
     // overriden by the filter condition.
     // (This worked before the fix for MONDRIAN-2202, since
     // RolapNativeSql cannot nativize tuple calculations.)
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "WITH  member measures.[overrideContext] as "
         + " '( measures.[unit sales], Time.[1997].Q1 )'\n"
         + "SELECT measures.[overrideContext] on 0, \n"
@@ -7027,7 +7027,7 @@ class NonEmptyTest extends BatchTestCase {
     // overriden by the filter condition.
     // (This worked before the fix for MONDRIAN-2202, since
     // RolapNativeSql cannot nativize tuple calculations.)
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "WITH  member measures.[overrideContext] as "
         + " '( measures.[unit sales], Time.[1997].Q1 )'\n"
         + "SELECT measures.[overrideContext] on 0, \n"
@@ -7051,7 +7051,7 @@ class NonEmptyTest extends BatchTestCase {
   void testMondrian2202WithMeasureContainingCJ(Context context)  {
     ((TestConfig)context.getConfig()).setLevelPreCacheThreshold(0);
     // NECJ nested within a measure expression
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "with  "
         + " member gender.agg as 'aggregate(NonEmptyCrossJoin({Gender.F}, {[Marital Status].[Marital Status]"
         + ".members}))' "
@@ -7075,7 +7075,7 @@ class NonEmptyTest extends BatchTestCase {
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testMon2202RunningSum(Context context)  {
     ((TestConfig)context.getConfig()).setLevelPreCacheThreshold(0);
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "WITH\n"
         + "SET [*NATIVE_CJ_SET] AS 'NONEMPTYCROSSJOIN([*BASE_MEMBERS__Time_],NONEMPTYCROSSJOIN"
         + "([*BASE_MEMBERS__Education Level_],[*BASE_MEMBERS__Customers_])))'\n"
@@ -7177,7 +7177,7 @@ class NonEmptyTest extends BatchTestCase {
         + "CROSSJOIN([*SORTED_COL_AXIS],[*BASE_MEMBERS__Measures_]) ON COLUMNS\n"
         + ",[*SORTED_ROW_AXIS] ON ROWS\n"
         + "FROM [Sales]\n"
-        + "WHERE ([*CJ_SLICER_AXIS])", context.getConnection());
+        + "WHERE ([*CJ_SLICER_AXIS])", context.getConnectionWithDefaultRole());
   }
 
   @ParameterizedTest
@@ -7186,7 +7186,7 @@ class NonEmptyTest extends BatchTestCase {
     ((TestConfig)context.getConfig()).setLevelPreCacheThreshold(0);
       ((TestConfig)context.getConfig())
           .setAlertNativeEvaluationUnsupported("ERROR");
-      assertQueryReturns(context.getConnection(),
+      assertQueryReturns(context.getConnectionWithDefaultRole(),
       "WITH\n"
         + "SET [*NATIVE_CJ_SET] AS 'NONEMPTYCROSSJOIN([*BASE_MEMBERS__Education Level_],NONEMPTYCROSSJOIN"
         + "([*BASE_MEMBERS__Product_],[*BASE_MEMBERS__Time_]))'\n"
@@ -7260,7 +7260,7 @@ class NonEmptyTest extends BatchTestCase {
     ((TestConfig)context.getConfig()).setLevelPreCacheThreshold(0);
       ((TestConfig)context.getConfig())
           .setAlertNativeEvaluationUnsupported("ERROR");
-      assertQueryReturns(context.getConnection(),
+      assertQueryReturns(context.getConnectionWithDefaultRole(),
       "WITH\n"
         + "SET [*NATIVE_CJ_SET] AS 'NONEMPTYCROSSJOIN([*BASE_MEMBERS__Education Level_],NONEMPTYCROSSJOIN"
         + "([*BASE_MEMBERS__Product_],[*BASE_MEMBERS__Time_]))'\n"
@@ -7344,7 +7344,7 @@ class NonEmptyTest extends BatchTestCase {
     ((TestConfig)context.getConfig()).setLevelPreCacheThreshold(0);
       ((TestConfig)context.getConfig())
           .setAlertNativeEvaluationUnsupported("ERROR");
-      assertQueryReturns(context.getConnection(),
+      assertQueryReturns(context.getConnectionWithDefaultRole(),
       "WITH\n"
         + "SET [*NATIVE_CJ_SET] AS 'FILTER(NONEMPTYCROSSJOIN([*BASE_MEMBERS__Education Level_],NONEMPTYCROSSJOIN"
         + "([*BASE_MEMBERS__Product_],[*BASE_MEMBERS__Time_])), NOT ISEMPTY ([Measures].[Unit Sales]))'\n"
@@ -7438,7 +7438,7 @@ class NonEmptyTest extends BatchTestCase {
     ((TestConfig)context.getConfig()).setLevelPreCacheThreshold(0);
       ((TestConfig)context.getConfig())
           .setAlertNativeEvaluationUnsupported("ERROR");
-      assertQueryReturns(context.getConnection(),
+      assertQueryReturns(context.getConnectionWithDefaultRole(),
       "WITH\n"
         + "SET [*NATIVE_CJ_SET] AS 'NONEMPTYCROSSJOIN([*BASE_MEMBERS__Promotion Media_],NONEMPTYCROSSJOIN"
         + "([*BASE_MEMBERS__Store_],NONEMPTYCROSSJOIN([*BASE_MEMBERS__Education Level_],NONEMPTYCROSSJOIN"
@@ -7517,7 +7517,7 @@ class NonEmptyTest extends BatchTestCase {
     ((TestConfig)context.getConfig()).setLevelPreCacheThreshold(0);
       ((TestConfig)context.getConfig())
           .setAlertNativeEvaluationUnsupported("ERROR");
-      assertQueryReturns(context.getConnection(),
+      assertQueryReturns(context.getConnectionWithDefaultRole(),
       "WITH\n"
         + "SET [*NATIVE_CJ_SET] AS 'NONEMPTYCROSSJOIN([*BASE_MEMBERS__Promotion Media_],NONEMPTYCROSSJOIN"
         + "([*BASE_MEMBERS__Product_],NONEMPTYCROSSJOIN([*BASE_MEMBERS__Gender_],[*BASE_MEMBERS__Time_])))'\n"
@@ -7608,7 +7608,7 @@ class NonEmptyTest extends BatchTestCase {
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testNonEmptyCrossJoinCalcMember(Context context)  {
     ((TestConfig)context.getConfig()).setLevelPreCacheThreshold(0);
-    assertQueryReturns(context.getConnection(), new StringBuilder()
+    assertQueryReturns(context.getConnectionWithDefaultRole(), new StringBuilder()
         .append( "WITH \n" )
         .append( "MEMBER Measures.Calc AS '[Measures].[Profit] * 2', SOLVE_ORDER=1000\n" )
         .append( "MEMBER Product.Conditional as 'Iif(Measures.CurrentMember IS Measures.[Calc], + Measures.CurrentMember, " )
@@ -7643,7 +7643,7 @@ class NonEmptyTest extends BatchTestCase {
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testCrossJoinCalcMember(Context context)  {
     ((TestConfig)context.getConfig()).setLevelPreCacheThreshold(0);
-    assertQueryReturns(context.getConnection(), String.format(
+    assertQueryReturns(context.getConnectionWithDefaultRole(), String.format(
       "WITH \nMEMBER Measures.Calc AS '[Measures].[Profit] * 2', SOLVE_ORDER=1000\nMEMBER Product.Conditional as 'Iif"
         + "(Measures.CurrentMember IS Measures.[Calc], + Measures.CurrentMember, null)', SOLVE_ORDER=2000\nSET [S2] AS "
         + "'{[Store].MEMBERS}' \nSET [S1] AS 'CROSSJOIN({[Customers].[All Customers]},{Product.Conditional})' \nSELECT "
@@ -7690,7 +7690,7 @@ class NonEmptyTest extends BatchTestCase {
         + "  </Dimension>" ));
      */
       withSchema(context, SchemaModifiers.NonEmptyTestModifier5::new);
-      assertQueryReturns(context.getConnection(),
+      assertQueryReturns(context.getConnectionWithDefaultRole(),
       "with member measures.one as '1' select non empty store2.usa.[OR].children on 0, measures.one on 1 from sales",
       "Axis #0:\n"
         + "{}\n"
@@ -7701,7 +7701,7 @@ class NonEmptyTest extends BatchTestCase {
         + "{[Measures].[one]}\n"
         + "Row #0: 1\n"
         + "Row #0: 1\n" );
-    assertQueryReturns(context.getConnection(), "with member measures.one as '1' "
+    assertQueryReturns(context.getConnectionWithDefaultRole(), "with member measures.one as '1' "
         + "select store2.usa.[OR].children on 0, measures.one on 1 from sales",
       "Axis #0:\n"
         + "{}\n"
@@ -7759,7 +7759,7 @@ class NonEmptyTest extends BatchTestCase {
           + "</Schema>" );
      */
       withSchema(context,  SchemaModifiers.NonEmptyTestModifier7::new);
-      verifySameNativeAndNot(context.getConnection(),
+      verifySameNativeAndNot(context.getConnectionWithDefaultRole(),
       "select "
         + " [Measures].[dummyMeasure2] on COLUMNS, "
         + " NON EMPTY CrossJoin([Store].[Store State].Members, Time.[Year].members) ON ROWS "

--- a/mondrian/src/test/java/mondrian/rolap/OrderKeyOneToOneCheckTest.java
+++ b/mondrian/src/test/java/mondrian/rolap/OrderKeyOneToOneCheckTest.java
@@ -55,7 +55,7 @@ class OrderKeyOneToOneCheckTest {
   public void prepareContext(Context context) {
     //TestContext testContext = super.getTestContext()
     //        .withFreshConnection();
-    flushSchemaCache(context.getConnection());
+    flushSchemaCache(context.getConnectionWithDefaultRole());
     /*
     withSchema(context,
             ""
@@ -91,7 +91,7 @@ class OrderKeyOneToOneCheckTest {
                     + "[Time].[1997] on 1 \n"
                     + "from [Sales]";
     prepareContext(context);
-    executeQuery(context.getConnection(), mdx);
+    executeQuery(context.getConnectionWithDefaultRole(), mdx);
     fail("need slf4j implementation");
     //TODO need slf4j implementation
     //assertEquals(
@@ -112,7 +112,7 @@ class OrderKeyOneToOneCheckTest {
             + "from [Sales]";
 
     prepareContext(context);
-    executeQuery(context.getConnection(), mdx);
+    executeQuery(context.getConnectionWithDefaultRole(), mdx);
     fail("need slf4j implementation");
     //TODO need slf4j implementation
     //assertEquals(

--- a/mondrian/src/test/java/mondrian/rolap/RolapCubeHierarchyTest.java
+++ b/mondrian/src/test/java/mondrian/rolap/RolapCubeHierarchyTest.java
@@ -37,7 +37,7 @@ class RolapCubeHierarchyTest {
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testMONDRIAN2535(Context context) {
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
         "Select\n"
         + "  [Customers].children on rows,\n"
         + "  [Gender].children on columns\n "

--- a/mondrian/src/test/java/mondrian/rolap/RolapCubeTest.java
+++ b/mondrian/src/test/java/mondrian/rolap/RolapCubeTest.java
@@ -70,7 +70,7 @@ class RolapCubeTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testProcessFormatStringAttributeToIgnoreNullFormatString(Context context) {
         RolapCube cube =
-            (RolapCube) context.getConnection().getSchema().lookupCube("Sales", false);
+            (RolapCube) context.getConnectionWithDefaultRole().getSchema().lookupCube("Sales", false);
         StringBuilder builder = new StringBuilder();
         cube.processFormatStringAttribute(
             CalculatedMemberMappingImpl.builder().build(), builder);
@@ -81,7 +81,7 @@ class RolapCubeTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testProcessFormatStringAttribute(Context context) {
         RolapCube cube =
-            (RolapCube) context.getConnection().getSchema().lookupCube("Sales", false);
+            (RolapCube) context.getConnectionWithDefaultRole().getSchema().lookupCube("Sales", false);
         StringBuilder builder = new StringBuilder();
         CalculatedMemberMappingImpl xmlCalcMember =
         		CalculatedMemberMappingImpl.builder().build();
@@ -102,7 +102,7 @@ class RolapCubeTest {
             "[Measures].[Profit Growth]",
             "[Measures].[Profit Per Unit Shipped]"
         };
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         try {
             Cube warehouseAndSalesCube =
                 cubeByName(connection, "Warehouse and Sales");
@@ -273,7 +273,7 @@ class RolapCubeTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testNonJoiningDimensions(Context context) {
 
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
 
         try {
             RolapCube salesCube = (RolapCube) cubeByName(connection, "Sales");
@@ -308,9 +308,9 @@ class RolapCubeTest {
     void testRolapCubeDimensionEquality(Context context) {
 
 
-        Connection connection1 = context.getConnection();
+        Connection connection1 = context.getConnectionWithDefaultRole();
         //withSchema(context, null);
-        Connection connection2 = context.getConnection();
+        Connection connection2 = context.getConnectionWithDefaultRole();
 
         try {
             RolapCube salesCube1 = (RolapCube) cubeByName(connection1, "Sales");
@@ -370,7 +370,7 @@ class RolapCubeTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testBasedCubesForVirtualCube(Context context) {
-      Connection connection = context.getConnection();
+      Connection connection = context.getConnectionWithDefaultRole();
       RolapCube cubeSales =
           (RolapCube) connection.getSchema().lookupCube("Sales", false);
       RolapCube cubeWarehouse =
@@ -394,7 +394,7 @@ class RolapCubeTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testBasedCubesForNotVirtualCubeIsThisCube(Context context) {
       RolapCube cubeSales =
-          (RolapCube) context.getConnection().getSchema().lookupCube("Sales", false);
+          (RolapCube) context.getConnectionWithDefaultRole().getSchema().lookupCube("Sales", false);
       assertNotNull(cubeSales);
       assertEquals(false, cubeSales.isVirtual());
       List<RolapCube> baseCubes = cubeSales.getBaseCubes();

--- a/mondrian/src/test/java/mondrian/rolap/RolapEvaluatorTest.java
+++ b/mondrian/src/test/java/mondrian/rolap/RolapEvaluatorTest.java
@@ -24,7 +24,7 @@ class RolapEvaluatorTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testGetSlicerPredicateInfo(Context context) throws Exception {
-        RolapResult result = (RolapResult) executeQuery(context.getConnection(),
+        RolapResult result = (RolapResult) executeQuery(context.getConnectionWithDefaultRole(),
             "select  from sales "
             + "WHERE {[Time].[1997].Q1, [Time].[1997].Q2} "
             + "* { Store.[USA].[CA], Store.[USA].[WA]}");
@@ -57,7 +57,7 @@ class RolapEvaluatorTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testListColumnPredicateInfo(Context context) throws Exception {
-      RolapResult result = (RolapResult) executeQuery(context.getConnection(),
+      RolapResult result = (RolapResult) executeQuery(context.getConnectionWithDefaultRole(),
           "select  from sales "
           + "WHERE {[Product].[Drink],[Product].[Non-Consumable]} ");
       RolapEvaluator evalulator = (RolapEvaluator) result.getRootEvaluator();
@@ -72,7 +72,7 @@ class RolapEvaluatorTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testOrPredicateInfo(Context context) throws Exception {
-      RolapResult result = (RolapResult) executeQuery(context.getConnection(),
+      RolapResult result = (RolapResult) executeQuery(context.getConnectionWithDefaultRole(),
           "select  from sales "
           + "WHERE {[Product].[Drink].[Beverages],[Product].[Food].[Produce],[Product].[Non-Consumable]} ");
       RolapEvaluator evalulator = (RolapEvaluator) result.getRootEvaluator();

--- a/mondrian/src/test/java/mondrian/rolap/RolapNativeSqlInjectionTest.java
+++ b/mondrian/src/test/java/mondrian/rolap/RolapNativeSqlInjectionTest.java
@@ -47,7 +47,7 @@ class RolapNativeSqlInjectionTest {
             + "from [Sales]";
 
         //TestContext context = getTestContext().withFreshConnection();
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         try {
             executeQuery(connection, mdxQuery);
         } catch (OlapRuntimeException e) {

--- a/mondrian/src/test/java/mondrian/rolap/RolapNativeTopCountTest.java
+++ b/mondrian/src/test/java/mondrian/rolap/RolapNativeTopCountTest.java
@@ -67,7 +67,7 @@ class RolapNativeTopCountTest extends BatchTestCase {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testTopCount_ImplicitCountMeasure(Context context) throws Exception {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             IMPLICIT_COUNT_MEASURE_QUERY, IMPLICIT_COUNT_MEASURE_RESULT);
     }
 
@@ -84,20 +84,20 @@ class RolapNativeTopCountTest extends BatchTestCase {
         //withCube(CUSTOM_COUNT_MEASURE_CUBE_NAME);
          */
         withSchema(context, SchemaModifiers.CustomCountMeasureCubeName::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             CUSTOM_COUNT_MEASURE_QUERY, CUSTOM_COUNT_MEASURE_RESULT);
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testTopCount_SumMeasure(Context context) throws Exception {
-        assertQueryReturns(context.getConnection(), SUM_MEASURE_QUERY, SUM_MEASURE_RESULT);
+        assertQueryReturns(context.getConnectionWithDefaultRole(), SUM_MEASURE_QUERY, SUM_MEASURE_RESULT);
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testEmptyCellsAreShown_Countries(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             EMPTY_CELLS_ARE_SHOWN_COUNTRIES_QUERY,
             EMPTY_CELLS_ARE_SHOWN_COUNTRIES_RESULT);
     }
@@ -105,7 +105,7 @@ class RolapNativeTopCountTest extends BatchTestCase {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testEmptyCellsAreShown_States(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             EMPTY_CELLS_ARE_SHOWN_STATES_QUERY,
             EMPTY_CELLS_ARE_SHOWN_STATES_RESULT);
     }
@@ -113,7 +113,7 @@ class RolapNativeTopCountTest extends BatchTestCase {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testEmptyCellsAreShown_ButNoMoreThanReallyExist(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             EMPTY_CELLS_ARE_SHOWN_NOT_MORE_THAN_EXIST_QUERY,
             EMPTY_CELLS_ARE_SHOWN_NOT_MORE_THAN_EXIST_RESULT);
     }
@@ -121,7 +121,7 @@ class RolapNativeTopCountTest extends BatchTestCase {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testEmptyCellsAreHidden_WhenNonEmptyIsDeclaredExplicitly(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             EMPTY_CELLS_ARE_HIDDEN_WHEN_NON_EMPTY_QUERY,
             EMPTY_CELLS_ARE_HIDDEN_WHEN_NON_EMPTY_RESULT);
     }
@@ -162,7 +162,7 @@ class RolapNativeTopCountTest extends BatchTestCase {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testMimicsHeadWhenTwoParams_States(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             TOPCOUNT_MIMICS_HEAD_WHEN_TWO_PARAMS_STATES_QUERY,
             TOPCOUNT_MIMICS_HEAD_WHEN_TWO_PARAMS_STATES_RESULT);
     }
@@ -170,7 +170,7 @@ class RolapNativeTopCountTest extends BatchTestCase {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testMimicsHeadWhenTwoParams_Cities(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             TOPCOUNT_MIMICS_HEAD_WHEN_TWO_PARAMS_CITIES_QUERY,
             TOPCOUNT_MIMICS_HEAD_WHEN_TWO_PARAMS_CITIES_RESULT);
     }
@@ -178,7 +178,7 @@ class RolapNativeTopCountTest extends BatchTestCase {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testMimicsHeadWhenTwoParams_ShowsNotMoreThanExist(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             RESULTS_ARE_SHOWN_NOT_MORE_THAN_EXIST_2_PARAMS_QUERY,
             RESULTS_ARE_SHOWN_NOT_MORE_THAN_EXIST_2_PARAMS_RESULT);
     }
@@ -186,7 +186,7 @@ class RolapNativeTopCountTest extends BatchTestCase {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testMimicsHeadWhenTwoParams_DoesNotIgnoreNonEmpty(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             NON_EMPTY_IS_NOT_IGNORED_WHEN_TWO_PARAMS_QUERY,
             NON_EMPTY_IS_NOT_IGNORED_WHEN_TWO_PARAMS_RESULT);
     }

--- a/mondrian/src/test/java/mondrian/rolap/RolapNativeTopCountVersusNonNativeTest.java
+++ b/mondrian/src/test/java/mondrian/rolap/RolapNativeTopCountVersusNonNativeTest.java
@@ -74,14 +74,14 @@ class RolapNativeTopCountVersusNonNativeTest extends BatchTestCase {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testTopCount_ImplicitCountMeasure(Context context) throws Exception {
-        assertResultsAreEqual(context.getConnection(),
+        assertResultsAreEqual(context.getConnectionWithDefaultRole(),
             "Implicit Count Measure", IMPLICIT_COUNT_MEASURE_QUERY);
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testTopCount_SumMeasure(Context context) throws Exception {
-        assertResultsAreEqual(context.getConnection(),
+        assertResultsAreEqual(context.getConnectionWithDefaultRole(),
             "Sum Measure", SUM_MEASURE_QUERY);
     }
 
@@ -96,14 +96,14 @@ class RolapNativeTopCountVersusNonNativeTest extends BatchTestCase {
        //withCube(CUSTOM_COUNT_MEASURE_CUBE_NAME);
        */
         withSchema(context, SchemaModifiers.CustomCountMeasureCubeName::new);
-        assertResultsAreEqual(context.getConnection(),
+        assertResultsAreEqual(context.getConnectionWithDefaultRole(),
             "Custom Count Measure", CUSTOM_COUNT_MEASURE_QUERY);
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testEmptyCellsAreShown_Countries(Context context) throws Exception {
-        assertResultsAreEqual(context.getConnection(),
+        assertResultsAreEqual(context.getConnectionWithDefaultRole(),
             "Empty Cells Are Shown - Countries",
             EMPTY_CELLS_ARE_SHOWN_COUNTRIES_QUERY);
     }
@@ -111,7 +111,7 @@ class RolapNativeTopCountVersusNonNativeTest extends BatchTestCase {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testEmptyCellsAreShown_States(Context context) throws Exception {
-        assertResultsAreEqual(context.getConnection(),
+        assertResultsAreEqual(context.getConnectionWithDefaultRole(),
             "Empty Cells Are Shown - States",
             EMPTY_CELLS_ARE_SHOWN_STATES_QUERY);
     }
@@ -119,7 +119,7 @@ class RolapNativeTopCountVersusNonNativeTest extends BatchTestCase {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testEmptyCellsAreShown_ButNoMoreThanReallyExist(Context context) {
-        assertResultsAreEqual(context.getConnection(),
+        assertResultsAreEqual(context.getConnectionWithDefaultRole(),
             "Empty Cells Are Shown - But no more than really exist",
             EMPTY_CELLS_ARE_SHOWN_NOT_MORE_THAN_EXIST_QUERY);
     }
@@ -127,7 +127,7 @@ class RolapNativeTopCountVersusNonNativeTest extends BatchTestCase {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testEmptyCellsAreHidden_WhenNonEmptyIsDeclaredExplicitly(Context context) {
-        assertResultsAreEqual(context.getConnection(),
+        assertResultsAreEqual(context.getConnectionWithDefaultRole(),
             "Empty Cells Are Hidden - When NON EMPTY is declared explicitly",
             EMPTY_CELLS_ARE_HIDDEN_WHEN_NON_EMPTY_QUERY);
     }
@@ -167,7 +167,7 @@ class RolapNativeTopCountVersusNonNativeTest extends BatchTestCase {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testMimicsHeadWhenTwoParams_States(Context context) {
-        assertResultsAreEqual(context.getConnection(),
+        assertResultsAreEqual(context.getConnectionWithDefaultRole(),
             "Two Parameters - States",
             TOPCOUNT_MIMICS_HEAD_WHEN_TWO_PARAMS_STATES_QUERY);
     }
@@ -175,7 +175,7 @@ class RolapNativeTopCountVersusNonNativeTest extends BatchTestCase {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testMimicsHeadWhenTwoParams_Cities(Context context) {
-        assertResultsAreEqual(context.getConnection(),
+        assertResultsAreEqual(context.getConnectionWithDefaultRole(),
             "Two Parameters - Cities",
             TOPCOUNT_MIMICS_HEAD_WHEN_TWO_PARAMS_CITIES_QUERY);
     }
@@ -183,7 +183,7 @@ class RolapNativeTopCountVersusNonNativeTest extends BatchTestCase {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testMimicsHeadWhenTwoParams_ShowsNotMoreThanExist(Context context) {
-        assertResultsAreEqual(context.getConnection(),
+        assertResultsAreEqual(context.getConnectionWithDefaultRole(),
             "Two Parameters - Shows not more than really exist",
             RESULTS_ARE_SHOWN_NOT_MORE_THAN_EXIST_2_PARAMS_QUERY);
     }
@@ -191,7 +191,7 @@ class RolapNativeTopCountVersusNonNativeTest extends BatchTestCase {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testMimicsHeadWhenTwoParams_DoesNotIgnoreNonEmpty(Context context) {
-        assertResultsAreEqual(context.getConnection(),
+        assertResultsAreEqual(context.getConnectionWithDefaultRole(),
             "Two Parameters - Does not ignore NON EMPTY",
             NON_EMPTY_IS_NOT_IGNORED_WHEN_TWO_PARAMS_QUERY);
     }

--- a/mondrian/src/test/java/mondrian/rolap/RolapResultTest.java
+++ b/mondrian/src/test/java/mondrian/rolap/RolapResultTest.java
@@ -91,7 +91,7 @@ class RolapResultTest extends AggTableTestCase {
         ((TestConfig)context.getConfig()).setUseAggregates(true);
         ((TestConfig)context.getConfig()).setReadAggregates(true);
         prepareContext(context);
-        if (!isApplicable(context.getConnection())) {
+        if (!isApplicable(context.getConnectionWithDefaultRole())) {
             return;
         }
 
@@ -104,7 +104,7 @@ class RolapResultTest extends AggTableTestCase {
             + " ON ROWS "
             + "from FTAll";
 
-        assertQueryReturns(context.getConnection(), mdx, RESULTS_ALL);
+        assertQueryReturns(context.getConnectionWithDefaultRole(), mdx, RESULTS_ALL);
 /*
         Result result = getCubeTestContext().executeQuery(mdx);
         String resultString = TestContext.toString(result);
@@ -120,7 +120,7 @@ class RolapResultTest extends AggTableTestCase {
         ((TestConfig)context.getConfig()).setUseAggregates(true);
         ((TestConfig)context.getConfig()).setReadAggregates(true);
         prepareContext(context);
-        if (!isApplicable(context.getConnection())) {
+        if (!isApplicable(context.getConnectionWithDefaultRole())) {
             return;
         }
         String mdx =
@@ -133,7 +133,7 @@ class RolapResultTest extends AggTableTestCase {
             + "from FT1";
 
         //getCubeTestContext().assertQueryReturns(mdx, RESULTS);
-        Result result = executeQuery(mdx, context.getConnection());
+        Result result = executeQuery(mdx, context.getConnectionWithDefaultRole());
         String resultString = TestUtil.toString(result);
 //System.out.println(resultString);
 /*
@@ -155,7 +155,7 @@ Axis #2:
         ((TestConfig)context.getConfig()).setUseAggregates(true);
         ((TestConfig)context.getConfig()).setReadAggregates(true);
         prepareContext(context);
-        if (!isApplicable(context.getConnection())) {
+        if (!isApplicable(context.getConnectionWithDefaultRole())) {
             return;
         }
         String mdx =
@@ -167,7 +167,7 @@ Axis #2:
             + " ON ROWS "
             + "from FT2";
 
-        assertQueryReturns(context.getConnection(), mdx, RESULTS);
+        assertQueryReturns(context.getConnectionWithDefaultRole(), mdx, RESULTS);
 /*
         Result result = getCubeTestContext().executeQuery(mdx);
         String resultString = TestContext.toString(result);
@@ -192,7 +192,7 @@ Axis #2:
         ((TestConfig)context.getConfig()).setUseAggregates(true);
         ((TestConfig)context.getConfig()).setReadAggregates(true);
         prepareContext(context);
-        if (!isApplicable(context.getConnection())) {
+        if (!isApplicable(context.getConnectionWithDefaultRole())) {
             return;
         }
 
@@ -206,7 +206,7 @@ Axis #2:
             + "from FT2Extra";
 
         //getCubeTestContext().assertQueryReturns(mdx, RESULTS);
-        Result result = executeQuery(mdx, context.getConnection());
+        Result result = executeQuery(mdx, context.getConnectionWithDefaultRole());
         String resultString = TestUtil.toString(result);
         assertTrue(resultString.equals(RESULTS));
     }
@@ -236,7 +236,7 @@ Axis #2:
             + "</Dimension>"));
          */
         withSchema(context, SchemaModifiers.RolapResultTestModifier::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Promotion2 Name].[Price Winners], [Promotion2 Name].[Sale Winners]} * {Tail([Time].[Year].Members,3)} ON COLUMNS, "
             + "NON EMPTY Crossjoin({[Store].CurrentMember.Children},  {[Store Type].[All Store Types].Children}) ON ROWS "
             + "from [Sales]",

--- a/mondrian/src/test/java/mondrian/rolap/RolapSchemaReaderTest.java
+++ b/mondrian/src/test/java/mondrian/rolap/RolapSchemaReaderTest.java
@@ -90,7 +90,7 @@ class RolapSchemaReaderTest {
                 "Sales Ragged", "Sales 2", "HR"
         };
 
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         try {
             SchemaReader reader = connection.getSchemaReader().withLocus();
 
@@ -136,7 +136,7 @@ class RolapSchemaReaderTest {
         //    "true");
 
         try {
-        	context.getConnection();
+        	context.getConnectionWithDefaultRole();
             //DriverManager.getConnection(
             //    properties,
             //    null);

--- a/mondrian/src/test/java/mondrian/rolap/RolapStarTest.java
+++ b/mondrian/src/test/java/mondrian/rolap/RolapStarTest.java
@@ -81,7 +81,7 @@ class RolapStarTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCloneRelationWithFilteredTable(Context context) {
-      RolapStarForTests rs = getStar(context.getConnection(), "sales");
+      RolapStarForTests rs = getStar(context.getConnectionWithDefaultRole(), "sales");
       TableQueryMappingImpl original = TableQueryMappingImpl.builder()
     		  .withTable(((Builder) PhysicalTableImpl.builder().withName("TestTable")
     				  .withsSchema(DatabaseSchemaImpl.builder().withName("Sechema").build())).build())

--- a/mondrian/src/test/java/mondrian/rolap/SharedDimensionTest.java
+++ b/mondrian/src/test/java/mondrian/rolap/SharedDimensionTest.java
@@ -346,7 +346,7 @@ class SharedDimensionTest  {
         // Query from the first cube.
         getTestContextForSharedDimCubeACubeB(context);
 
-        assertQueryReturns(context.getConnection(), queryCubeA, resultCubeA);
+        assertQueryReturns(context.getConnectionWithDefaultRole(), queryCubeA, resultCubeA);
     }
 
     @ParameterizedTest
@@ -357,7 +357,7 @@ class SharedDimensionTest  {
         // Query from the second cube.
         getTestContextForSharedDimCubeACubeB(context);
 
-        assertQueryReturns(context.getConnection(), queryCubeB, resultCubeB);
+        assertQueryReturns(context.getConnectionWithDefaultRole(), queryCubeB, resultCubeB);
     }
 
     @ParameterizedTest
@@ -380,7 +380,7 @@ class SharedDimensionTest  {
         */
         withSchema(context, SchemaModifiers.SharedDimensionTestModifier::new);
 
-        assertQueryReturns(context.getConnection(), queryVirtualCube, resultVirtualCube);
+        assertQueryReturns(context.getConnectionWithDefaultRole(), queryVirtualCube, resultVirtualCube);
     }
 
     @ParameterizedTest
@@ -391,7 +391,7 @@ class SharedDimensionTest  {
         // Query from the second cube.
         getTestContextForSharedDimCubeACubeB(context);
 
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             queryNECJMemberList,
             resultNECJMemberList);
     }
@@ -406,7 +406,7 @@ class SharedDimensionTest  {
         // but also produces incorrect result.
         getTestContextForSharedDimCubeACubeB(context);
 
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             queryNECJMultiLevelMemberList,
             resultNECJMultiLevelMemberList);
     }
@@ -420,14 +420,14 @@ class SharedDimensionTest  {
     void testBugMondrian286(Context context) {
         // Test for sourceforge.net bug 1711865 (MONDRIAN-286).
         // Use the default FoodMart schema
-        assertQueryReturns(context.getConnection(), querySF1711865, resultSF1711865);
+        assertQueryReturns(context.getConnectionWithDefaultRole(), querySF1711865, resultSF1711865);
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testStoreCube(Context context) {
         // Use the default FoodMart schema
-        assertQueryReturns(context.getConnection(), queryStoreCube, resultStoreCube);
+        assertQueryReturns(context.getConnectionWithDefaultRole(), queryStoreCube, resultStoreCube);
     }
 
     /**
@@ -439,7 +439,7 @@ class SharedDimensionTest  {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testBugMondrian1243WrongAlias(Context context) {
         getTestContextForSharedDimCubeAltSales(context);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             queryIssue1243,
             resultIssue1243);
     }
@@ -448,7 +448,7 @@ class SharedDimensionTest  {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testMemberUniqueNameForSharedWithChangedName(Context context) {
         getTestContextForSharedDimCubeAltSales(context);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with "
             + " member [BuyerTwo].[Mexico].[calc] as '[BuyerTwo].[Mexico]' "
             + "select [BuyerTwo].[Mexico].[calc] on 0 from [Alternate Sales]",

--- a/mondrian/src/test/java/mondrian/rolap/SqlConstraintUtilsTest.java
+++ b/mondrian/src/test/java/mondrian/rolap/SqlConstraintUtilsTest.java
@@ -401,7 +401,7 @@ class SqlConstraintUtilsTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testReplaceCompoundSlicerPlaceholder(Context context) {
-        final Connection connection = context.getConnection();
+        final Connection connection = context.getConnectionWithDefaultRole();
 
         final String queryText =
             "SELECT {[Measures].[Customer Count]} ON 0 "
@@ -623,7 +623,7 @@ class SqlConstraintUtilsTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testExpandSupportedCalculatedMembers2(Context context) {
-      final Connection connection = context.getConnection();
+      final Connection connection = context.getConnectionWithDefaultRole();
 
       final String queryText =
           "SELECT {[Measures].[Customer Count]} ON 0 "

--- a/mondrian/src/test/java/mondrian/rolap/TestAggregationManager.java
+++ b/mondrian/src/test/java/mondrian/rolap/TestAggregationManager.java
@@ -118,7 +118,7 @@ class TestAggregationManager extends BatchTestCase {
 
     private void prepareContext(Context context) {
         final Statement statement =
-            ((Connection) context.getConnection())
+            ((Connection) context.getConnectionWithDefaultRole())
                 .getInternalStatement();
         execution = new ExecutionImpl(statement, Optional.empty());
         aggMgr =
@@ -133,7 +133,7 @@ class TestAggregationManager extends BatchTestCase {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testFemaleUnitSales(Context context) {
         prepareContext(context);
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         final FastBatchingCellReader fbcr =
             new FastBatchingCellReader(execution, getCube(connection,"Sales"), aggMgr);
         CellRequest request = createRequest(connection,
@@ -152,9 +152,9 @@ class TestAggregationManager extends BatchTestCase {
     void  testFemaleCustomerCount(Context context) {
         prepareContext(context);
         final FastBatchingCellReader fbcr =
-            new FastBatchingCellReader(execution, getCube(context.getConnection(), "Sales"), aggMgr);
+            new FastBatchingCellReader(execution, getCube(context.getConnectionWithDefaultRole(), "Sales"), aggMgr);
         CellRequest request =
-            createRequest(context.getConnection(),
+            createRequest(context.getConnectionWithDefaultRole(),
                 "Sales", "[Measures].[Customer Count]",
                 "customer", "gender", "F");
         Object value = aggMgr.getCellFromCache(request);
@@ -179,7 +179,7 @@ class TestAggregationManager extends BatchTestCase {
         List<String[]> Q1M1Q2M5 = new ArrayList<> ();
         Q1M1Q2M5.add(new String[] {"1997", "Q1", "1"});
         Q1M1Q2M5.add(new String[] {"1997", "Q2", "5"});
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         CellRequest request1 =
             createRequest(connection,
                 "Sales", "[Measures].[Customer Count]",
@@ -236,7 +236,7 @@ class TestAggregationManager extends BatchTestCase {
         {
             return;
         }
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         CellRequest request = createRequest(connection,
             "Sales", "[Measures].[Unit Sales]", "customer", "gender", "F");
 
@@ -262,7 +262,7 @@ class TestAggregationManager extends BatchTestCase {
      */
     private void _testFemaleUnitSalesSql_withAggs(Context context) {
         prepareContext(context);
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         CellRequest request = createRequest(connection,
             "Sales", "[Measures].[Unit Sales]", "customer", "gender", "F");
 
@@ -297,7 +297,7 @@ class TestAggregationManager extends BatchTestCase {
         {
             return;
         }
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         CellRequest[] requests = new CellRequest[] {
             createRequest(connection,
                 "Sales",
@@ -349,7 +349,7 @@ class TestAggregationManager extends BatchTestCase {
     @SuppressWarnings("java:S5810")
     private void _testMultipleMeasures_withAgg(Context context) {
         prepareContext(context);
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         CellRequest[] requests = new CellRequest[] {
             createRequest(connection,
                 "Sales",
@@ -401,7 +401,7 @@ class TestAggregationManager extends BatchTestCase {
         String table = "store";
         String column = "store_state";
         String value = "CA";
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         final boolean fail = true;
         Cube salesCube = connection.getSchema().lookupCube(cube, fail);
         Member storeSqftMeasure =
@@ -518,7 +518,7 @@ class TestAggregationManager extends BatchTestCase {
                     DatabaseProduct.DERBY, derbySql, derbySql)
             };
         }
-        assertQuerySql(context.getConnection(), mdxQuery, patterns);
+        assertQuerySql(context.getConnectionWithDefaultRole(), mdxQuery, patterns);
     }
 
     /**
@@ -534,7 +534,7 @@ class TestAggregationManager extends BatchTestCase {
         prepareContext(context);
         // Not sure what this test is checking.
         // For now, only run it for derby.
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         final Dialect dialect = getDialect(connection);
         if (getDatabaseProduct(dialect.getDialectName()) != DatabaseProduct.DERBY) {
             return;
@@ -597,7 +597,7 @@ class TestAggregationManager extends BatchTestCase {
     void testHierarchyInFactTable(Context context) {
     	context.getSchemaCache().clear();
         prepareContext(context);
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         CellRequest request = createRequest(connection,
             "Store",
             "[Measures].[Store Sqft]",
@@ -636,7 +636,7 @@ class TestAggregationManager extends BatchTestCase {
     void testCountDistinctAggMiss(Context context) {
     	context.getSchemaCache().clear();
         prepareContext(context);
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         CellRequest request = createRequest(connection,
             "Sales",
             "[Measures].[Customer Count]",
@@ -708,7 +708,7 @@ class TestAggregationManager extends BatchTestCase {
         {
             return;
         }
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         CellRequest request = createRequest(connection,
             "Sales", "[Measures].[Customer Count]",
             new String[] { "time_by_day", "time_by_day", "time_by_day" },
@@ -742,7 +742,7 @@ class TestAggregationManager extends BatchTestCase {
         // Summary "agg_g_ms_pcat_sales_fact_1997" doesn't match,
         // because we'd need to roll-up the distinct-count measure over
         // "month_of_year".
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         CellRequest request = createRequest(connection,
             "Sales", "[Measures].[Customer Count]",
             new String[] { "time_by_day", "time_by_day", "product_class" },
@@ -848,7 +848,7 @@ class TestAggregationManager extends BatchTestCase {
         //
         // Because [Gender] and [Marital Status] come from the [Customer]
         // table (the same as the distinct-count measure), we can roll up.
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         CellRequest request = createRequest(connection,
             "Sales", "[Measures].[Customer Count]",
             new String[] {
@@ -900,7 +900,7 @@ class TestAggregationManager extends BatchTestCase {
         {
             return;
         }
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         CellRequest request = createRequest(connection,
             "Sales", "[Measures].[Customer Count]",
             new String[] {
@@ -962,7 +962,7 @@ class TestAggregationManager extends BatchTestCase {
 
         CellRequestConstraint aggConstraint =
             makeConstraintYearQuarterMonth(compoundMembers);
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         CellRequest request1 = createRequest(connection,
             "Sales", "[Measures].[Customer Count]",
             new String[] {"product_class"},
@@ -1050,7 +1050,7 @@ class TestAggregationManager extends BatchTestCase {
                 + "group by `store`.`store_country` "
                 + "order by ISNULL(`store`.`store_country`) ASC, `store`.`store_country` ASC",
                 26)};
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         assertQuerySql(connection,
             "select NON EMPTY {[Customers].[USA]} ON COLUMNS,\n"
             + "       NON EMPTY Crossjoin(Hierarchize(Union({[Store].[All Stores]},\n"
@@ -1071,7 +1071,7 @@ class TestAggregationManager extends BatchTestCase {
     void testAggChildMembersOfLeaf(Context context) {
     	context.getSchemaCache().clear();
         prepareContext(context);
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         assertQueryReturns(connection,
             "select NON EMPTY {[Time].[1997]} ON COLUMNS,\n"
             + "       NON EMPTY Crossjoin(Hierarchize(Union({[Store].[All Stores]},\n"
@@ -1111,7 +1111,7 @@ class TestAggregationManager extends BatchTestCase {
             + "</Dimension>"));
          */
         withSchema(context, SchemaModifiers.TestAggregationManagerModifier1::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Measures].[Unit Sales]} on columns, "
             + "Filter ({ "
             + "[Store2].[All Stores].[USA].[CA].[Beverly Hills], "
@@ -1174,7 +1174,7 @@ class TestAggregationManager extends BatchTestCase {
             };
 
         //final TestContext context = getTestContext().withFreshConnection();
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         try {
             // This MDX gets the [Product].[Product Family] cardinality
             // from the DB.
@@ -1484,7 +1484,7 @@ class TestAggregationManager extends BatchTestCase {
         withSchema(context, TestKeyExpressionCardinalityCacheModifier::new);
         // This query causes "store"."store_country" cardinality to be
         // retrieved.
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         executeQuery(query, connection);
 
         // Query1 will find the "store"."store_country" cardinality in cache.
@@ -1536,7 +1536,7 @@ class TestAggregationManager extends BatchTestCase {
 
         List<String[]> compoundMembers = new ArrayList<> ();
         compoundMembers.add(new String[] {"1997", "Q1", "1"});
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         CellRequest request = createRequest(connection,
             "Sales", "[Measures].[Customer Count]",
             new String[] { "product_class", "product_class", "product_class" },
@@ -1595,7 +1595,7 @@ class TestAggregationManager extends BatchTestCase {
         if (!(context.getConfig().enableNativeCrossJoin())) {
             return;
         }
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         flushSchemaCache(connection);
         /*
         String cube = "<Cube name=\"Sales_Prod_Ord\">\n"
@@ -1801,9 +1801,9 @@ class TestAggregationManager extends BatchTestCase {
         };
 
         assertQuerySqlOrNot(
-            context.getConnection(), query, patterns, false, false, false);
+            context.getConnectionWithDefaultRole(), query, patterns, false, false, false);
 
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             query,
             "Axis #0:\n"
             + "{}\n"
@@ -1813,7 +1813,7 @@ class TestAggregationManager extends BatchTestCase {
             + "{[Product].[Food].[Deli].[Meat], [Gender].[M]}\n"
             + "Row #0: 4,705\n");
 
-        Result result = executeQuery(query, context.getConnection());
+        Result result = executeQuery(query, context.getConnectionWithDefaultRole());
         // this verifies that the caption for meat is Food
         assertEquals(
             "Meat",
@@ -1828,7 +1828,7 @@ class TestAggregationManager extends BatchTestCase {
             + "non empty [Product].[Food].[Deli].Children on rows "
             + "from [Sales_Prod_Ord] ";
 
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             query,
             "Axis #0:\n"
             + "{}\n"
@@ -1855,7 +1855,7 @@ class TestAggregationManager extends BatchTestCase {
             return;
         }
         // flush cache, to be sure sql is executed
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         flushSchemaCache(connection);
 
         // This first query verifies that simple collapsed levels in aggregate
@@ -1969,7 +1969,7 @@ class TestAggregationManager extends BatchTestCase {
         if (!(context.getConfig().enableNativeCrossJoin())) {
             return;
         }
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         // flush cache to be sure sql is executed
         flushSchemaCache(connection);
 
@@ -2016,7 +2016,7 @@ class TestAggregationManager extends BatchTestCase {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testLevelKeyAsSqlExpWithAgg(Context context) {
         prepareContext(context);
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         final boolean p;
         switch (getDatabaseProduct(getDialect(connection).getDialectName())) {
         case POSTGRES:
@@ -2075,7 +2075,7 @@ class TestAggregationManager extends BatchTestCase {
         context.getSchemaCache().clear();
         catalog = ((RolapContext) context).getCatalogMapping();
         ((TestContext)context).setCatalogMappingSupplier(new SchemaModifiers.TestAggregationManagerModifier10(catalog, colName));
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select non empty{[Promotions].[All Promotions].Children} ON rows, "
             + "non empty {[Store].[All Stores]} ON columns "
             + "from [Sales] "
@@ -2362,7 +2362,7 @@ class TestAggregationManager extends BatchTestCase {
         // If the approxRowcount is used, there should not be
         // a query like : select count(*) from agg_pl_01_sales_fact_1997
         assertQuerySqlOrNot(
-            context.getConnection(),
+            context.getConnectionWithDefaultRole(),
             mdxQuery,
             new SqlPattern[] {
                 new SqlPattern(
@@ -2601,7 +2601,7 @@ class TestAggregationManager extends BatchTestCase {
         final String sqlMysql =
             "select `product_class`.`product_family` as `c0`, sum(`agg_l_05_sales_fact_1997`.`unit_sales`) as `m0` from `product_class` as `product_class`, `product` as `product`, `agg_l_05_sales_fact_1997` as `agg_l_05_sales_fact_1997` where `agg_l_05_sales_fact_1997`.`product_id` = `product`.`product_id` and `product`.`product_class_id` = `product_class`.`product_class_id` group by `product_class`.`product_family`";
         assertQuerySqlOrNot(
-            context.getConnection(),
+            context.getConnectionWithDefaultRole(),
             mdx,
             new SqlPattern[] {
                 new SqlPattern(
@@ -2678,7 +2678,7 @@ class TestAggregationManager extends BatchTestCase {
             + "[Product].[Product Family].members } on rows, "
             + "{[Measures].[Unit Sales]} on columns from [Foo]";
 
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             mdx,
             "Axis #0:\n"
             +    "{}\n"
@@ -2694,7 +2694,7 @@ class TestAggregationManager extends BatchTestCase {
         final String sqlMysql =
             "select `product_class`.`product_family` as `c0`, sum(`agg_l_05_sales_fact_1997`.`unit_sales`) as `m0` from `product_class` as `product_class`, `product` as `product`, `agg_l_05_sales_fact_1997` as `agg_l_05_sales_fact_1997` where `agg_l_05_sales_fact_1997`.`product_id` = `product`.`product_id` and `product`.`product_class_id` = `product_class`.`product_class_id` group by `product_class`.`product_family`";
         assertQuerySqlOrNot(
-            context.getConnection(),
+            context.getConnectionWithDefaultRole(),
             mdx,
             new SqlPattern[] {
                 new SqlPattern(
@@ -2761,7 +2761,7 @@ class TestAggregationManager extends BatchTestCase {
             + "{ "
             + "[Promotions].[Media Type].members } on rows, {[Measures].[Unit Sales]} on columns from [Foo]";
 
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             mdx,
             "Axis #0:\n"
             + "{}\n"
@@ -2799,7 +2799,7 @@ class TestAggregationManager extends BatchTestCase {
         final String sqlMysql =
             "select `promotion`.`media_type` as `c0`, sum(`agg_c_special_sales_fact_1997`.`unit_sales_sum`) as `m0` from `promotion` as `promotion`, `agg_c_special_sales_fact_1997` as `agg_c_special_sales_fact_1997` where `agg_c_special_sales_fact_1997`.`promotion_id` = `promotion`.`promotion_id` group by `promotion`.`media_type`";
         assertQuerySqlOrNot(
-            context.getConnection(),
+            context.getConnectionWithDefaultRole(),
             mdx,
             new SqlPattern[] {
                 new SqlPattern(
@@ -3125,7 +3125,7 @@ class TestAggregationManager extends BatchTestCase {
             + "    `product_class`.`product_family`,\n"
             + "    `agg_l_05_sales_fact_1997`.`store_id`";
         assertQuerySqlOrNot(
-            context.getConnection(),
+            context.getConnectionWithDefaultRole(),
             mdx,
             new SqlPattern[] {
                 new SqlPattern(
@@ -3276,7 +3276,7 @@ class TestAggregationManager extends BatchTestCase {
                 + "    `agg_c_14_sales_fact_1997`.`month_of_year`,\n"
                 + "    `store`.`store_country`\n"
                 + "order by\n"
-                + (getDialect(context.getConnection()).requiresOrderByAlias()
+                + (getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
                     ? "    ISNULL(`c0`) ASC, `c0` ASC,\n"
                     + "    ISNULL(`c1`) ASC, `c1` ASC,\n"
                     + "    ISNULL(`c2`) ASC, `c2` ASC,\n"
@@ -3287,7 +3287,7 @@ class TestAggregationManager extends BatchTestCase {
                     + "    ISNULL(`store`.`store_country`) ASC, `store`.`store_country` ASC");
 
             assertQuerySqlOrNot(
-                context.getConnection(),
+                context.getConnectionWithDefaultRole(),
                 mdx,
                 new SqlPattern[] {
                     new SqlPattern(
@@ -3297,7 +3297,7 @@ class TestAggregationManager extends BatchTestCase {
                 },
                 false, false, true);
         }
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             mdx,
             "Axis #0:\n"
             + "{}\n"
@@ -3437,7 +3437,7 @@ class TestAggregationManager extends BatchTestCase {
             + "    `time_by_day`.`the_year`,\n"
             + "    `store`.`store_country`\n"
             + "order by\n"
-            + (getDialect(context.getConnection()).requiresOrderByAlias()
+            + (getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
                 ? "    ISNULL(`c0`) ASC, `c0` ASC,\n"
                 + "    ISNULL(`c1`) ASC, `c1` ASC"
                 : "    ISNULL(`time_by_day`.`the_year`) ASC, `time_by_day`.`the_year` ASC,\n"
@@ -3484,7 +3484,7 @@ class TestAggregationManager extends BatchTestCase {
             + "    `time_by_day`.`day_of_month`,\n"
             + "    `store`.`store_country`\n"
             + "order by\n"
-            + (getDialect(context.getConnection()).requiresOrderByAlias()
+            + (getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
                 ? "    ISNULL(`c0`) ASC, `c0` ASC,\n"
                 + "    ISNULL(`c1`) ASC, `c1` ASC,\n"
                 + "    ISNULL(`c2`) ASC, `c2` ASC,\n"
@@ -3520,7 +3520,7 @@ class TestAggregationManager extends BatchTestCase {
         withSchema(context, SchemaModifiers.TestAggregationManagerModifier6::new);
 
         assertQuerySqlOrNot(
-            context.getConnection(),
+            context.getConnectionWithDefaultRole(),
             mdx,
             new SqlPattern[] {
                 new SqlPattern(
@@ -3531,7 +3531,7 @@ class TestAggregationManager extends BatchTestCase {
             false, false, true);
 
         assertQuerySqlOrNot(
-            context.getConnection(),
+            context.getConnectionWithDefaultRole(),
             mdx,
             new SqlPattern[] {
                 new SqlPattern(
@@ -3543,7 +3543,7 @@ class TestAggregationManager extends BatchTestCase {
 
         // Because we have caused a many-to-many relation between the agg table
         // and the dim table, we expect retarded numbers here.
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             mdx,
             "Axis #0:\n"
             + "{}\n"
@@ -3558,7 +3558,7 @@ class TestAggregationManager extends BatchTestCase {
         // Make sure that queries on lower levels don't trigger a
         // false positive with the agg matcher.
         assertQuerySqlOrNot(
-            context.getConnection(),
+            context.getConnectionWithDefaultRole(),
             mdxTooLowForAgg,
             new SqlPattern[] {
                 new SqlPattern(
@@ -3569,7 +3569,7 @@ class TestAggregationManager extends BatchTestCase {
             false, false, true);
 
         assertQuerySqlOrNot(
-            context.getConnection(),
+            context.getConnectionWithDefaultRole(),
             mdxTooLowForAgg,
             new SqlPattern[] {
                 new SqlPattern(
@@ -3622,7 +3622,7 @@ class TestAggregationManager extends BatchTestCase {
                 + "</Schema>");
          */
         withSchema(context, SchemaModifiers.TestAggregationManagerModifier7::new);
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         RolapStar star = connection.getSchemaReader()
             .getSchema().getRolapStarRegistry().getStar("sales_fact_1997");
         AggStar aggStar1 = getAggStar(star, "agg_c_10_sales_fact_1997");
@@ -3664,7 +3664,7 @@ class TestAggregationManager extends BatchTestCase {
             + "group by\n"
             + "    \"agg_c_10_sales_fact_1997\".\"the_year\"";
         assertQuerySqlOrNot(
-            context.getConnection(),
+            context.getConnectionWithDefaultRole(),
             "select Time.[1997] on 0 from sales",
             new SqlPattern[]{
                 new SqlPattern(
@@ -3703,13 +3703,13 @@ class TestAggregationManager extends BatchTestCase {
         */
         withSchema(context, SchemaModifiers.TestAggregationManagerModifier3::new);
 
-        RolapStar star = context.getConnection().getSchemaReader()
+        RolapStar star = context.getConnectionWithDefaultRole().getSchemaReader()
             .getSchema().getRolapStarRegistry().getStar("sales_fact_1997");
         AggStar aggStarSpy = spy(
             getAggStar(star, "agg_c_special_sales_fact_1997"));
         // make sure the test AggStar will be prioritized first
         when(aggStarSpy.getSize(context.getConfig().chooseAggregateByVolume())).thenReturn(0l);
-        context.getConnection().getSchemaReader()
+        context.getConnectionWithDefaultRole().getSchemaReader()
             .getSchema().getRolapStarRegistry().getStar("sales_fact_1997").addAggStar(aggStarSpy);
 
         boolean[] rollup = { false };
@@ -3747,7 +3747,7 @@ class TestAggregationManager extends BatchTestCase {
             + "group by\n"
             + "    `customer`.`gender`";
         assertQuerySqlOrNot(
-            context.getConnection(),
+            context.getConnectionWithDefaultRole(),
             "select gender.gender.members on 0 from sales",
             new SqlPattern[]{
                 new SqlPattern(
@@ -3803,13 +3803,13 @@ class TestAggregationManager extends BatchTestCase {
                 + "</Schema>");
          */
         withSchema(context, SchemaModifiers.TestAggregationManagerModifier4::new);
-        RolapStar star = context.getConnection().getSchemaReader()
+        RolapStar star = context.getConnectionWithDefaultRole().getSchemaReader()
             .getSchema().getRolapStarRegistry().getStar("sales_fact_1997");
         AggStar aggStarSpy = spy(
             getAggStar(star, "agg_g_ms_pcat_sales_fact_1997"));
         // make sure the test AggStar will be prioritized first
         when(aggStarSpy.getSize(context.getConfig().chooseAggregateByVolume())).thenReturn(0l);
-        context.getConnection().getSchemaReader()
+        context.getConnectionWithDefaultRole().getSchemaReader()
             .getSchema().getRolapStarRegistry().getStar("sales_fact_1997").addAggStar(aggStarSpy);
         boolean[] rollup = { false };
         AggStar returnedStar = AggregationManager
@@ -3846,7 +3846,7 @@ class TestAggregationManager extends BatchTestCase {
             + "group by\n"
             + "    `time_by_day`.`the_year`";
         assertQuerySqlOrNot(
-            context.getConnection(),
+            context.getConnectionWithDefaultRole(),
             "select Time.[1997] on 0 from sales where "
             + "measures.[Customer Count]",
             new SqlPattern[]{
@@ -3874,7 +3874,7 @@ class TestAggregationManager extends BatchTestCase {
         String sql =
             "select count(*) as `c0` from `agg_c_10_sales_fact_1997` as `agg_c_10_sales_fact_1997`";
         assertQuerySqlOrNot(
-            context.getConnection(),
+            context.getConnectionWithDefaultRole(),
             "select from sales",
             new SqlPattern[]{
                 new SqlPattern(

--- a/mondrian/src/test/java/mondrian/rolap/TopCountWithTwoParamsVersusHeadTest.java
+++ b/mondrian/src/test/java/mondrian/rolap/TopCountWithTwoParamsVersusHeadTest.java
@@ -69,7 +69,7 @@ class TopCountWithTwoParamsVersusHeadTest extends BatchTestCase {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void test_States(Context context) throws Exception {
-        assertResultsAreEqual(context.getConnection(),
+        assertResultsAreEqual(context.getConnectionWithDefaultRole(),
             "States",
             TOPCOUNT_MIMICS_HEAD_WHEN_TWO_PARAMS_STATES_QUERY);
     }
@@ -77,7 +77,7 @@ class TopCountWithTwoParamsVersusHeadTest extends BatchTestCase {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void test_Cities(Context context) throws Exception {
-        assertResultsAreEqual(context.getConnection(),
+        assertResultsAreEqual(context.getConnectionWithDefaultRole(),
             "Cities",
             TOPCOUNT_MIMICS_HEAD_WHEN_TWO_PARAMS_CITIES_QUERY);
     }
@@ -85,7 +85,7 @@ class TopCountWithTwoParamsVersusHeadTest extends BatchTestCase {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void test_ShowsNotMoreThanExist(Context context) {
-        assertResultsAreEqual(context.getConnection(),
+        assertResultsAreEqual(context.getConnectionWithDefaultRole(),
             "Not more than exists",
             RESULTS_ARE_SHOWN_NOT_MORE_THAN_EXIST_2_PARAMS_QUERY);
     }
@@ -93,7 +93,7 @@ class TopCountWithTwoParamsVersusHeadTest extends BatchTestCase {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void test_DoesNotIgnoreNonEmpty(Context context) {
-        assertResultsAreEqual(context.getConnection(),
+        assertResultsAreEqual(context.getConnectionWithDefaultRole(),
             "Does not ignore NON EMPTY",
             NON_EMPTY_IS_NOT_IGNORED_WHEN_TWO_PARAMS_QUERY);
     }

--- a/mondrian/src/test/java/mondrian/rolap/VirtualCubeTest.java
+++ b/mondrian/src/test/java/mondrian/rolap/VirtualCubeTest.java
@@ -130,7 +130,7 @@ class VirtualCubeTest extends BatchTestCase {
         withSchema(context, schema);
          */
         withSchema(context, TestNoTimeDimensionModifier::new);
-        checkXxx(context.getConnection());
+        checkXxx(context.getConnectionWithDefaultRole());
     }
 
     @ParameterizedTest
@@ -189,7 +189,7 @@ class VirtualCubeTest extends BatchTestCase {
         String query1 = "select from [Sales vs Warehouse]";
         String query2 =
             "select from [Sales vs Warehouse] where measures.profit";
-        assertQueriesReturnSimilarResults(context.getConnection(), query1, query2);
+        assertQueriesReturnSimilarResults(context.getConnectionWithDefaultRole(), query1, query2);
     }
 
     @ParameterizedTest
@@ -249,7 +249,7 @@ class VirtualCubeTest extends BatchTestCase {
         String query2 =
             "select from [Sales vs Warehouse] "
             + "where measures.[Warehouse Sales]";
-        assertQueriesReturnSimilarResults(context.getConnection(), query1, query2);
+        assertQueriesReturnSimilarResults(context.getConnectionWithDefaultRole(), query1, query2);
     }
 
     @Disabled // cube name not a string. we use reference to cube. we not able to set "Bad cube". this test will delete in future
@@ -366,7 +366,7 @@ class VirtualCubeTest extends BatchTestCase {
             "select from [Sales vs Warehouse] "
             + "where measures.[Profit]";
 
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         if (SystemWideProperties.instance().CaseSensitive) {
             assertQueriesReturnSimilarResults(connection,
                 queryWithoutFilter, queryWithFirstMeasure);
@@ -429,7 +429,7 @@ class VirtualCubeTest extends BatchTestCase {
         withSchema(context, schema);
          */
         withSchema(context, TestWithTimeDimensionModifier::new);
-        checkXxx(context.getConnection());
+        checkXxx(context.getConnectionWithDefaultRole());
     }
 
 
@@ -464,7 +464,7 @@ class VirtualCubeTest extends BatchTestCase {
         // that does not have ALL as its default member.
         createContextWithNonDefaultAllMember(context);
 
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Warehouse].defaultMember} on columns, "
             + "{[Measures].[Warehouse Cost]} on rows from [Warehouse (Default USA)]",
             "Axis #0:\n"
@@ -477,7 +477,7 @@ class VirtualCubeTest extends BatchTestCase {
 
         // There is a value for [USA] -- because it is the default member and
         // the hierarchy has no all member -- but not for [USA].[CA].
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Warehouse].defaultMember, [Warehouse].[USA].[CA]} on columns, "
             + "{[Measures].[Warehouse Cost], [Measures].[Sales Count]} on rows "
             + "from [Warehouse (Default USA) and Sales]",
@@ -499,7 +499,7 @@ class VirtualCubeTest extends BatchTestCase {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testNonDefaultAllMember2(Context context) {
         createContextWithNonDefaultAllMember(context);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select { measures.[unit sales] } on 0 \n"
             + "from [warehouse (Default USA) and Sales]",
             "Axis #0:\n"
@@ -764,7 +764,7 @@ class VirtualCubeTest extends BatchTestCase {
             + " [Measures].[Profit],\n"
             + " [Measures].[Profit last Period],\n"
             + " [Measures].[Average Warehouse Sale]} on columns\n"
-            + "from [Warehouse and Sales Member Visibility]", context.getConnection());
+            + "from [Warehouse and Sales Member Visibility]", context.getConnectionWithDefaultRole());
         assertVisibility(result, 0, "Sales Count", true); // explicitly visible
         assertVisibility(
             result, 1, "Store Cost", true); // explicitly invisible
@@ -777,13 +777,13 @@ class VirtualCubeTest extends BatchTestCase {
 
         // check that visibilities in the base cubes are still the same
         result = executeQuery(
-          "select {[Measures].[Profit last Period]} on columns from [Sales]", context.getConnection());
+          "select {[Measures].[Profit last Period]} on columns from [Sales]", context.getConnectionWithDefaultRole());
         assertVisibility(result, 0, "Profit last Period", true); // explicitly visible in base cube
 
         result = executeQuery(
           "select {[Measures].[Units Shipped],\n"
             + " [Measures].[Average Warehouse Sale]} on columns\n"
-            + " from [Warehouse]", context.getConnection());
+            + " from [Warehouse]", context.getConnectionWithDefaultRole());
         assertVisibility(result, 0, "Units Shipped", true); // implicitly visible in base cube
         assertVisibility(result, 1, "Average Warehouse Sale", true); // implicitly visible in base cube
     }
@@ -925,7 +925,7 @@ class VirtualCubeTest extends BatchTestCase {
         withSchema(context, schema);
          */
         withSchema(context, TestFormatStringExpressionCubeNoCacheModifier::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Measures].[Profit Per Unit Shipped]} ON COLUMNS, "
             + "{[Store].[All Stores].[USA].[CA], [Store].[All Stores].[USA].[OR], [Store].[All Stores].[USA].[WA]} ON ROWS "
             + "from [Warehouse and Sales Format Expression Cube No Cache] "
@@ -947,7 +947,7 @@ class VirtualCubeTest extends BatchTestCase {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCalculatedMeasure(Context context) {
         // calculated measures reference measures defined in the base cube
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select\n"
             + "{[Measures].[Profit Growth], "
             + "[Measures].[Profit], "
@@ -968,7 +968,7 @@ class VirtualCubeTest extends BatchTestCase {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testLostData(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Time].[Time].Members} on columns,\n"
             + " {[Product].Children} on rows\n"
             + "from [Sales]",
@@ -1115,7 +1115,7 @@ class VirtualCubeTest extends BatchTestCase {
             + "Row #2: \n"
             + "Row #2: \n"
             + "Row #2: \n");
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select\n"
             + " {[Measures].[Unit Sales]} on 0,\n"
             + " {[Product].Children} on 1\n"
@@ -1140,7 +1140,7 @@ class VirtualCubeTest extends BatchTestCase {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCalculatedMeasureAcrossCubes(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with member [Measures].[Shipped per Ordered] as ' [Measures].[Units Shipped] / [Measures].[Unit Sales] ', format_string='#.00%'\n"
             + " member [Measures].[Profit per Unit Shipped] as ' [Measures].[Profit] / [Measures].[Units Shipped] '\n"
             + "select\n"
@@ -1236,7 +1236,7 @@ class VirtualCubeTest extends BatchTestCase {
             + "  </CalculatedMember>\n"));
          */
         withSchema(context, SchemaModifiers.VirtualCubeTestModifier1::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select\n"
             + " {[Measures].[Unit Sales], \n"
             + "  [Measures].[Shipped per Ordered]} on 0,\n"
@@ -1291,7 +1291,7 @@ class VirtualCubeTest extends BatchTestCase {
     void testAllMeasureMembers(Context context) {
         // result should exclude measures that are not explicitly defined
         // in the virtual cube (e.g., [Profit last Period])
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select\n"
             + "{[Measures].allMembers} on columns\n"
             + "from [Warehouse and Sales]",
@@ -1380,7 +1380,7 @@ class VirtualCubeTest extends BatchTestCase {
         withSchema(context, schema);
          */
         withSchema(context, TestOrdinalColumnModifier::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Measures].[Org Salary]} on columns, "
             + "non empty "
             + "crossjoin([Store].[Store Country].members, [Position].[Store Management].children) "
@@ -1469,7 +1469,7 @@ class VirtualCubeTest extends BatchTestCase {
         String queryWithDeflaultMeasureFilter =
             "select "
             + "from [Sales vs Warehouse] where measures.[Unit Sales]";
-        assertQueriesReturnSimilarResults(context.getConnection(),
+        assertQueriesReturnSimilarResults(context.getConnectionWithDefaultRole(),
             queryWithoutFilter, queryWithDeflaultMeasureFilter);
     }
 
@@ -1483,7 +1483,7 @@ class VirtualCubeTest extends BatchTestCase {
     void testNativeSetCaching(Context context) {
         // Only need to run this against one db to verify caching
         // behavior is correct.
-        final Dialect dialect = getDialect(context.getConnection());
+        final Dialect dialect = getDialect(context.getConnectionWithDefaultRole());
         if (getDatabaseProduct(dialect.getDialectName()) != DatabaseProduct.DERBY) {
             return;
         }
@@ -1586,12 +1586,12 @@ class VirtualCubeTest extends BatchTestCase {
 
         // Run query 1 with cleared cache;
         // Make sure NECJ 1 is evaluated natively.
-        assertQuerySql(context.getConnection(), query1, patterns1, true);
+        assertQuerySql(context.getConnectionWithDefaultRole(), query1, patterns1, true);
 
         // Now run query 2 with warm cache;
         // Make sure NECJ 2 does not reuse the cache result from NECJ 1, and
         // NECJ 2 is evaluated natively.
-        assertQuerySql(context.getConnection(), query2, patterns2, false);
+        assertQuerySql(context.getConnectionWithDefaultRole(), query2, patterns2, false);
     }
 
     /**
@@ -1665,7 +1665,7 @@ class VirtualCubeTest extends BatchTestCase {
 //       See the next test case for a constraint that does not contain
 //       AllLevel member and hence cannot be satisfied. The cell should be
 //       empty.
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with member [Warehouse].[x] as 'Aggregate([Warehouse].members)'\n"
             + "member [Measures].[foo] AS '([Warehouse].[x],[Measures].[Customer Count])'\n"
             + "select {[Measures].[foo]} on 0 from [Warehouse And Sales2]",
@@ -1731,7 +1731,7 @@ class VirtualCubeTest extends BatchTestCase {
         withSchema(context, schema);
          */
         withSchema(context, TestBugMondrian322aModifier::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with member [Warehouse].[x] as 'Aggregate({[Warehouse].[Canada], [Warehouse].[USA]})'\n"
             + "member [Measures].[foo] AS '([Warehouse].[x],[Measures].[Customer Count])'\n"
             + "select {[Measures].[foo]} on 0 from [Warehouse And Sales2]",
@@ -1841,7 +1841,7 @@ class VirtualCubeTest extends BatchTestCase {
         Result result = executeQuery(
             "select {[Measures].[Store Sqft]} ON COLUMNS,"
             + "{[HCB]} ON ROWS "
-            + "from [VirtualTestStore]", context.getConnection());
+            + "from [VirtualTestStore]", context.getConnectionWithDefaultRole());
 
         Axis[] axes = result.getAxes();
         List<Position> positions = axes[0].getPositions();
@@ -1877,7 +1877,7 @@ class VirtualCubeTest extends BatchTestCase {
             + "Set [*BASE_MEMBERS_Measures] as '{[Measures].[*FORMATTED_MEASURE_0]}' Member [Measures].[*FORMATTED_MEASURE_0] as '[Measures].[Warehouse Sales]', FORMAT_STRING = '#,##0', SOLVE_ORDER=400 "
             + "Select [*BASE_MEMBERS_Measures] on columns, Non Empty Generate([*NATIVE_CJ_SET], {([Warehouse].currentMember,[Time].[Time].currentMember)}) on rows From [Warehouse and Sales]";
 
-        executeQuery(query1, context.getConnection());
+        executeQuery(query1, context.getConnectionWithDefaultRole());
 
         /* The query with the filter should now succeed without NPE */
         String result =
@@ -1909,7 +1909,7 @@ class VirtualCubeTest extends BatchTestCase {
             + "Row #9: 15,356\n"
             + "Row #10: 13,948\n";
 
-        assertQueryReturns(context.getConnection(), query2, result);
+        assertQueryReturns(context.getConnectionWithDefaultRole(), query2, result);
     }
 
     /**
@@ -2119,7 +2119,7 @@ class VirtualCubeTest extends BatchTestCase {
             + "Row #11: 9,705.561\n"
             + "Row #11: 41,484.40\n";
 
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         assertQuerySql(connection, query, mysqlPattern, true);
         assertQueryReturns(connection, query, result);
     }
@@ -2255,7 +2255,7 @@ class VirtualCubeTest extends BatchTestCase {
                 DatabaseProduct.MYSQL, mysqlSQL, mysqlSQL)
         };
 
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         assertQuerySql(connection, query, mysqlPattern, true);
         assertQueryReturns(connection, query, result);
     }
@@ -2277,7 +2277,7 @@ class VirtualCubeTest extends BatchTestCase {
             + "NON EMPTY CrossJoin(\n"
             + "  [Promotions].[Promotion Name].Members,\n"
             + "  [Marital Status].[Marital Status].Members) ON ROWS\n"
-            + "FROM [Warehouse and Sales]", context.getConnection());
+            + "FROM [Warehouse and Sales]", context.getConnectionWithDefaultRole());
         assertEquals(
             "[[Education Level].[Bachelors Degree], [Product].[Drink], [Store].[USA].[CA]]",
             result.getAxes()[0].getPositions().get(0).toString());
@@ -2369,7 +2369,7 @@ class VirtualCubeTest extends BatchTestCase {
         + "Row #0: 72,024\n"
         + "Row #0: 72,024\n"
         + "Row #0: 72,024\n";
-      assertQueryReturns(context.getConnection(), query, expected);
+      assertQueryReturns(context.getConnectionWithDefaultRole(), query, expected);
     }
 
     @ParameterizedTest
@@ -2385,7 +2385,7 @@ class VirtualCubeTest extends BatchTestCase {
          */
         withSchema(context, SchemaModifiers.VirtualCubeTestModifier2::new);
 
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH member measures.ratio as 'measures.[Store Cost]/measures.[warehouse cost]' "
             + " member [marital status].agg as 'aggregate({[marital status].M})' "
             + " select non empty [Warehouse].[USA] "

--- a/mondrian/src/test/java/mondrian/rolap/agg/AggregationOnDistinctCountMeasuresTest.java
+++ b/mondrian/src/test/java/mondrian/rolap/agg/AggregationOnDistinctCountMeasuresTest.java
@@ -151,7 +151,7 @@ class AggregationOnDistinctCountMeasuresTest {
         withSchema(context, schema);
          */
         withSchema(context, SchemaModifiers.AggregationOnDistinctCountMeasuresTestModifier::new);
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
 
         schemaReader =
                 connection.getSchemaReader().withLocus();
@@ -168,7 +168,7 @@ class AggregationOnDistinctCountMeasuresTest {
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testTupleWithAllLevelMembersOnly(Context context) {
       prepareContext(context);
-      assertQueryReturns(context.getConnection(),
+      assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH MEMBER GENDER.X AS 'AGGREGATE({([GENDER].DEFAULTMEMBER,\n"
             + "[STORE].DEFAULTMEMBER)})'\n"
             + "SELECT GENDER.X ON 0, [MEASURES].[CUSTOMER COUNT] ON 1 FROM SALES",
@@ -185,7 +185,7 @@ class AggregationOnDistinctCountMeasuresTest {
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testCrossJoinOfAllMembers(Context context) {
       prepareContext(context);
-      assertQueryReturns(context.getConnection(),
+      assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH MEMBER GENDER.X AS 'AGGREGATE({CROSSJOIN({[GENDER].DEFAULTMEMBER},\n"
             + "{[STORE].DEFAULTMEMBER})})'\n"
             + "SELECT GENDER.X ON 0, [MEASURES].[CUSTOMER COUNT] ON 1 FROM SALES",
@@ -218,7 +218,7 @@ class AggregationOnDistinctCountMeasuresTest {
             + "{[Measures].[Customer Count]}\n"
             + "Row #0: 2,716\n";
 
-      assertQueryReturns(context.getConnection(), query, result);
+      assertQueryReturns(context.getConnectionWithDefaultRole(), query, result);
 
         // Check aggregate loading sql pattern
         String mysqlSql =
@@ -246,7 +246,7 @@ class AggregationOnDistinctCountMeasuresTest {
                 DatabaseProduct.TERADATA, oraTeraSql, oraTeraSql),
         };
 
-        assertQuerySql(context.getConnection(), query, patterns);
+        assertQuerySql(context.getConnectionWithDefaultRole(), query, patterns);
     }
 
   @ParameterizedTest
@@ -270,7 +270,7 @@ class AggregationOnDistinctCountMeasuresTest {
             + "{[Measures].[Customer Count]}\n"
             + "Row #0: 2,716\n";
 
-      assertQueryReturns(context.getConnection(), query, result);
+      assertQueryReturns(context.getConnectionWithDefaultRole(), query, result);
 
         // Check aggregate loading sql pattern.  Note Derby does not support
         // multicolumn IN list, so the predicates remain in AND/OR form.
@@ -311,14 +311,14 @@ class AggregationOnDistinctCountMeasuresTest {
                 DatabaseProduct.TERADATA, oraTeraSql, oraTeraSql),
         };
 
-        assertQuerySql(context.getConnection(), query, patterns);
+        assertQuerySql(context.getConnectionWithDefaultRole(), query, patterns);
     }
 
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testCrossJoinParticularMembersFromTwoDimensions(Context context) {
       prepareContext(context);
-      assertQueryReturns(context.getConnection(),
+      assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH MEMBER GENDER.X AS 'AGGREGATE({[GENDER].M} * "
             + "{[STORE].[ALL STORES].[USA].[CA]})', solve_order=100 "
             + "SELECT GENDER.X ON 0, [MEASURES].[CUSTOMER COUNT] ON 1 FROM SALES",
@@ -335,7 +335,7 @@ class AggregationOnDistinctCountMeasuresTest {
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testDistinctCountOnSetOfMembersFromOneDimension(Context context) {
       prepareContext(context);
-      assertQueryReturns(context.getConnection(),
+      assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH MEMBER GENDER.X AS 'AGGREGATE({[GENDER].[GENDER].members})'"
             + "SELECT GENDER.X ON 0, [MEASURES].[CUSTOMER COUNT] ON 1 FROM SALES",
             "Axis #0:\n"
@@ -351,7 +351,7 @@ class AggregationOnDistinctCountMeasuresTest {
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testDistinctCountWithAMeasureAsPartOfTuple(Context context) {
       prepareContext(context);
-      assertQueryReturns(context.getConnection(),
+      assertQueryReturns(context.getConnectionWithDefaultRole(),
             "SELECT [STORE].[ALL STORES].[USA].[CA] ON 0, "
             + "([MEASURES].[CUSTOMER COUNT], [Gender].[m]) ON 1 FROM SALES",
             "Axis #0:\n"
@@ -367,7 +367,7 @@ class AggregationOnDistinctCountMeasuresTest {
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testDistinctCountOnSetOfMembers(Context context) {
       prepareContext(context);
-      assertQueryReturns(context.getConnection(),
+      assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH MEMBER STORE.X as 'Aggregate({[STORE].[ALL STORES].[USA].[CA],"
             + "[STORE].[ALL STORES].[USA].[WA]})'"
             + "SELECT STORE.X  ON ROWS, "
@@ -401,16 +401,16 @@ class AggregationOnDistinctCountMeasuresTest {
             + "Axis #2:\n"
             + "{[Warehouse].[X]}\n"
             + "Row #0: \n";
-      assertQueryReturns(context.getConnection(), mdx, expectedResult);
+      assertQueryReturns(context.getConnectionWithDefaultRole(), mdx, expectedResult);
       ((TestConfig)context.getConfig()).setIgnoreMeasureForNonJoiningDimension(true);
-      assertQueryReturns(context.getConnection() ,mdx, expectedResult);
+      assertQueryReturns(context.getConnectionWithDefaultRole() ,mdx, expectedResult);
     }
 
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testAggregationListOptimizationForChildren(Context context) {
       prepareContext(context);
-      assertQueryReturns(context.getConnection(),
+      assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH MEMBER GENDER.X AS 'AGGREGATE({[GENDER].[GENDER].members} * "
             + "{[STORE].[ALL STORES].[USA].[CA], [STORE].[ALL STORES].[USA].[OR], "
             + "[STORE].[ALL STORES].[USA].[WA], [Store].[All Stores].[Canada]})' "
@@ -429,7 +429,7 @@ class AggregationOnDistinctCountMeasuresTest {
   void testDistinctCountOnMembersWithNonJoiningDimensionNotAtAllLevel(Context context)
     {
       prepareContext(context);
-      assertQueryReturns(context.getConnection(),
+      assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH MEMBER WAREHOUSE.X as "
             + "'Aggregate({WAREHOUSE.[STATE PROVINCE].MEMBERS})'"
             + "SELECT WAREHOUSE.X  ON ROWS, "
@@ -448,7 +448,7 @@ class AggregationOnDistinctCountMeasuresTest {
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testNonJoiningDimensionWithAllMember(Context context) {
       prepareContext(context);
-      assertQueryReturns(context.getConnection(),
+      assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH MEMBER WAREHOUSE.X as 'Aggregate({WAREHOUSE.MEMBERS})'"
             + "SELECT WAREHOUSE.X  ON ROWS, "
             + "{[MEASURES].[CUSTOMER COUNT]} ON COLUMNS\n"
@@ -466,7 +466,7 @@ class AggregationOnDistinctCountMeasuresTest {
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testCrossJoinOfJoiningAndNonJoiningDimensionWithAllMember(Context context) {
       prepareContext(context);
-      assertQueryReturns(context.getConnection(),
+      assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH MEMBER WAREHOUSE.X AS "
             + "'AGGREGATE({GENDER.GENDER.MEMBERS} * {WAREHOUSE.MEMBERS})'"
             + "SELECT WAREHOUSE.X  ON ROWS, "
@@ -480,7 +480,7 @@ class AggregationOnDistinctCountMeasuresTest {
             + "{[Warehouse].[X]}\n"
             + "Row #0: 5,581\n");
 
-      assertQueryReturns(context.getConnection(),
+      assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH MEMBER WAREHOUSE.X AS "
             + "'AGGREGATE({GENDER.GENDER.MEMBERS} * {WAREHOUSE.MEMBERS})'"
             + "SELECT WAREHOUSE.X  ON ROWS, "
@@ -499,7 +499,7 @@ class AggregationOnDistinctCountMeasuresTest {
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testCrossJoinOfJoiningAndNonJoiningDimension(Context context) {
       prepareContext(context);
-      assertQueryReturns(context.getConnection(),
+      assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH MEMBER WAREHOUSE.X AS "
             + "'AGGREGATE({GENDER.GENDER.MEMBERS} * {WAREHOUSE.[STATE PROVINCE].MEMBERS})'"
             + "SELECT WAREHOUSE.X  ON ROWS, "
@@ -513,7 +513,7 @@ class AggregationOnDistinctCountMeasuresTest {
             + "{[Warehouse].[X]}\n"
             + "Row #0: \n");
 
-      assertQueryReturns(context.getConnection(),
+      assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH MEMBER WAREHOUSE.X AS "
             + "'AGGREGATE({GENDER.GENDER.MEMBERS} * {WAREHOUSE.[STATE PROVINCE].MEMBERS})'"
             + "SELECT WAREHOUSE.X  ON ROWS, "
@@ -537,10 +537,10 @@ class AggregationOnDistinctCountMeasuresTest {
 
         // LucidDB has no limit on the size of IN list
         final boolean isLuciddb =
-            getDatabaseProduct(getDialect(context.getConnection()).getDialectName())
+            getDatabaseProduct(getDialect(context.getConnectionWithDefaultRole()).getDialectName())
             == DatabaseProduct.LUCIDDB;
 
-      assertQueryReturns(context.getConnection(),
+      assertQueryReturns(context.getConnectionWithDefaultRole(),
             makeQuery("[MEASURES].[CUSTOMER COUNT]"),
             isLuciddb
             ? "Axis #0:\n"
@@ -560,7 +560,7 @@ class AggregationOnDistinctCountMeasuresTest {
               + "Aggregation is not supported over a list with more than 7 predicates (see property MaxConstraints)\n");
 
         // aggregation over a non-distinct-count measure is OK
-      assertQueryReturns(context.getConnection(),
+      assertQueryReturns(context.getConnectionWithDefaultRole(),
             makeQuery("[Measures].[Store Sales]"),
             "Axis #0:\n"
             + "{}\n"
@@ -573,7 +573,7 @@ class AggregationOnDistinctCountMeasuresTest {
         // aggregation over a non-distinct-count measure in slicer should be
         // OK. Before bug MONDRIAN-1122 was fixed, a large set in the slicer
         // would cause an error even if there was not a distinct-count measure.
-      assertQueryReturns(context.getConnection(),
+      assertQueryReturns(context.getConnectionWithDefaultRole(),
             "SELECT {[Measures].[Store Sales]} ON COLUMNS\n"
             + "FROM [WAREHOUSE AND SALES2]\n"
             + "WHERE {\n"
@@ -631,7 +631,7 @@ class AggregationOnDistinctCountMeasuresTest {
         }
 
         SystemWideProperties.instance().MaxConstraints = 5;
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "SELECT\n"
             + "  Measures.[Unit Sales] on columns,\n"
             + "  Product.[Product Family].Members on rows\n"
@@ -806,7 +806,7 @@ class AggregationOnDistinctCountMeasuresTest {
                 DatabaseProduct.MYSQL, necjSqlMySql, necjSqlMySql)
         };
 
-        assertQuerySql(context.getConnection(), query, patterns);
+        assertQuerySql(context.getConnectionWithDefaultRole(), query, patterns);
     }
 
   @ParameterizedTest
@@ -932,7 +932,7 @@ class AggregationOnDistinctCountMeasuresTest {
             + "{[Warehouse2].[TwoMembers]}\n"
             + "Row #0: 220\n";
 
-        assertQueryReturns(context.getConnection(), query, result);
+        assertQueryReturns(context.getConnectionWithDefaultRole(), query, result);
     }
 
   @ParameterizedTest
@@ -1057,7 +1057,7 @@ class AggregationOnDistinctCountMeasuresTest {
             + "{[Warehouse2].[TwoMembers]}\n"
             + "Row #0: 220\n";
       withSchema(context, TestMultiLevelsMixedNullNonNullChildModifier::new);
-      assertQueryReturns(context.getConnection(), query, result);
+      assertQueryReturns(context.getConnectionWithDefaultRole(), query, result);
     }
 
   @ParameterizedTest
@@ -1088,7 +1088,7 @@ class AggregationOnDistinctCountMeasuresTest {
             new SqlPattern(
                 DatabaseProduct.TERADATA, oraTeraSql, oraTeraSql),
         };
-        assertQuerySql(context.getConnection(),
+        assertQuerySql(context.getConnectionWithDefaultRole(),
             "WITH \n"
             + "SET [COG_OQP_INT_s2] AS 'CROSSJOIN({[Store].[Store].MEMBERS}, "
             + "{{[Gender].[Gender].MEMBERS}, "
@@ -1181,8 +1181,8 @@ class AggregationOnDistinctCountMeasuresTest {
                 oraTeraSqlForDetail),
         };
 
-      assertQueryReturns(context.getConnection(), mdxQueryWithFewMembers, desiredResult);
-        assertQuerySql(context.getConnection(), mdxQueryWithFewMembers, patterns);
+      assertQueryReturns(context.getConnectionWithDefaultRole(), mdxQueryWithFewMembers, desiredResult);
+        assertQuerySql(context.getConnectionWithDefaultRole(), mdxQueryWithFewMembers, patterns);
     }
 
 
@@ -1265,8 +1265,8 @@ class AggregationOnDistinctCountMeasuresTest {
                 oraTeraSqlForDistinctCountAgg),
         };
 
-      assertQueryReturns(context.getConnection(), mdxQueryWithFewMembers, desiredResult);
-        assertQuerySql(context.getConnection(), mdxQueryWithFewMembers, patterns);
+      assertQueryReturns(context.getConnectionWithDefaultRole(), mdxQueryWithFewMembers, desiredResult);
+        assertQuerySql(context.getConnectionWithDefaultRole(), mdxQueryWithFewMembers, patterns);
     }
 
   @ParameterizedTest
@@ -1326,10 +1326,10 @@ class AggregationOnDistinctCountMeasuresTest {
                 DatabaseProduct.TERADATA, oraTeraSql, oraTeraSql),
         };
 
-      assertQueryReturns(context.getConnection(), mdxQueryWithMembers, desiredResult);
-        assertQuerySql(context.getConnection(), mdxQueryWithMembers, patterns);
-      assertQueryReturns(context.getConnection(), mdxQueryWithDefaultMember, desiredResult);
-        assertQuerySql(context.getConnection(), mdxQueryWithDefaultMember, patterns);
+      assertQueryReturns(context.getConnectionWithDefaultRole(), mdxQueryWithMembers, desiredResult);
+        assertQuerySql(context.getConnectionWithDefaultRole(), mdxQueryWithMembers, patterns);
+      assertQueryReturns(context.getConnectionWithDefaultRole(), mdxQueryWithDefaultMember, desiredResult);
+        assertQuerySql(context.getConnectionWithDefaultRole(), mdxQueryWithDefaultMember, patterns);
     }
 
   @ParameterizedTest
@@ -1349,7 +1349,7 @@ class AggregationOnDistinctCountMeasuresTest {
             + "Axis #2:\n"
             + "{[Measures].[Customer Count]}\n"
             + "Row #0: 5,581\n";
-      assertQueryReturns(context.getConnection(), query, expected);
+      assertQueryReturns(context.getConnectionWithDefaultRole(), query, expected);
 
         String derbySql =
             "select \"time_by_day\".\"the_year\" as \"c0\", "
@@ -1385,7 +1385,7 @@ class AggregationOnDistinctCountMeasuresTest {
                 DatabaseProduct.LUCIDDB, luciddbSql, luciddbSql),
         };
 
-        assertQuerySql(context.getConnection(), query, patterns);
+        assertQuerySql(context.getConnectionWithDefaultRole(), query, patterns);
     }
 
   @ParameterizedTest
@@ -1416,7 +1416,7 @@ class AggregationOnDistinctCountMeasuresTest {
             + "Axis #2:\n"
             + "{[Measures].[Customer Count]}\n"
             + "Row #0: 421\n";
-      assertQueryReturns(context.getConnection(), query, expected);
+      assertQueryReturns(context.getConnectionWithDefaultRole(), query, expected);
         String derbySql =
             "select \"time_by_day\".\"the_year\" as \"c0\", "
             + "count(distinct \"sales_fact_1997\".\"customer_id\") as \"m0\" "
@@ -1475,7 +1475,7 @@ class AggregationOnDistinctCountMeasuresTest {
             new SqlPattern(
                 DatabaseProduct.ACCESS, accessSql, accessSql)};
 
-        assertQuerySql(context.getConnection(), query, patterns);
+        assertQuerySql(context.getConnectionWithDefaultRole(), query, patterns);
     }
 
   @ParameterizedTest
@@ -1514,7 +1514,7 @@ class AggregationOnDistinctCountMeasuresTest {
             + "Axis #2:\n"
             + "{[Measures].[Customer Count]}\n"
             + "Row #0: 189\n";
-      assertQueryReturns(context.getConnection(), query, expected);
+      assertQueryReturns(context.getConnectionWithDefaultRole(), query, expected);
     }
 
   @ParameterizedTest
@@ -1733,7 +1733,7 @@ class AggregationOnDistinctCountMeasuresTest {
       prepareContext(context);
       ((TestConfig) context.getConfig()).setEnableGroupingSets(true);
 
-      assertQueryReturns(context.getConnection(),
+      assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH "
             + "MEMBER GENDER.AGG AS 'AGGREGATE({ GENDER.[F] })' "
             + "MEMBER GENDER.AGG2 AS 'AGGREGATE({ GENDER.[M] })' "
@@ -1760,7 +1760,7 @@ class AggregationOnDistinctCountMeasuresTest {
   void testDistinctCountForAggregatesAtTheSameLevel(Context context) {
       prepareContext(context);
       ((TestConfig) context.getConfig()).setEnableGroupingSets(true);
-      assertQueryReturns(context.getConnection(),
+      assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH "
             + "MEMBER GENDER.AGG AS 'AGGREGATE({ GENDER.[F], GENDER.[M] })' "
             + "SELECT "
@@ -1915,7 +1915,7 @@ class AggregationOnDistinctCountMeasuresTest {
       withSchema(context, schema);
        */
       withSchema(context, TestMondrian906Modifier::new);
-      Connection connection = context.getConnection();
+      Connection connection = context.getConnectionWithDefaultRole();
 
       schemaReader =
               connection.getSchemaReader().withLocus();
@@ -2264,7 +2264,7 @@ class AggregationOnDistinctCountMeasuresTest {
         /*
         withSchema(context, simpleSchema);
         */
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             query,
             "Axis #0:\n"
             + "{}\n"
@@ -2292,7 +2292,7 @@ class AggregationOnDistinctCountMeasuresTest {
             + "and\n"
             + "    `agg_c_10_sales_fact_1997`.`month_of_year` in (1, 2, 3)";
         assertQuerySqlOrNot(
-            context.getConnection(),
+            context.getConnectionWithDefaultRole(),
             monthsQuery,
             new SqlPattern[]{
                 new SqlPattern(
@@ -2316,7 +2316,7 @@ class AggregationOnDistinctCountMeasuresTest {
   void testCachedAggregate(Context context) {
         prepareContext(context);
     Result result =
-        executeQuery(context.getConnection(), " WITH\r\n"
+        executeQuery(context.getConnectionWithDefaultRole(), " WITH\r\n"
             + " SET [*NATIVE_CJ_SET_WITH_SLICER] AS 'NONEMPTYCROSSJOIN([*BASE_MEMBERS__Gender_],NONEMPTYCROSSJOIN([*BASE_MEMBERS__Store Type_],[*BASE_MEMBERS__Product_]))'\r\n"
             + " SET [*NATIVE_CJ_SET] AS 'GENERATE([*NATIVE_CJ_SET_WITH_SLICER], {([Gender].CURRENTMEMBER,[Store Type].CURRENTMEMBER)})'\r\n"
             + " SET [*BASE_MEMBERS__Store Type_] AS '{[Store Type].[All Store Types].[Gourmet Supermarket],[Store Type].[All Store Types].[Supermarket]}'\r\n"
@@ -2351,7 +2351,7 @@ class AggregationOnDistinctCountMeasuresTest {
   void testCachedCompoundSlicer(Context context) {
         prepareContext(context);
     Result result =
-        executeQuery(context.getConnection(), " WITH\r\n"
+        executeQuery(context.getConnectionWithDefaultRole(), " WITH\r\n"
             + " SET [*NATIVE_CJ_SET_WITH_SLICER] AS 'NONEMPTYCROSSJOIN([*BASE_MEMBERS__Gender_],NONEMPTYCROSSJOIN([*BASE_MEMBERS__Store Type_],[*BASE_MEMBERS__Product_]))'\r\n"
             + " SET [*NATIVE_CJ_SET] AS 'GENERATE([*NATIVE_CJ_SET_WITH_SLICER], {([Gender].CURRENTMEMBER,[Store Type].CURRENTMEMBER)})'\r\n"
             + " SET [*BASE_MEMBERS__Store Type_] AS '{[Store Type].[All Store Types].[Gourmet Supermarket],[Store Type].[All Store Types].[Supermarket]}'\r\n"
@@ -2389,7 +2389,7 @@ class AggregationOnDistinctCountMeasuresTest {
   void testExpCacheHit(Context context) {
         prepareContext(context);
     Result result =
-        executeQuery(context.getConnection(), "WITH\r\n"
+        executeQuery(context.getConnectionWithDefaultRole(), "WITH\r\n"
             + " SET [*NATIVE_CJ_SET_WITH_SLICER] AS 'NONEMPTYCROSSJOIN([*BASE_MEMBERS__Gender_],NONEMPTYCROSSJOIN([*BASE_MEMBERS__Store Type_],[*BASE_MEMBERS__Product_]))'\r\n"
             + " SET [*NATIVE_CJ_SET] AS 'GENERATE([*NATIVE_CJ_SET_WITH_SLICER], {([Gender].CURRENTMEMBER,[Store Type].CURRENTMEMBER)})'\r\n"
             + " SET [*METRIC_CJ_SET] AS 'FILTER([*NATIVE_CJ_SET],[Gender].CURRENTMEMBER IN [*METRIC_CACHE_SET])'\r\n"
@@ -2425,7 +2425,7 @@ class AggregationOnDistinctCountMeasuresTest {
   void testExpCacheHit2(Context context) {
     prepareContext(context);
     Result result =
-        executeQuery(context.getConnection(), "WITH\r\n" +
+        executeQuery(context.getConnectionWithDefaultRole(), "WITH\r\n" +
             " SET [*NATIVE_CJ_SET_WITH_SLICER] AS 'NONEMPTYCROSSJOIN([*BASE_MEMBERS__Customers_],NONEMPTYCROSSJOIN([*BASE_MEMBERS__Education Level_],NONEMPTYCROSSJOIN([*BASE_MEMBERS__Time_],NONEMPTYCROSSJOIN([*BASE_MEMBERS__Product_],[*BASE_MEMBERS__Promotion Media_]))))'\r\n" +
             " SET [*NATIVE_CJ_SET] AS 'GENERATE([*NATIVE_CJ_SET_WITH_SLICER], {([Customers].CURRENTMEMBER,[Education Level].CURRENTMEMBER,[Time].CURRENTMEMBER)})'\r\n" +
             " SET [*METRIC_CJ_SET] AS 'FILTER([*NATIVE_CJ_SET],[Customers].CURRENTMEMBER IN [*METRIC_CACHE_SET])'\r\n" +

--- a/mondrian/src/test/java/mondrian/rolap/agg/DrillThroughQuerySpecTest.java
+++ b/mondrian/src/test/java/mondrian/rolap/agg/DrillThroughQuerySpecTest.java
@@ -150,7 +150,7 @@ class DrillThroughQuerySpecTest {
         + "FROM [Warehouse] " + "WHERE ([*CJ_SLICER_AXIS]) "
         + "RETURN [Product].[Product Department]";
 
-    Connection connection = foodMartContext.getConnection();
+    Connection connection = foodMartContext.getConnectionWithDefaultRole();
     ResultSet resultSet = connection.createStatement().executeQuery(drillThroughMdx, Optional.empty(), Optional.empty(), null);
 
     assertEquals(1, resultSet.getMetaData().getColumnCount());

--- a/mondrian/src/test/java/mondrian/rolap/agg/SegmentBuilderTest.java
+++ b/mondrian/src/test/java/mondrian/rolap/agg/SegmentBuilderTest.java
@@ -255,7 +255,7 @@ class SegmentBuilderTest {
         // offsets to be incorrect for a Segment rollup.
         // First query loads the cache with a segment that can fulfill the
         // second query.
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         executeQuery(connection,
             "select [Store Size in SQFT].[Store Sqft].members * "
             + "gender.gender.members  on 0 from sales");
@@ -297,7 +297,7 @@ class SegmentBuilderTest {
         // columns.  This tests a case where
         // SegmentBuilder.computeAxisMultipliers needs to factor in
         // the null axis flag.
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         executeQuery(connection,
             "select [Store Size in SQFT].[Store Sqft].members * "
             + "[store].[store state].members * time.[quarter].members on 0"
@@ -373,7 +373,7 @@ class SegmentBuilderTest {
 
         if (PerformanceTest.LOGGER.isDebugEnabled()) {
             // load the cache with a segment for the subsequent rollup
-            Connection connection = context.getConnection();
+            Connection connection = context.getConnectionWithDefaultRole();
             executeQuery(connection,
                 "select NON EMPTY Crossjoin([Store Type].[Store Type].members, "
                 + "CrossJoin([Promotion Media].[Media Type].members, "
@@ -532,7 +532,7 @@ class SegmentBuilderTest {
         // to cause issues with rollup since one segment body will have
         // 3 values for quarter, the other segment body will have a different
         // set of values.
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         flushSchemaCache(connection);
         //TestContext context = getTestContext().withFreshConnection();
 
@@ -584,7 +584,7 @@ class SegmentBuilderTest {
         // result in roughly half of the customers having empty results
         // for the 3rd query, since the values of only one of the two
         // segments would be loaded into the AxisInfo.
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         flushSchemaCache(connection);
         //TestContext context = getTestContext().withFreshConnection();
         final String query = "select customers.[name].members on 0 from sales";
@@ -630,7 +630,7 @@ class SegmentBuilderTest {
             "[Mexico].Guerrero", "[Mexico].Jalisco", "[USA].[OR]",
             "[Mexico].Veracruz", "[USA].WA", "[Mexico].Yucatan",
             "[Mexico].Zacatecas"};
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         flushSchemaCache(connection);
         //TestContext context = getTestContext().withFreshConnection();
         final String query =
@@ -671,7 +671,7 @@ class SegmentBuilderTest {
         // capable of being rolled up to fulfill the 3rd query.
         // MONDRIAN-1729 involved the rollup being invalid, causing
         // an infinite loop.
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         flushSchemaCache(connection);
         //TestContext context = getTestContext().withFreshConnection();
 
@@ -704,9 +704,9 @@ class SegmentBuilderTest {
         // This tests a wildcarded segment (on year) rolled up w/ a seg
         // containing a single val.
         // The resulting segment contains only empty results (for 1998)
-    	context.getConnection().getCacheControl(null).flushSchemaCache();
-    	clearAggregationCache(context.getConnection());
-        runRollupTest(context.getConnection(),
+    	context.getConnectionWithDefaultRole().getCacheControl(null).flushSchemaCache();
+    	clearAggregationCache(context.getConnectionWithDefaultRole());
+        runRollupTest(context.getConnectionWithDefaultRole(),
             // queries to populate the cache with segments which will be rolled
             // up
             new String[]{
@@ -744,9 +744,9 @@ class SegmentBuilderTest {
         // http://jira.pentaho.com/browse/MONDRIAN-1729
         // Tests a wildcarded segment rolled up w/ a seg containing a single
         // val.  Both segments are associated w/ non empty results.
-    	context.getConnection().getCacheControl(null).flushSchemaCache();
-    	clearAggregationCache(context.getConnection());
-        runRollupTest(context.getConnection(),
+    	context.getConnectionWithDefaultRole().getCacheControl(null).flushSchemaCache();
+    	clearAggregationCache(context.getConnectionWithDefaultRole());
+        runRollupTest(context.getConnectionWithDefaultRole(),
             new String[]{
                 "select {{[Product].[Drink].[Alcoholic Beverages]},\n"
                 + "{[Product].[Drink].[Beverages]},\n"
@@ -779,7 +779,7 @@ class SegmentBuilderTest {
     void testSameRollupRegardlessOfSegmentOrderNoWildcards(Context context) {
         // http://jira.pentaho.com/browse/MONDRIAN-1729
         // Tests 2 segments, each w/ no wildcarded values.
-        runRollupTest(context.getConnection(),
+        runRollupTest(context.getConnectionWithDefaultRole(),
             new String[]{
                 "select {{[Product].[Drink].[Alcoholic Beverages]},\n"
                 + "{[Product].[Drink].[Beverages]},\n"
@@ -806,9 +806,9 @@ class SegmentBuilderTest {
     void testSameRollupRegardlessOfSegmentOrderThreeSegs(Context context) {
         // http://jira.pentaho.com/browse/MONDRIAN-1729
         // Tests 3 segments, each w/ no wildcarded values.
-    	context.getConnection().getCacheControl(null).flushSchemaCache();
-    	clearAggregationCache(context.getConnection());
-        runRollupTest(context.getConnection(),
+    	context.getConnectionWithDefaultRole().getCacheControl(null).flushSchemaCache();
+    	clearAggregationCache(context.getConnectionWithDefaultRole());
+        runRollupTest(context.getConnectionWithDefaultRole(),
             new String[]{
                 "select {{[Product].[Drink].[Alcoholic Beverages]},\n"
                 + "{[Product].[Non-Consumable].[Periodicals]}}\n on 0 from sales",
@@ -834,13 +834,13 @@ class SegmentBuilderTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testSegmentCreationForBoolean_True(Context context) {
-        doTestSegmentCreationForBoolean(context.getConnection(), true);
+        doTestSegmentCreationForBoolean(context.getConnectionWithDefaultRole(), true);
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testSegmentCreationForBoolean_False(Context context) {
-        doTestSegmentCreationForBoolean(context.getConnection(),false);
+        doTestSegmentCreationForBoolean(context.getConnectionWithDefaultRole(),false);
     }
 
     private void doTestSegmentCreationForBoolean(Connection connection, boolean value) {

--- a/mondrian/src/test/java/mondrian/rolap/agg/SegmentCacheTest.java
+++ b/mondrian/src/test/java/mondrian/rolap/agg/SegmentCacheTest.java
@@ -64,7 +64,7 @@ class SegmentCacheTest {
             + "Axis #2:\n"
             + "{[Measures].[Customer Count]}\n"
             + "Row #0: 2,716\n";
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         connection.getCacheControl(null).flushSchemaCache();
         assertQueryReturns(connection, query, result);
         assertQueryReturns(connection, query2, result2);
@@ -79,7 +79,7 @@ class SegmentCacheTest {
 
         // Flush the cache before we start. Wait a second for the cache
         // flush to propagate.
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         connection.getCacheControl(null).flushSchemaCache();
         final CacheControl cc =
                 connection.getCacheControl(null);

--- a/mondrian/src/test/java/mondrian/rolap/agg/SegmentLoaderTest.java
+++ b/mondrian/src/test/java/mondrian/rolap/agg/SegmentLoaderTest.java
@@ -76,7 +76,7 @@ class SegmentLoaderTest extends BatchTestCase {
     private Statement statement;
 
     private void prepareContext(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         cacheMgr =
             ((AbstractBasicContext) connection
                 .getContext()).getAggregationManager().cacheMgr;
@@ -123,7 +123,7 @@ class SegmentLoaderTest extends BatchTestCase {
         prepareContext(context);
         for (boolean rollup : new Boolean[] {true, false}) {
             PrintWriter pw = new PrintWriter(System.out);
-            context.getConnection().getCacheControl(pw).flushSchemaCache();
+            context.getConnectionWithDefaultRole().getCacheControl(pw).flushSchemaCache();
             pw.flush();
             ((TestConfig)context.getConfig()).setDisableCaching(false);
             ((TestConfig)context.getConfig()).setEnableInMemoryRollup(rollup);
@@ -131,10 +131,10 @@ class SegmentLoaderTest extends BatchTestCase {
                 "select \"time_by_day\".\"the_year\" as \"c0\", sum(\"sales_fact_1997\".\"unit_sales\") as \"m0\" from \"sales_fact_1997\" \"sales_fact_1997\", \"time_by_day\" \"time_by_day\" where \"sales_fact_1997\".\"time_id\" = \"time_by_day\".\"time_id\" group by \"time_by_day\".\"the_year\"";
             final String queryMySQL =
                 "select `time_by_day`.`the_year` as `c0`, sum(`sales_fact_1997`.`unit_sales`) as `m0` from `sales_fact_1997` as `sales_fact_1997`, `time_by_day` as `time_by_day` where `sales_fact_1997`.`time_id` = `time_by_day`.`time_id` group by `time_by_day`.`the_year`";
-            TestUtil.executeQuery(context.getConnection(),
+            TestUtil.executeQuery(context.getConnectionWithDefaultRole(),
                 "select {[Store].[Store Country].Members} on rows, {[Time].[Time].[Year].Members} on columns from [Sales]");
             assertQuerySqlOrNot(
-                context.getConnection(),
+                context.getConnectionWithDefaultRole(),
                 "select {[Time].[Time].[Year].Members} on columns from [Sales]",
                 new SqlPattern[] {
                     new SqlPattern(
@@ -158,9 +158,9 @@ class SegmentLoaderTest extends BatchTestCase {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testLoadWithMockResultsForLoadingSummaryAndDetailedSegments(Context context) throws ExecutionException, InterruptedException {
         prepareContext(context);
-        GroupingSet groupableSetsInfo = getGroupingSetRollupOnGender(context.getConnection());
+        GroupingSet groupableSetsInfo = getGroupingSetRollupOnGender(context.getConnectionWithDefaultRole());
 
-        GroupingSet groupingSetsInfo = getDefaultGroupingSet(context.getConnection());
+        GroupingSet groupingSetsInfo = getDefaultGroupingSet(context.getConnectionWithDefaultRole());
         ArrayList<GroupingSet> groupingSets =
             new ArrayList<>();
         groupingSets.add(groupingSetsInfo);
@@ -241,9 +241,9 @@ class SegmentLoaderTest extends BatchTestCase {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testLoadWithWithNullInRollupColumn(Context context) throws ExecutionException, InterruptedException {
         prepareContext(context);
-        GroupingSet groupableSetsInfo = getGroupingSetRollupOnGender(context.getConnection());
+        GroupingSet groupableSetsInfo = getGroupingSetRollupOnGender(context.getConnectionWithDefaultRole());
 
-        GroupingSet groupingSetsInfo = getDefaultGroupingSet(context.getConnection());
+        GroupingSet groupingSetsInfo = getDefaultGroupingSet(context.getConnectionWithDefaultRole());
         ArrayList<GroupingSet> groupingSets =
             new ArrayList<>();
         groupingSets.add(groupingSetsInfo);
@@ -277,9 +277,9 @@ class SegmentLoaderTest extends BatchTestCase {
     public void
         testLoadWithMockResultsForLoadingSummaryAndDetailedSegmentsUsingSparse(Context context) throws ExecutionException, InterruptedException {
         prepareContext(context);
-        GroupingSet groupableSetsInfo = getGroupingSetRollupOnGender(context.getConnection());
+        GroupingSet groupableSetsInfo = getGroupingSetRollupOnGender(context.getConnectionWithDefaultRole());
 
-        GroupingSet groupingSetsInfo = getDefaultGroupingSet(context.getConnection());
+        GroupingSet groupingSetsInfo = getDefaultGroupingSet(context.getConnectionWithDefaultRole());
         ArrayList<GroupingSet> groupingSets =
             new ArrayList<>();
         groupingSets.add(groupingSetsInfo);
@@ -364,7 +364,7 @@ class SegmentLoaderTest extends BatchTestCase {
     void testLoadWithMockResultsForLoadingOnlyDetailedSegments(Context context) throws ExecutionException,
             InterruptedException {
         prepareContext(context);
-        GroupingSet groupingSetsInfo = getDefaultGroupingSet(context.getConnection());
+        GroupingSet groupingSetsInfo = getDefaultGroupingSet(context.getConnectionWithDefaultRole());
         ArrayList<GroupingSet> groupingSets =
             new ArrayList<>();
         groupingSets.add(groupingSetsInfo);
@@ -403,9 +403,9 @@ class SegmentLoaderTest extends BatchTestCase {
     public void
         testProcessDataForGettingGroupingSetsBitKeysAndLoadingAxisValueSet(Context context) throws SQLException {
         prepareContext(context);
-        GroupingSet groupableSetsInfo = getGroupingSetRollupOnGender(context.getConnection());
+        GroupingSet groupableSetsInfo = getGroupingSetRollupOnGender(context.getConnectionWithDefaultRole());
 
-        GroupingSet groupingSetsInfo = getDefaultGroupingSet(context.getConnection());
+        GroupingSet groupingSetsInfo = getDefaultGroupingSet(context.getConnectionWithDefaultRole());
 
         List<GroupingSet> groupingSets = new ArrayList<>();
         groupingSets.add(groupingSetsInfo);
@@ -486,7 +486,7 @@ class SegmentLoaderTest extends BatchTestCase {
         throws SQLException
     {
         prepareContext(context);
-        GroupingSet groupingSetsInfo = getDefaultGroupingSet(context.getConnection());
+        GroupingSet groupingSetsInfo = getDefaultGroupingSet(context.getConnectionWithDefaultRole());
 
         final SqlStatement stmt =
             new MockSqlStatement(
@@ -531,7 +531,7 @@ class SegmentLoaderTest extends BatchTestCase {
             throws SQLException
     {
         prepareContext(context);
-        GroupingSet groupingSetsInfo = getDefaultGroupingSet(context.getConnection());
+        GroupingSet groupingSetsInfo = getDefaultGroupingSet(context.getConnectionWithDefaultRole());
 
         String binaryData0 = "11011";
         String binaryData1 = "01011";
@@ -583,7 +583,7 @@ class SegmentLoaderTest extends BatchTestCase {
         throws SQLException
     {
         prepareContext(context);
-        GroupingSet groupingSetsInfo = getDefaultGroupingSet(context.getConnection());
+        GroupingSet groupingSetsInfo = getDefaultGroupingSet(context.getConnectionWithDefaultRole());
         final List<Object[]> data = new ArrayList<>();
         data.add(new Object[]{"1997", "Food", "Deli", "F", "5990"});
         data.add(new Object[]{"1997", "Food", "Deli", "M", "6047"});
@@ -750,8 +750,8 @@ class SegmentLoaderTest extends BatchTestCase {
     void testGroupingSetsUtilForMissingGroupingBitKeys(Context context) {
         prepareContext(context);
         List<GroupingSet> groupingSets = new ArrayList<>();
-        groupingSets.add(getDefaultGroupingSet(context.getConnection()));
-        groupingSets.add(getGroupingSetRollupOnGender(context.getConnection()));
+        groupingSets.add(getDefaultGroupingSet(context.getConnectionWithDefaultRole()));
+        groupingSets.add(getGroupingSetRollupOnGender(context.getConnectionWithDefaultRole()));
         GroupingSetsList detail = new GroupingSetsList(groupingSets);
 
         List<BitKey> bitKeysList = detail.getRollupColumnsBitKeyList();
@@ -764,8 +764,8 @@ class SegmentLoaderTest extends BatchTestCase {
         assertEquals(key, bitKeysList.get(1));
 
         groupingSets = new ArrayList<>();
-        groupingSets.add(getDefaultGroupingSet(context.getConnection()));
-        groupingSets.add(getGroupingSetRollupOnGenderAndProductFamily(context.getConnection()));
+        groupingSets.add(getDefaultGroupingSet(context.getConnectionWithDefaultRole()));
+        groupingSets.add(getGroupingSetRollupOnGenderAndProductFamily(context.getConnectionWithDefaultRole()));
         bitKeysList = new GroupingSetsList(groupingSets)
             .getRollupColumnsBitKeyList();
         assertEquals(
@@ -794,7 +794,7 @@ class SegmentLoaderTest extends BatchTestCase {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testGroupingSetsUtilSetsDetailForRollupColumns(Context context) {
         prepareContext(context);
-        RolapStar.Measure measure = getMeasure(context.getConnection(), cubeNameSales, measureUnitSales);
+        RolapStar.Measure measure = getMeasure(context.getConnectionWithDefaultRole(), cubeNameSales, measureUnitSales);
         RolapStar star = measure.getStar();
         RolapStar.Column year = star.lookupColumn(tableTime, fieldYear);
         RolapStar.Column productFamily =
@@ -804,9 +804,9 @@ class SegmentLoaderTest extends BatchTestCase {
         RolapStar.Column gender = star.lookupColumn(tableCustomer, fieldGender);
 
         List<GroupingSet> groupingSets = new ArrayList<>();
-        groupingSets.add(getDefaultGroupingSet(context.getConnection()));
-        groupingSets.add(getGroupingSetRollupOnProductDepartment(context.getConnection()));
-        groupingSets.add(getGroupingSetRollupOnGenderAndProductDepartment(context.getConnection()));
+        groupingSets.add(getDefaultGroupingSet(context.getConnectionWithDefaultRole()));
+        groupingSets.add(getGroupingSetRollupOnProductDepartment(context.getConnectionWithDefaultRole()));
+        groupingSets.add(getGroupingSetRollupOnGenderAndProductDepartment(context.getConnectionWithDefaultRole()));
         GroupingSetsList detail = new GroupingSetsList(groupingSets);
 
         List<RolapStar.Column> rollupColumnsList = detail.getRollupColumns();
@@ -815,7 +815,7 @@ class SegmentLoaderTest extends BatchTestCase {
         assertEquals(productDepartment, rollupColumnsList.get(1));
 
         groupingSets
-            .add(getGroupingSetRollupOnGenderAndProductDepartmentAndYear(context.getConnection()));
+            .add(getGroupingSetRollupOnGenderAndProductDepartmentAndYear(context.getConnectionWithDefaultRole()));
         detail = new GroupingSetsList(groupingSets);
         rollupColumnsList = detail.getRollupColumns();
         assertEquals(3, rollupColumnsList.size());
@@ -824,7 +824,7 @@ class SegmentLoaderTest extends BatchTestCase {
         assertEquals(year, rollupColumnsList.get(2));
 
         groupingSets
-            .add(getGroupingSetRollupOnProductFamilyAndProductDepartment(context.getConnection()));
+            .add(getGroupingSetRollupOnProductFamilyAndProductDepartment(context.getConnectionWithDefaultRole()));
         detail = new GroupingSetsList(groupingSets);
         rollupColumnsList = detail.getRollupColumns();
         assertEquals(4, rollupColumnsList.size());
@@ -883,7 +883,7 @@ class SegmentLoaderTest extends BatchTestCase {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testGroupingSetsUtilSetsForDetailForRollupColumns(Context context) {
         prepareContext(context);
-        RolapStar.Measure measure = getMeasure(context.getConnection(), cubeNameSales, measureUnitSales);
+        RolapStar.Measure measure = getMeasure(context.getConnectionWithDefaultRole(), cubeNameSales, measureUnitSales);
         RolapStar star = measure.getStar();
         RolapStar.Column year = star.lookupColumn(tableTime, fieldYear);
         RolapStar.Column productFamily =
@@ -893,9 +893,9 @@ class SegmentLoaderTest extends BatchTestCase {
         RolapStar.Column gender = star.lookupColumn(tableCustomer, fieldGender);
 
         List<GroupingSet> groupingSets = new ArrayList<>();
-        groupingSets.add(getDefaultGroupingSet(context.getConnection()));
-        groupingSets.add(getGroupingSetRollupOnProductDepartment(context.getConnection()));
-        groupingSets.add(getGroupingSetRollupOnGenderAndProductDepartment(context.getConnection()));
+        groupingSets.add(getDefaultGroupingSet(context.getConnectionWithDefaultRole()));
+        groupingSets.add(getGroupingSetRollupOnProductDepartment(context.getConnectionWithDefaultRole()));
+        groupingSets.add(getGroupingSetRollupOnGenderAndProductDepartment(context.getConnectionWithDefaultRole()));
         GroupingSetsList detail = new GroupingSetsList(groupingSets);
 
         List<RolapStar.Column> rollupColumnsList = detail.getRollupColumns();
@@ -904,7 +904,7 @@ class SegmentLoaderTest extends BatchTestCase {
         assertEquals(productDepartment, rollupColumnsList.get(1));
 
         groupingSets
-            .add(getGroupingSetRollupOnGenderAndProductDepartmentAndYear(context.getConnection()));
+            .add(getGroupingSetRollupOnGenderAndProductDepartmentAndYear(context.getConnectionWithDefaultRole()));
         detail = new GroupingSetsList(groupingSets);
         rollupColumnsList = detail.getRollupColumns();
         assertEquals(3, rollupColumnsList.size());
@@ -913,7 +913,7 @@ class SegmentLoaderTest extends BatchTestCase {
         assertEquals(year, rollupColumnsList.get(2));
 
         groupingSets
-            .add(getGroupingSetRollupOnProductFamilyAndProductDepartment(context.getConnection()));
+            .add(getGroupingSetRollupOnProductFamilyAndProductDepartment(context.getConnectionWithDefaultRole()));
         detail = new GroupingSetsList(groupingSets);
         rollupColumnsList = detail.getRollupColumns();
         assertEquals(4, rollupColumnsList.size());
@@ -932,22 +932,22 @@ class SegmentLoaderTest extends BatchTestCase {
     void testGroupingSetsUtilSetsForGroupingFunctionIndex(Context context) {
         prepareContext(context);
         List<GroupingSet> groupingSets = new ArrayList<>();
-        groupingSets.add(getDefaultGroupingSet(context.getConnection()));
-        groupingSets.add(getGroupingSetRollupOnProductDepartment(context.getConnection()));
-        groupingSets.add(getGroupingSetRollupOnGenderAndProductDepartment(context.getConnection()));
+        groupingSets.add(getDefaultGroupingSet(context.getConnectionWithDefaultRole()));
+        groupingSets.add(getGroupingSetRollupOnProductDepartment(context.getConnectionWithDefaultRole()));
+        groupingSets.add(getGroupingSetRollupOnGenderAndProductDepartment(context.getConnectionWithDefaultRole()));
         GroupingSetsList detail = new GroupingSetsList(groupingSets);
         assertEquals(0, detail.findGroupingFunctionIndex(3));
         assertEquals(1, detail.findGroupingFunctionIndex(2));
 
         groupingSets
-            .add(getGroupingSetRollupOnGenderAndProductDepartmentAndYear(context.getConnection()));
+            .add(getGroupingSetRollupOnGenderAndProductDepartmentAndYear(context.getConnectionWithDefaultRole()));
         detail = new GroupingSetsList(groupingSets);
         assertEquals(0, detail.findGroupingFunctionIndex(3));
         assertEquals(1, detail.findGroupingFunctionIndex(2));
         assertEquals(2, detail.findGroupingFunctionIndex(0));
 
         groupingSets
-            .add(getGroupingSetRollupOnProductFamilyAndProductDepartment(context.getConnection()));
+            .add(getGroupingSetRollupOnProductFamilyAndProductDepartment(context.getConnectionWithDefaultRole()));
         detail = new GroupingSetsList(groupingSets);
         assertEquals(0, detail.findGroupingFunctionIndex(3));
         assertEquals(1, detail.findGroupingFunctionIndex(2));
@@ -959,9 +959,9 @@ class SegmentLoaderTest extends BatchTestCase {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testGetGroupingColumnsList(Context context) {
         prepareContext(context);
-        GroupingSet groupingSetsInfo = getDefaultGroupingSet(context.getConnection());
+        GroupingSet groupingSetsInfo = getDefaultGroupingSet(context.getConnectionWithDefaultRole());
 
-        GroupingSet groupableSetsInfo = getGroupingSetRollupOnGender(context.getConnection());
+        GroupingSet groupableSetsInfo = getGroupingSetRollupOnGender(context.getConnectionWithDefaultRole());
 
 
         RolapStar.Column[] detailedColumns =

--- a/mondrian/src/test/java/mondrian/rolap/aggmatcher/AggGenTest.java
+++ b/mondrian/src/test/java/mondrian/rolap/aggmatcher/AggGenTest.java
@@ -71,7 +71,7 @@ class AggGenTest {
         ((TestConfig)context.getConfig()).setReadAggregates(true);
         ((TestConfig)context.getConfig()).setGenerateAggregateSql(true);
 
-        final RolapConnection rolapConn = (RolapConnection) context.getConnection();
+        final RolapConnection rolapConn = (RolapConnection) context.getConnectionWithDefaultRole();
         QueryImpl query =
             rolapConn.parseQuery(
                 "select {[Measures].[Count]} on columns from [HR]");

--- a/mondrian/src/test/java/mondrian/rolap/aggmatcher/AggMeasureFactCountTest.java
+++ b/mondrian/src/test/java/mondrian/rolap/aggmatcher/AggMeasureFactCountTest.java
@@ -747,7 +747,7 @@ class AggMeasureFactCountTest extends CsvDBTestCase {
                 + "Row #2: 3\n";
 
         withSchema(context, getAggSchema(aggExcludes, aggTables));
-        assertQueryReturns(context.getConnection(), QUERY, result);
+        assertQueryReturns(context.getConnectionWithDefaultRole(), QUERY, result);
     }
 
     @ParameterizedTest
@@ -848,10 +848,10 @@ class AggMeasureFactCountTest extends CsvDBTestCase {
     private void verifySameAggAndNot(Context context, String query, Function<CatalogMapping, PojoMappingModifier> mf) {
         withSchema(context, mf);
         Result resultWithAgg =
-                executeQuery(query, context.getConnection());
+                executeQuery(query, context.getConnectionWithDefaultRole());
         ((TestConfig)context.getConfig()).setUseAggregates(false);
         ((TestConfig)context.getConfig()).setReadAggregates(false);
-        Result result = executeQuery(query, context.getConnection());
+        Result result = executeQuery(query, context.getConnectionWithDefaultRole());
 
         String resultStr = TestUtil.toString(result);
         String resultWithAggStr = TestUtil.toString(resultWithAgg);
@@ -877,7 +877,7 @@ class AggMeasureFactCountTest extends CsvDBTestCase {
         withSchema(context, mf);
         //withFreshConnection();
         assertQuerySql
-                (context.getConnection(), query, new SqlPattern[]
+                (context.getConnectionWithDefaultRole(), query, new SqlPattern[]
                         {
                                 new SqlPattern
                                         (DatabaseProduct.MYSQL,

--- a/mondrian/src/test/java/mondrian/rolap/aggmatcher/AggSchemaScanTest.java
+++ b/mondrian/src/test/java/mondrian/rolap/aggmatcher/AggSchemaScanTest.java
@@ -51,7 +51,7 @@ class AggSchemaScanTest {
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testAggScanPropertiesEmptySchema(Context context) throws Exception {
-    final RolapConnection rolapConn = (RolapConnection) context.getConnection();
+    final RolapConnection rolapConn = (RolapConnection) context.getConnectionWithDefaultRole();
     final DataSource dataSource = rolapConn.getDataSource();
     Connection sqlConnection = null;
     try {
@@ -83,7 +83,7 @@ class AggSchemaScanTest {
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testAggScanPropertiesPopulatedSchema(Context context) throws Exception {
-    final RolapConnection rolapConn = (RolapConnection) context.getConnection();
+    final RolapConnection rolapConn = (RolapConnection) context.getConnectionWithDefaultRole();
     final DataSource dataSource = rolapConn.getDataSource();
     Connection sqlConnection = null;
     try {

--- a/mondrian/src/test/java/mondrian/rolap/aggmatcher/AggregationOverAggTableTest.java
+++ b/mondrian/src/test/java/mondrian/rolap/aggmatcher/AggregationOverAggTableTest.java
@@ -90,7 +90,7 @@ class AggregationOverAggTableTest extends AggTableTestCase {
             + "non empty CrossJoin({[TimeExtra].[1997].[Q1].Children},{[Gender].[M]}) on rows "
             + "from [ExtraCol]";
 
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             query,
             "Axis #0:\n"
             + "{}\n"
@@ -105,7 +105,7 @@ class AggregationOverAggTableTest extends AggTableTestCase {
             + "Row #2: 3\n");
 
         assertQuerySqlOrNot(
-            context.getConnection(),
+            context.getConnectionWithDefaultRole(),
             query,
             mysqlPattern(
                 "select\n"

--- a/mondrian/src/test/java/mondrian/rolap/aggmatcher/BUG_1541077.java
+++ b/mondrian/src/test/java/mondrian/rolap/aggmatcher/BUG_1541077.java
@@ -41,7 +41,7 @@ public class BUG_1541077 extends AggTableTestCase {
         ((TestConfig)context.getConfig()).setUseAggregates(true);
         ((TestConfig)context.getConfig()).setReadAggregates(true);
         prepareContext(context);
-        if (!isApplicable(context.getConnection())) {
+        if (!isApplicable(context.getConnectionWithDefaultRole())) {
             return;
         }
 
@@ -50,12 +50,12 @@ public class BUG_1541077 extends AggTableTestCase {
 
         String mdx =
             "select {[Measures].[Store Count]} on columns from Cheques";
-        Result result = executeQuery(mdx, context.getConnection());
+        Result result = executeQuery(mdx, context.getConnectionWithDefaultRole());
         Object v = result.getCell(new int[]{0}).getValue();
 
         ((TestConfig)context.getConfig()).setUseAggregates(true);
 
-        Result result1 = executeQuery(mdx, context.getConnection());
+        Result result1 = executeQuery(mdx, context.getConnectionWithDefaultRole());
         Object v1 = result1.getCell(new int[]{0}).getValue();
 
         assertTrue(v.equals(v1));
@@ -67,7 +67,7 @@ public class BUG_1541077 extends AggTableTestCase {
         ((TestConfig)context.getConfig()).setUseAggregates(true);
         ((TestConfig)context.getConfig()).setReadAggregates(true);
         prepareContext(context);
-        if (!isApplicable(context.getConnection())) {
+        if (!isApplicable(context.getConnectionWithDefaultRole())) {
             return;
         }
 
@@ -76,12 +76,12 @@ public class BUG_1541077 extends AggTableTestCase {
 
         String mdx =
             "select {[Measures].[Sales Count]} on columns from Cheques";
-        Result result = executeQuery(mdx, context.getConnection());
+        Result result = executeQuery(mdx, context.getConnectionWithDefaultRole());
         Object v = result.getCell(new int[]{0}).getValue();
 
         ((TestConfig)context.getConfig()).setUseAggregates(true);
 
-        Result result1 = executeQuery(mdx, context.getConnection());
+        Result result1 = executeQuery(mdx, context.getConnectionWithDefaultRole());
         Object v1 = result1.getCell(new int[]{0}).getValue();
 
         assertTrue(v.equals(v1));
@@ -93,7 +93,7 @@ public class BUG_1541077 extends AggTableTestCase {
         ((TestConfig)context.getConfig()).setUseAggregates(true);
         ((TestConfig)context.getConfig()).setReadAggregates(true);
         prepareContext(context);
-        if (!isApplicable(context.getConnection())) {
+        if (!isApplicable(context.getConnectionWithDefaultRole())) {
             return;
         }
 
@@ -102,12 +102,12 @@ public class BUG_1541077 extends AggTableTestCase {
 
         String mdx =
             "select {[Measures].[Total Amount]} on columns from Cheques";
-        Result result = executeQuery(mdx, context.getConnection());
+        Result result = executeQuery(mdx, context.getConnectionWithDefaultRole());
         Object v = result.getCell(new int[]{0}).getValue();
 
         ((TestConfig)context.getConfig()).setUseAggregates(false);
 
-        Result result1 = executeQuery(mdx, context.getConnection());
+        Result result1 = executeQuery(mdx, context.getConnectionWithDefaultRole());
         Object v1 = result1.getCell(new int[]{0}).getValue();
 
         assertTrue(v.equals(v1));
@@ -119,7 +119,7 @@ public class BUG_1541077 extends AggTableTestCase {
         ((TestConfig)context.getConfig()).setUseAggregates(true);
         ((TestConfig)context.getConfig()).setReadAggregates(true);
         prepareContext(context);
-        if (!isApplicable(context.getConnection())) {
+        if (!isApplicable(context.getConnectionWithDefaultRole())) {
             return;
         }
 
@@ -128,13 +128,13 @@ public class BUG_1541077 extends AggTableTestCase {
 
         String mdx = "select {[Measures].[Avg Amount]} on columns from Cheques";
 
-        Result result = executeQuery(mdx, context.getConnection());
+        Result result = executeQuery(mdx, context.getConnectionWithDefaultRole());
         Object v = result.getCell(new int[]{0}).getFormattedValue();
 
         // get value with aggregates
         ((TestConfig)context.getConfig()).setUseAggregates(true);
 
-        Result result1 = executeQuery(mdx, context.getConnection());
+        Result result1 = executeQuery(mdx, context.getConnectionWithDefaultRole());
         Object v1 = result1.getCell(new int[]{0}).getFormattedValue();
 
         assertTrue(v.equals(v1));

--- a/mondrian/src/test/java/mondrian/rolap/aggmatcher/Checkin_7634.java
+++ b/mondrian/src/test/java/mondrian/rolap/aggmatcher/Checkin_7634.java
@@ -77,13 +77,13 @@ public class Checkin_7634 extends CsvDBTestCase {
 
         // Execute query but do not used the CrossJoin nonEmptyList optimization
         ((TestConfig)context.getConfig()).setCrossJoinOptimizerSize(Integer.MAX_VALUE);
-        Result result1 = executeQuery(mdx, context.getConnection());
+        Result result1 = executeQuery(mdx, context.getConnectionWithDefaultRole());
         String resultString1 = TestUtil.toString(result1);
 
         // Execute query using the new version of the CrossJoin
         // nonEmptyList optimization
         ((TestConfig)context.getConfig()).setCrossJoinOptimizerSize(Integer.MAX_VALUE);
-        Result result2 = executeQuery(mdx, context.getConnection());
+        Result result2 = executeQuery(mdx, context.getConnectionWithDefaultRole());
         String resultString2 = TestUtil.toString(result2);
 
         // This succeeds.

--- a/mondrian/src/test/java/mondrian/rolap/aggmatcher/Checkin_7641.java
+++ b/mondrian/src/test/java/mondrian/rolap/aggmatcher/Checkin_7641.java
@@ -68,9 +68,9 @@ public class Checkin_7641 extends CsvDBTestCase {
             + "[Geography].[All Regions].Children)) ON ROWS"
             + " from [ImplicitMember]";
 
-        Result result1 = executeQuery(mdx, context.getConnection());
+        Result result1 = executeQuery(mdx, context.getConnectionWithDefaultRole());
         String resultString1 = TestUtil.toString(result1);
-        Result result2 = executeQuery(mdx, context.getConnection());
+        Result result2 = executeQuery(mdx, context.getConnectionWithDefaultRole());
         String resultString2 = TestUtil.toString(result2);
 
         assertEquals(resultString1, resultString2);

--- a/mondrian/src/test/java/mondrian/rolap/aggmatcher/DefaultRecognizerTest.java
+++ b/mondrian/src/test/java/mondrian/rolap/aggmatcher/DefaultRecognizerTest.java
@@ -49,7 +49,7 @@ class DefaultRecognizerTest {
         ((TestConfig)context.getConfig()).setGenerateFormattedSql(true);
         ((TestConfig)context.getConfig()).setUseAggregates(true);
         ((TestConfig)context.getConfig()).setReadAggregates(true);
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         flushSchemaCache(connection);
         /*
         final String cube =
@@ -103,7 +103,7 @@ class DefaultRecognizerTest {
             + "    `agg_c_10_sales_fact_1997`.`month_of_year` in (1, 2, 3)";
 
         withSchema(context, SchemaModifiers.DefaultRecognizerTestModifier::new);
-        assertQuerySqlOrNot(context.getConnection(),
+        assertQuerySqlOrNot(context.getConnectionWithDefaultRole(),
             query,
             mysqlPattern(expectedSql),
             false, true, true);
@@ -117,7 +117,7 @@ class DefaultRecognizerTest {
         ((TestConfig)context.getConfig()).setGenerateFormattedSql(true);
         ((TestConfig)context.getConfig()).setUseAggregates(true);
         ((TestConfig)context.getConfig()).setReadAggregates(true);
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         flushSchemaCache(connection);
         // Validates that if a distinct count measure is in context
         // SqlTupleReader is able to find an appropriate agg table, if

--- a/mondrian/src/test/java/mondrian/rolap/aggmatcher/ExplicitRecognizerTest.java
+++ b/mondrian/src/test/java/mondrian/rolap/aggmatcher/ExplicitRecognizerTest.java
@@ -178,9 +178,9 @@ class ExplicitRecognizerTest extends AggTableTestCase {
             "select {[Measures].[Unit Sales]} on columns, "
             + "non empty CrossJoin({[TimeExtra].[Month].members},{[Gender].[M]}) on rows "
             + "from [ExtraCol] ";
-        TestUtil.flushSchemaCache(context.getConnection());
+        TestUtil.flushSchemaCache(context.getConnectionWithDefaultRole());
         assertQuerySql(
-            context.getConnection(),
+            context.getConnectionWithDefaultRole(),
             query,
             mysqlPattern(
                 "select\n"
@@ -203,7 +203,7 @@ class ExplicitRecognizerTest extends AggTableTestCase {
                 + "    `time_by_day`.`the_month`,\n"
                 + "    `agg_g_ms_pcat_sales_fact_1997`.`gender`\n"
                 + "order by\n"
-                + (getDialect(context.getConnection()).requiresOrderByAlias()
+                + (getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
                     ? "    ISNULL(`c0`) ASC, `c0` ASC,\n"
                     + "    ISNULL(`c1`) ASC, `c1` ASC,\n"
                     + "    ISNULL(`c2`) ASC, `c2` ASC,\n"
@@ -213,7 +213,7 @@ class ExplicitRecognizerTest extends AggTableTestCase {
                     + "    ISNULL(`agg_g_ms_pcat_sales_fact_1997`.`month_of_year`) ASC, `agg_g_ms_pcat_sales_fact_1997`.`month_of_year` ASC,\n"
                     + "    ISNULL(`agg_g_ms_pcat_sales_fact_1997`.`gender`) ASC, `agg_g_ms_pcat_sales_fact_1997`.`gender` ASC")));
         assertQuerySql(
-            context.getConnection(),
+            context.getConnectionWithDefaultRole(),
             query,
             mysqlPattern(
                 "select\n"
@@ -298,7 +298,7 @@ class ExplicitRecognizerTest extends AggTableTestCase {
         // Run the query twice, verifying both the SqlTupleReader and
         // Segment load queries.
         assertQuerySql(
-            context.getConnection(),
+            context.getConnectionWithDefaultRole(),
             query,
             mysqlPattern(
                 "select\n"
@@ -330,7 +330,7 @@ class ExplicitRecognizerTest extends AggTableTestCase {
                 + "    `store`.`store_name`,\n"
                 + "    `store`.`store_street_address`\n"
                 + "order by\n"
-                + (getDialect(context.getConnection()).requiresOrderByAlias()
+                + (getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
                     ? "    ISNULL(`c0`) ASC, `c0` ASC,\n"
                     + "    ISNULL(`c1`) ASC, `c1` ASC,\n"
                     + "    ISNULL(`c2`) ASC, `c2` ASC,\n"
@@ -347,7 +347,7 @@ class ExplicitRecognizerTest extends AggTableTestCase {
                     + "    ISNULL(`store`.`store_name`) ASC, `store`.`store_name` ASC")));
 
         assertQuerySql(
-            context.getConnection(),
+            context.getConnectionWithDefaultRole(),
             query,
             mysqlPattern(
                 "select\n"
@@ -422,7 +422,7 @@ class ExplicitRecognizerTest extends AggTableTestCase {
             + "from [ExtraCol] ";
 
         assertQuerySql(
-            context.getConnection(),
+            context.getConnectionWithDefaultRole(),
             query,
             mysqlPattern(
                 "select\n"
@@ -442,7 +442,7 @@ class ExplicitRecognizerTest extends AggTableTestCase {
                 + "    `exp_agg_test`.`testmonthord`,\n"
                 + "    `exp_agg_test`.`gender`\n"
                 + "order by\n"
-                + (getDialect(context.getConnection()).requiresOrderByAlias()
+                + (getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
                     ? "    ISNULL(`c0`) ASC, `c0` ASC,\n"
                     + "    ISNULL(`c1`) ASC, `c1` ASC,\n"
                     + "    ISNULL(`c3`) ASC, `c3` ASC,\n"
@@ -505,7 +505,7 @@ class ExplicitRecognizerTest extends AggTableTestCase {
             + "from [ExtraCol] ";
 
         assertQuerySql(
-            context.getConnection(),
+            context.getConnectionWithDefaultRole(),
             query,
             mysqlPattern(
                 "select\n"
@@ -525,7 +525,7 @@ class ExplicitRecognizerTest extends AggTableTestCase {
                 + "    `exp_agg_test`.`testmonthcap`,\n"
                 + "    `exp_agg_test`.`gender`\n"
                 + "order by\n"
-                + (getDialect(context.getConnection()).requiresOrderByAlias()
+                + (getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
                     ? "    ISNULL(`c0`) ASC, `c0` ASC,\n"
                     + "    ISNULL(`c1`) ASC, `c1` ASC,\n"
                     + "    ISNULL(`c2`) ASC, `c2` ASC,\n"
@@ -598,7 +598,7 @@ class ExplicitRecognizerTest extends AggTableTestCase {
             + "from [ExtraCol] ";
 
         assertQuerySql(
-            context.getConnection(),
+            context.getConnectionWithDefaultRole(),
             query,
             mysqlPattern(
                 "select\n"
@@ -620,7 +620,7 @@ class ExplicitRecognizerTest extends AggTableTestCase {
                 + "    `exp_agg_test`.`testmonprop1`,\n"
                 + "    `exp_agg_test`.`gender`\n"
                 + "order by\n"
-                + (getDialect(context.getConnection()).requiresOrderByAlias()
+                + (getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
                     ? "    ISNULL(`c0`) ASC, `c0` ASC,\n"
                     + "    ISNULL(`c1`) ASC, `c1` ASC,\n"
                     + "    ISNULL(`c2`) ASC, `c2` ASC,\n"
@@ -703,7 +703,7 @@ class ExplicitRecognizerTest extends AggTableTestCase {
             + "non empty CrossJoin({[Gender].Gender.members},{[Store].[USA].[WA].[Spokane].[Store 16]}) on rows "
             + "from [ExtraCol]";
         assertQuerySql(
-            context.getConnection(),
+            context.getConnectionWithDefaultRole(),
             query,
             mysqlPattern(
                 "select\n"
@@ -725,7 +725,7 @@ class ExplicitRecognizerTest extends AggTableTestCase {
                 + "    `exp_agg_test_distinct_count`.`store_name`,\n"
                 + "    `exp_agg_test_distinct_count`.`store_add`\n"
                 + "order by\n"
-                + (getDialect(context.getConnection()).requiresOrderByAlias()
+                + (getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
                     ? "    ISNULL(`c0`) ASC, `c0` ASC,\n"
                     + "    ISNULL(`c1`) ASC, `c1` ASC,\n"
                     + "    ISNULL(`c2`) ASC, `c2` ASC,\n"
@@ -737,7 +737,7 @@ class ExplicitRecognizerTest extends AggTableTestCase {
                     + "    ISNULL(`exp_agg_test_distinct_count`.`store_cty`) ASC, `exp_agg_test_distinct_count`.`store_cty` ASC,\n"
                     + "    ISNULL(`exp_agg_test_distinct_count`.`store_name`) ASC, `exp_agg_test_distinct_count`.`store_name` ASC")));
 
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "Store Address Property should be '5922 La Salle Ct'",
             query,
             "Axis #0:\n"
@@ -757,7 +757,7 @@ class ExplicitRecognizerTest extends AggTableTestCase {
             + "Row #1: 11,523\n");
         // Should use agg table for distinct count measure
         assertQuerySql(
-            context.getConnection(),
+            context.getConnectionWithDefaultRole(),
             query,
             mysqlPattern(
                 "select\n"
@@ -847,7 +847,7 @@ class ExplicitRecognizerTest extends AggTableTestCase {
             + "from [ExtraCol]";
 
         assertQuerySql(
-            context.getConnection(),
+            context.getConnectionWithDefaultRole(),
             query,
             mysqlPattern(
                 "select\n"
@@ -869,7 +869,7 @@ class ExplicitRecognizerTest extends AggTableTestCase {
                 + "    `exp_agg_test_distinct_count`.`store_name`,\n"
                 + "    `exp_agg_test_distinct_count`.`store_add`\n"
                 + "order by\n"
-                + (getDialect(context.getConnection()).requiresOrderByAlias()
+                + (getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
                     ? "    ISNULL(`c0`) ASC, `c0` ASC,\n"
                     + "    ISNULL(`c1`) ASC, `c1` ASC,\n"
                     + "    ISNULL(`c2`) ASC, `c2` ASC,\n"
@@ -882,7 +882,7 @@ class ExplicitRecognizerTest extends AggTableTestCase {
                     + "    ISNULL(`exp_agg_test_distinct_count`.`store_name`) ASC, `exp_agg_test_distinct_count`.`store_name` ASC")));
 
         assertQuerySql(
-            context.getConnection(),
+            context.getConnectionWithDefaultRole(),
             query,
             mysqlPattern(
                 "select\n"
@@ -977,7 +977,7 @@ class ExplicitRecognizerTest extends AggTableTestCase {
         // attributes for store are on the aggStar bitkey and not part of the
         // request and rollup is not safe
         assertQuerySql(
-            context.getConnection(),
+            context.getConnectionWithDefaultRole(),
             query,
             mysqlPattern(
                 "select\n"

--- a/mondrian/src/test/java/mondrian/rolap/aggmatcher/MultipleColsInTupleAggTest.java
+++ b/mondrian/src/test/java/mondrian/rolap/aggmatcher/MultipleColsInTupleAggTest.java
@@ -76,7 +76,7 @@ class MultipleColsInTupleAggTest extends AggTableTestCase {
         ((TestConfig)context.getConfig()).setReadAggregates(true);
         ((TestConfig)context.getConfig()).setDisableCaching(true);
         prepareContext(context);
-        if (!isApplicable(context.getConnection())) {
+        if (!isApplicable(context.getConnectionWithDefaultRole())) {
             return;
         }
 
@@ -86,13 +86,13 @@ class MultipleColsInTupleAggTest extends AggTableTestCase {
 
         String mdx =
             "select {[Measures].[Total]} on columns from [Fact]";
-        Result result = executeQuery(mdx, context.getConnection());
+        Result result = executeQuery(mdx, context.getConnectionWithDefaultRole());
         Object v = result.getCell(new int[]{0}).getValue();
 
         String mdx2 =
             "select {[Measures].[Total]} on columns from [Fact] where "
             + "{[Product].[Cat One].[Prod Cat One].[One]}";
-        Result aresult = executeQuery(mdx2, context.getConnection());
+        Result aresult = executeQuery(mdx2, context.getConnectionWithDefaultRole());
         Object av = aresult.getCell(new int[]{0}).getValue();
 
         // unless there is a way to flush the cache,
@@ -100,12 +100,12 @@ class MultipleColsInTupleAggTest extends AggTableTestCase {
         ((TestConfig)context.getConfig()).setUseAggregates(true);
         ((TestConfig)context.getConfig()).setReadAggregates(false);
 
-        Result result1 = executeQuery(mdx, context.getConnection());
+        Result result1 = executeQuery(mdx, context.getConnectionWithDefaultRole());
         Object v1 = result1.getCell(new int[]{0}).getValue();
 
         assertTrue(v.equals(v1));
 
-        Result aresult2 = executeQuery(mdx2, context.getConnection());
+        Result aresult2 = executeQuery(mdx2, context.getConnectionWithDefaultRole());
         Object av1 = aresult2.getCell(new int[]{0}).getValue();
 
         assertTrue(av.equals(av1));
@@ -119,7 +119,7 @@ class MultipleColsInTupleAggTest extends AggTableTestCase {
         ((TestConfig)context.getConfig()).setReadAggregates(true);
         ((TestConfig)context.getConfig()).setDisableCaching(true);
         prepareContext(context);
-        if (!isApplicable(context.getConnection())) {
+        if (!isApplicable(context.getConnectionWithDefaultRole())) {
             return;
         }
 
@@ -130,7 +130,7 @@ class MultipleColsInTupleAggTest extends AggTableTestCase {
             + "{[Store].[All Stores]}) on rows "
             + "from [Fact]";
 
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             mdx,
             "Axis #0:\n"
             + "{}\n"
@@ -150,14 +150,14 @@ class MultipleColsInTupleAggTest extends AggTableTestCase {
         ((TestConfig)context.getConfig()).setReadAggregates(true);
         ((TestConfig)context.getConfig()).setDisableCaching(true);
         prepareContext(context);
-        if (!isApplicable(context.getConnection())) {
+        if (!isApplicable(context.getConnectionWithDefaultRole())) {
             return;
         }
         // Native filter without any measures hit an edge case that
         // could fail to include the Agg star in the WHERE clause,
         // and could also mishandle the field referred to in the native
         // HAVING clause.  ANALYZER-2655
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select "
             + "Filter([Product].[Category].members, "
             + "Product.CurrentMember.Caption MATCHES (\"(?i).*Two.*\") )"
@@ -170,7 +170,7 @@ class MultipleColsInTupleAggTest extends AggTableTestCase {
             + "Row #0: 33\n");
         //  CurrentMember.Name should map to
         // `test_lp_xxx_fact`.`product_category`, with 2 member matches
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select "
             + "Filter([Product].[Product Category].members, "
             + "Product.CurrentMember.Name MATCHES (\"(?i).*Two.*\") )"
@@ -185,7 +185,7 @@ class MultipleColsInTupleAggTest extends AggTableTestCase {
             + "Row #0: 18\n");
         // .Caption is defined as `product_cat`.`cap`.
         // [Cat One].[Prod Cat Two] has just one caption matching -- "PCTwo"
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select "
             + "Filter([Product].[Product Category].Members, "
             + "Product.CurrentMember.Caption MATCHES (\"(?i).*Two.*\") )"
@@ -208,7 +208,7 @@ class MultipleColsInTupleAggTest extends AggTableTestCase {
         ((TestConfig)context.getConfig()).setReadAggregates(true);
         ((TestConfig)context.getConfig()).setDisableCaching(true);
         prepareContext(context);
-        if (!isApplicable(context.getConnection())) {
+        if (!isApplicable(context.getConnectionWithDefaultRole())) {
             return;
         }
         // similar to the previous test, but verifies a case where
@@ -220,7 +220,7 @@ class MultipleColsInTupleAggTest extends AggTableTestCase {
             + "Product.CurrentMember.Caption MATCHES (\"(?i).*Two.*\") )"
             + " on columns "
             + "from [Fact] ";
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             query,
             "Axis #0:\n"
             + "{}\n"
@@ -230,7 +230,7 @@ class MultipleColsInTupleAggTest extends AggTableTestCase {
 
         // check generated sql only for native evaluation
         if (context.getConfig().enableNativeFilter()) {
-          assertQuerySql(context.getConnection(),
+          assertQuerySql(context.getConnectionWithDefaultRole(),
               query,
               new SqlPattern[] {
                   new SqlPattern(
@@ -269,7 +269,7 @@ class MultipleColsInTupleAggTest extends AggTableTestCase {
                   + "having\n"
                   + "    c7 IS NOT NULL AND UPPER(c7) REGEXP '.*TWO.*'\n"
                   + "order by\n"
-                  + (getDialect(context.getConnection()).requiresOrderByAlias()
+                  + (getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
                       ? "    ISNULL(`c2`) ASC, `c2` ASC,\n"
                       + "    ISNULL(`c6`) ASC, `c6` ASC,\n"
                       + "    ISNULL(`c7`) ASC, `c7` ASC"
@@ -278,7 +278,7 @@ class MultipleColsInTupleAggTest extends AggTableTestCase {
                       + "    ISNULL(`test_lp_xx2_fact`.`prodname`) ASC, "
                       + "`test_lp_xx2_fact`.`prodname` ASC"), null)});
         }
-        Axis axis = executeAxis(context.getConnection(), "Fact",
+        Axis axis = executeAxis(context.getConnectionWithDefaultRole(), "Fact",
             "Filter([Product].[Product Name].members, "
             + "Product.CurrentMember.Caption MATCHES (\"(?i).*Two.*\") )");
         assertEquals(
@@ -295,13 +295,13 @@ class MultipleColsInTupleAggTest extends AggTableTestCase {
         ((TestConfig)context.getConfig()).setReadAggregates(true);
         ((TestConfig)context.getConfig()).setDisableCaching(true);
         prepareContext(context);
-        if (!isApplicable(context.getConnection())) {
+        if (!isApplicable(context.getConnectionWithDefaultRole())) {
             return;
         }
 
         String mdx = "select {[Measures].[Total]} on columns, "
             + "non empty [Product].[Cat One].Children on rows from [Fact]";
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             mdx,
             "Axis #0:\n"
             + "{}\n"

--- a/mondrian/src/test/java/mondrian/rolap/aggmatcher/NonCollapsedAggTest.java
+++ b/mondrian/src/test/java/mondrian/rolap/aggmatcher/NonCollapsedAggTest.java
@@ -298,7 +298,7 @@ class NonCollapsedAggTest extends AggTableTestCase {
         ((TestConfig)context.getConfig()).setUseAggregates(true);
         ((TestConfig)context.getConfig()).setReadAggregates(true);
     	super.prepareContext(context);
-        if (!isApplicable(context.getConnection())) {
+        if (!isApplicable(context.getConnectionWithDefaultRole())) {
             return;
         }
 
@@ -308,7 +308,7 @@ class NonCollapsedAggTest extends AggTableTestCase {
 
 
         // We expect the correct cell value + 1 if the agg table is used.
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             mdx,
             "Axis #0:\n"
             + "{}\n"
@@ -327,7 +327,7 @@ class NonCollapsedAggTest extends AggTableTestCase {
         ((TestConfig)context.getConfig()).setUseAggregates(true);
         ((TestConfig)context.getConfig()).setReadAggregates(true);
         prepareContext(context);
-        if (!isApplicable(context.getConnection())) {
+        if (!isApplicable(context.getConnectionWithDefaultRole())) {
             return;
         }
 
@@ -337,7 +337,7 @@ class NonCollapsedAggTest extends AggTableTestCase {
 
 
         // We expect the correct cell value + 1 if the agg table is used.
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             mdx,
             "Axis #0:\n"
             + "{}\n"
@@ -352,7 +352,7 @@ class NonCollapsedAggTest extends AggTableTestCase {
         final String mdx2 =
             "select {[Measures].[Unit Sales]} on columns, {[dimension.network].[line class].Members} on rows from [foo]";
         // We expect the correct cell value + 1 if the agg table is used.
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             mdx2,
             "Axis #0:\n"
             + "{}\n"
@@ -372,14 +372,14 @@ class NonCollapsedAggTest extends AggTableTestCase {
         ((TestConfig)context.getConfig()).setUseAggregates(true);
         ((TestConfig)context.getConfig()).setReadAggregates(true);
         prepareContext(context);
-        if (!isApplicable(context.getConnection())) {
+        if (!isApplicable(context.getConnectionWithDefaultRole())) {
             return;
         }
 
         // We expect the correct cell value + 2 if the agg table is used.
         final String mdx =
             "select {[Measures].[Unit Sales]} on columns, {[dimension.distributor].[line class].Members} on rows from [foo2]";
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             mdx,
             "Axis #0:\n"
             + "{}\n"
@@ -394,7 +394,7 @@ class NonCollapsedAggTest extends AggTableTestCase {
         final String mdx2 =
             "select {[Measures].[Unit Sales]} on columns, {[dimension.network].[line class].Members} on rows from [foo2]";
         // We expect the correct cell value + 2 if the agg table is used.
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             mdx2,
             "Axis #0:\n"
             + "{}\n"
@@ -794,7 +794,7 @@ class NonCollapsedAggTest extends AggTableTestCase {
 
         final String mdx =
                 "select {[Measures].[Unit Sales]} on columns, {[dimension].[tenant].[tenant].Members} on rows from [testSsas]";
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             mdx,
             "Axis #0:\n"
             + "{}\n"
@@ -861,7 +861,7 @@ class NonCollapsedAggTest extends AggTableTestCase {
         withSchema(context, TestMondrian1325Modifier::new);
 
 
-        executeQuery(query2, context.getConnection());
+        executeQuery(query2, context.getConnectionWithDefaultRole());
     }
 
     protected Function<CatalogMapping, PojoMappingModifier> getModifierFunction(){

--- a/mondrian/src/test/java/mondrian/rolap/aggmatcher/SpeciesNonCollapsedAggTest.java
+++ b/mondrian/src/test/java/mondrian/rolap/aggmatcher/SpeciesNonCollapsedAggTest.java
@@ -109,12 +109,12 @@ class SpeciesNonCollapsedAggTest extends AggTableTestCase {
         ((TestConfig)context.getConfig()).setUseAggregates(true);
         ((TestConfig)context.getConfig()).setReadAggregates(true);
         prepareContext(context);
-        if (!isApplicable(context.getConnection())) {
+        if (!isApplicable(context.getConnectionWithDefaultRole())) {
             return;
         }
 
         // If agg table is not used, cell values will be very different.
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "SELECT \n"
             + " { [Measures].[Population] } ON COLUMNS,\n"
             + " { [Animal.Animals].[Family].Members } ON ROWS\n"

--- a/mondrian/src/test/java/mondrian/rolap/aggmatcher/UsagePrefixTest.java
+++ b/mondrian/src/test/java/mondrian/rolap/aggmatcher/UsagePrefixTest.java
@@ -41,7 +41,7 @@ class UsagePrefixTest extends AggTableTestCase {
         ((TestConfig)context.getConfig()).setUseAggregates(true);
         ((TestConfig)context.getConfig()).setReadAggregates(true);
         prepareContext(context);
-        if (!isApplicable(context.getConnection())) {
+        if (!isApplicable(context.getConnectionWithDefaultRole())) {
             return;
         }
         SystemWideProperties props = SystemWideProperties.instance();
@@ -55,8 +55,8 @@ class UsagePrefixTest extends AggTableTestCase {
                 +   "{ measures.[Amount] } on rows from Cheques";
 
         withSchema(context, SchemaModifiers.UsagePrefixTestModifier1::new);
-        context.getConnection().getCacheControl(null).flushSchemaCache();
-        assertQueryReturns(context.getConnection(),
+        context.getConnectionWithDefaultRole().getCacheControl(null).flushSchemaCache();
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             mdx,
             "Axis #0:\n"
             +    "{}\n"
@@ -78,7 +78,7 @@ class UsagePrefixTest extends AggTableTestCase {
         ((TestConfig)context.getConfig()).setUseAggregates(true);
         ((TestConfig)context.getConfig()).setReadAggregates(true);
         prepareContext(context);
-        if (!isApplicable(context.getConnection())) {
+        if (!isApplicable(context.getConnectionWithDefaultRole())) {
             return;
         }
 
@@ -92,8 +92,8 @@ class UsagePrefixTest extends AggTableTestCase {
             +   "{ measures.[Amount] } on rows from Cheques";
 
         withSchema(context, SchemaModifiers.UsagePrefixTestModifier1::new);
-        context.getConnection().getCacheControl(null).flushSchemaCache();
-        assertQueryReturns(context.getConnection(),
+        context.getConnectionWithDefaultRole().getCacheControl(null).flushSchemaCache();
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             mdx,
                 "Axis #0:\n"
                 + "{}\n"

--- a/mondrian/src/test/java/mondrian/rolap/sql/CrossJoinArgFactoryTest.java
+++ b/mondrian/src/test/java/mondrian/rolap/sql/CrossJoinArgFactoryTest.java
@@ -55,6 +55,6 @@ class CrossJoinArgFactoryTest {
                 + "Row #0: 15,941.98\n"
                 + "Row #1: 16,598.87\n"
                 + "Row #1: 15,649.64\n";
-        assertQueryReturns(context.getConnection(), query, expected);
+        assertQueryReturns(context.getConnectionWithDefaultRole(), query, expected);
     }
 }

--- a/mondrian/src/test/java/mondrian/rolap/sql/EffectiveMemberCacheTest.java
+++ b/mondrian/src/test/java/mondrian/rolap/sql/EffectiveMemberCacheTest.java
@@ -41,7 +41,7 @@ class EffectiveMemberCacheTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCachedLevelMembers(Context context) {
         ((TestConfig)context.getConfig()).setGenerateFormattedSql(true);
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         clearCache(connection);
         // verify query for specific members can be fulfilled by members cached
         // from a level members query.
@@ -59,7 +59,7 @@ class EffectiveMemberCacheTest {
                 + "group by\n"
                 + "    `product`.`product_name`\n"
                 + "order by\n"
-                + (getDialect(context.getConnection()).requiresOrderByAlias()
+                + (getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
                 ? "    ISNULL(`c0`) ASC, `c0` ASC"
                 : "    ISNULL(`product`.`product_name`) ASC, "
                 + "`product`.`product_name` ASC");
@@ -81,7 +81,7 @@ class EffectiveMemberCacheTest {
     void testCachedChildMembers(Context context) {
     	context.getSchemaCache().clear();
         ((TestConfig)context.getConfig()).setGenerateFormattedSql(true);
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         clearCache(connection);
         // verify query for specific members can be fulfilled by members cached
         // from a child members query.
@@ -100,7 +100,7 @@ class EffectiveMemberCacheTest {
                 + "group by\n"
                 + "    `product`.`product_name`\n"
                 + "order by\n"
-                + (getDialect(context.getConnection()).requiresOrderByAlias()
+                + (getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
                 ? "    ISNULL(`c0`) ASC, `c0` ASC"
                 : "    ISNULL(`product`.`product_name`) ASC, "
                 + "`product`.`product_name` ASC");
@@ -121,7 +121,7 @@ class EffectiveMemberCacheTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testLevelPreCacheThreshold(Context context) {
         ((TestConfig)context.getConfig()).setGenerateFormattedSql(true);
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         clearCache(connection);
         // [Store Type] members cardinality falls well below
         // LevelPreCacheThreshold.  All members should be loaded, not
@@ -154,7 +154,7 @@ class EffectiveMemberCacheTest {
         // with LevelPreCacheThreshold set to 0, we should not load
         // all [store type] members, we should only retrieve the 2
         // specified.
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         clearCache(connection);
         ((TestConfig)context.getConfig()).setLevelPreCacheThreshold(0);
         String sql = "select\n"
@@ -188,7 +188,7 @@ class EffectiveMemberCacheTest {
         // we should avoid pulling all deg members, regardless of cardinality.
         // The cost of doing full scans of the fact table is assumed
         // to be too high.
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         clearCache(connection);
         ((TestConfig)context.getConfig()).setLevelPreCacheThreshold(1000);
         String sql = "select\n"

--- a/mondrian/src/test/java/mondrian/rolap/sql/SelectNotInGroupByTest.java
+++ b/mondrian/src/test/java/mondrian/rolap/sql/SelectNotInGroupByTest.java
@@ -163,7 +163,7 @@ class SelectNotInGroupByTest extends BatchTestCase {
         ((TestConfig)context.getConfig()).setGenerateFormattedSql(true);
         // Property group by should be skipped only if dialect supports it
         String sqlpat;
-        if (dialectAllowsSelectNotInGroupBy(context.getConnection())) {
+        if (dialectAllowsSelectNotInGroupBy(context.getConnectionWithDefaultRole())) {
             sqlpat = sqlWithLevelGroupBy;
         } else {
             sqlpat = sqlWithAllGroupBy;
@@ -185,7 +185,7 @@ class SelectNotInGroupByTest extends BatchTestCase {
         withSchema(context, schema);
          */
         withSchema(context, SchemaModifiers.SelectNotInGroupByTestModifier1::new);
-        assertQuerySqlOrNot(context.getConnection(), queryCubeA, sqlPatterns, false, false, true);
+        assertQuerySqlOrNot(context.getConnectionWithDefaultRole(), queryCubeA, sqlPatterns, false, false, true);
     }
 
     @ParameterizedTest
@@ -212,7 +212,7 @@ class SelectNotInGroupByTest extends BatchTestCase {
         withSchema(context, schema);
          */
         withSchema(context, SchemaModifiers.SelectNotInGroupByTestModifier2::new);
-        assertQuerySqlOrNot(context.getConnection(), queryCubeA, sqlPatterns, false, false, true);
+        assertQuerySqlOrNot(context.getConnectionWithDefaultRole(), queryCubeA, sqlPatterns, false, false, true);
     }
 
     @ParameterizedTest
@@ -241,7 +241,7 @@ class SelectNotInGroupByTest extends BatchTestCase {
         withSchema(context, schema);
          */
         withSchema(context, SchemaModifiers.SelectNotInGroupByTestModifier3::new);
-        assertQuerySqlOrNot(context.getConnection(), queryCubeA, sqlPatterns, false, false, true);
+        assertQuerySqlOrNot(context.getConnectionWithDefaultRole(), queryCubeA, sqlPatterns, false, false, true);
     }
 
     @ParameterizedTest
@@ -268,7 +268,7 @@ class SelectNotInGroupByTest extends BatchTestCase {
         withSchema(context, schema);
         */
         withSchema(context, SchemaModifiers.SelectNotInGroupByTestModifier4::new);
-        assertQuerySqlOrNot(context.getConnection(), queryCubeA, sqlPatterns, false, false, true);
+        assertQuerySqlOrNot(context.getConnectionWithDefaultRole(), queryCubeA, sqlPatterns, false, false, true);
     }
 
     private boolean dialectAllowsSelectNotInGroupBy(Connection connection) {

--- a/mondrian/src/test/java/mondrian/rolap/sql/SqlQueryTest.java
+++ b/mondrian/src/test/java/mondrian/rolap/sql/SqlQueryTest.java
@@ -114,7 +114,7 @@ class SqlQueryTest  extends BatchTestCase {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testToStringForSingleGroupingSetSql(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         prepareContext(connection);
         if (!isGroupingSetsSupported(connection)) {
             return;
@@ -163,7 +163,7 @@ class SqlQueryTest  extends BatchTestCase {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testOrderBy(Context context) throws SQLException {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         prepareContext(connection);
         // Test with requireAlias = true
         assertEquals(
@@ -218,7 +218,7 @@ class SqlQueryTest  extends BatchTestCase {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testToStringForForcedIndexHint(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         prepareContext(connection);
         Map<String, String> hints = new HashMap<>();
         hints.put("force_index", "myIndex");
@@ -312,7 +312,7 @@ class SqlQueryTest  extends BatchTestCase {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testPredicatesAreOptimizedWhenPropertyIsTrue(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         prepareContext(connection);
         if (context.getConfig().readAggregates() && context.getConfig().useAggregates()) {
             // Sql pattner will be different if using aggregate tables.
@@ -358,7 +358,7 @@ class SqlQueryTest  extends BatchTestCase {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testTableNameIsIncludedWithParentChildQuery(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         prepareContext(connection);
         String sql =
             "select `employee`.`employee_id` as `c0`, "
@@ -393,13 +393,13 @@ class SqlQueryTest  extends BatchTestCase {
         SqlPattern[] sqlPatterns = {
             new SqlPattern(DatabaseProduct.ACCESS, sql, sql)
         };
-        assertQuerySql(context.getConnection(), mdx, sqlPatterns);
+        assertQuerySql(context.getConnectionWithDefaultRole(), mdx, sqlPatterns);
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testPredicatesAreNotOptimizedWhenPropertyIsFalse(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         prepareContext(connection);
         if (context.getConfig().readAggregates() && context.getConfig().useAggregates()) {
             // Sql pattner will be different if using aggregate tables.
@@ -446,7 +446,7 @@ class SqlQueryTest  extends BatchTestCase {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testPredicatesAreOptimizedWhenAllTheMembersAreIncluded(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         prepareContext(connection);
         if (context.getConfig().readAggregates() && context.getConfig().useAggregates()) {
             // Sql pattner will be different if using aggregate tables.
@@ -499,7 +499,7 @@ class SqlQueryTest  extends BatchTestCase {
 
         try {
             ((TestConfig)context.getConfig()).setOptimizePredicates(optimizePredicatesValue);
-            assertQuerySql(context.getConnection(), inputMdx, sqlPatterns);
+            assertQuerySql(context.getConnectionWithDefaultRole(), inputMdx, sqlPatterns);
         } finally {
             ((TestConfig)context.getConfig()).setOptimizePredicates(intialValueOptimize);
         }
@@ -508,7 +508,7 @@ class SqlQueryTest  extends BatchTestCase {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testToStringForGroupingSetSqlWithEmptyGroup(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         prepareContext(connection);
         if (!isGroupingSetsSupported(connection)) {
             return;
@@ -560,7 +560,7 @@ class SqlQueryTest  extends BatchTestCase {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testToStringForMultipleGroupingSetsSql(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         prepareContext(connection);
         if (!isGroupingSetsSupported(connection)) {
             return;
@@ -629,9 +629,9 @@ class SqlQueryTest  extends BatchTestCase {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDoubleInList(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         prepareContext(connection);
-        final Dialect dialect = getDialect(context.getConnection());
+        final Dialect dialect = getDialect(context.getConnectionWithDefaultRole());
         if (getDatabaseProduct(dialect.getDialectName()) != DatabaseProduct.LUCIDDB) {
             return;
         }
@@ -772,7 +772,7 @@ class SqlQueryTest  extends BatchTestCase {
         withSchema(context, schema);
          */
         withSchema(context, TestDoubleInListModifier::new);
-        assertQuerySql(context.getConnection(), query, patterns);
+        assertQuerySql(context.getConnectionWithDefaultRole(), query, patterns);
     }
 
     /**
@@ -787,7 +787,7 @@ class SqlQueryTest  extends BatchTestCase {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testInvalidSqlMemberLookup(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         prepareContext(connection);
         String sqlMySql =
             "select `store`.`store_type` as `c0` from `store` as `store` "
@@ -822,7 +822,7 @@ class SqlQueryTest  extends BatchTestCase {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testApproxRowCountOverridesCount(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         prepareContext(connection);
         final String cubeSchema =
             "<Cube name=\"ApproxTest\"> \n"
@@ -911,7 +911,7 @@ class SqlQueryTest  extends BatchTestCase {
          */
         withSchema(context, TestApproxRowCountOverridesCountModifier::new);
         assertQuerySqlOrNot(
-        	context.getConnection(),
+        	context.getConnectionWithDefaultRole(),
             mdxQuery,
             patterns,
             true,
@@ -922,7 +922,7 @@ class SqlQueryTest  extends BatchTestCase {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testLimitedRollupMemberRetrievableFromCache(Context context) throws Exception {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         prepareContext(connection);
         final String mdx =
             "select NON EMPTY { [Store].[Store].[Store State].members } on 0 from [Sales]";
@@ -1023,7 +1023,7 @@ class SqlQueryTest  extends BatchTestCase {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testAvgAggregator(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         prepareContext(connection);
         ((TestConfig)context.getConfig()).setGenerateFormattedSql(true);
         /*
@@ -1038,7 +1038,7 @@ class SqlQueryTest  extends BatchTestCase {
         withSchema(context, SchemaModifiers.SqlQueryTestModifier::new);
         String mdx = "select measures.[avg sales] on 0 from sales"
                        + " where { time.[1997].q1, time.[1997].q2.[4] }";
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             mdx,
             "Axis #0:\n"
             + "{[Time].[1997].[Q1]}\n"
@@ -1060,7 +1060,7 @@ class SqlQueryTest  extends BatchTestCase {
             + "and `time_by_day`.`the_year` = 1997))";
         SqlPattern mySqlPattern =
             new SqlPattern(DatabaseProduct.MYSQL, sql, sql.length());
-        assertQuerySql(context.getConnection(), mdx, new SqlPattern[]{mySqlPattern});
+        assertQuerySql(context.getConnectionWithDefaultRole(), mdx, new SqlPattern[]{mySqlPattern});
     }
 
     private boolean isGroupingSetsSupported(Connection connection) {

--- a/mondrian/src/test/java/mondrian/test/AccessControlTest.java
+++ b/mondrian/src/test/java/mondrian/test/AccessControlTest.java
@@ -100,7 +100,7 @@ class AccessControlTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testSchemaReader(Context foodMartContext) {
-        final Connection connection = foodMartContext.getConnection();
+        final Connection connection = foodMartContext.getConnectionWithDefaultRole();
         Schema schema = connection.getSchema();
         final boolean fail = true;
         Cube cube = schema.lookupCube("Sales", fail);
@@ -115,7 +115,7 @@ class AccessControlTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testGrantDimensionNone(Context foodMartContext) {
-        final Connection connection = foodMartContext.getConnection();
+        final Connection connection = foodMartContext.getConnectionWithDefaultRole();
         RoleImpl role = ((RoleImpl) connection.getRole()).makeMutableClone();
         Schema schema = connection.getSchema();
         Cube salesCube = schema.lookupCube("Sales", true);
@@ -140,7 +140,7 @@ class AccessControlTest {
         TestUtil.withSchema(foodMartContext, SchemaModifiers.AccessControlTestModifier31::new);
 
         ConnectionProps props = new RolapConnectionPropsR(List.of("Role1"), true, Locale.getDefault(), Duration.ofSeconds(-1), Optional.empty(), Optional.empty());
-    	Connection connection = foodMartContext.getConnection();
+    	Connection connection = foodMartContext.getConnectionWithDefaultRole();
 
         TestUtil.assertQueryReturns(
     		connection,
@@ -849,7 +849,7 @@ class AccessControlTest {
             + "Row #1: 187\n");
 
         TestUtil.assertQueryReturns(
-        	foodMartContext.getConnection(),
+        	foodMartContext.getConnectionWithDefaultRole(),
             "select NON EMPTY {[Measures].[Unit Sales]} ON COLUMNS, \n"
             + "  NON EMPTY TopCount([Store].[USA].[CA].Children, 10, "
             + "           [Measures].[Unit Sales]) ON ROWS \n"
@@ -894,7 +894,7 @@ class AccessControlTest {
             + "Row #1: 337\n");
 
         TestUtil.assertQueryReturns(
-        	foodMartContext.getConnection(),
+        	foodMartContext.getConnectionWithDefaultRole(),
             "select NON EMPTY {[Measures].[Unit Sales]} ON COLUMNS, \n"
             + "  NON EMPTY TopCount([Store].[USA].[CA].Children, 10, "
             + "           [Measures].[Unit Sales]) ON ROWS \n"
@@ -979,7 +979,7 @@ class AccessControlTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     public void _testSharedObjectsInGrantMappingsBug(Context foodMartContext) {
         boolean mustGet = true;
-        Connection connection = foodMartContext.getConnection();
+        Connection connection = foodMartContext.getConnectionWithDefaultRole();
         Schema schema = connection.getSchema();
         Cube salesCube = schema.lookupCube("Sales", mustGet);
         Cube warehouseCube = schema.lookupCube("Warehouse", mustGet);
@@ -1029,7 +1029,7 @@ class AccessControlTest {
      * @return restricted connection
      */
     private Connection getRestrictedConnection(Context foodMartContext, boolean restrictCustomers) {
-        Connection connection = foodMartContext.getConnection();
+        Connection connection = foodMartContext.getConnectionWithDefaultRole();
         RoleImpl role = new RoleImpl();
         Schema schema = connection.getSchema();
         final boolean fail = true;
@@ -1196,7 +1196,7 @@ class AccessControlTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testUnusedAccessControlledDimension(Context foodMartContext) {
-        Connection connection = foodMartContext.getConnection();
+        Connection connection = foodMartContext.getConnectionWithDefaultRole();
         TestUtil.assertQueryReturns(
     		connection,
             "select [Gender].Children on 0 from [Sales]",
@@ -1533,7 +1533,7 @@ class AccessControlTest {
             + "{[Customers].[USA].Children,\n"
             + " [Customers].[USA].[OR].Children}) on 0\n"
             + "from [Sales]";
-        connection = foodMartContext.getConnection();
+        connection = foodMartContext.getConnectionWithDefaultRole();
         TestUtil.assertQueryReturns(
     		connection,
             mdx,
@@ -2011,7 +2011,7 @@ class AccessControlTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testParentChildUserDefinedRole(Context foodMartContext)
     {
-        final Connection connection = foodMartContext.getConnection();
+        final Connection connection = foodMartContext.getConnectionWithDefaultRole();
         final Role savedRole = connection.getRole();
         try {
             // Run queries as top-level employee.
@@ -2420,7 +2420,7 @@ class AccessControlTest {
         StringBuilder buf = new StringBuilder();
         StringBuilder buf2 = new StringBuilder();
         final String cubeName = "Sales with multiple customers";
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         final Result result = TestUtil.executeQuery(
     		connection,
             "select [Customers].[City].Members on 0 from [Sales]");
@@ -2564,7 +2564,7 @@ class AccessControlTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testCalcMemberLevel(Context foodMartContext) {
-    	Connection connection = foodMartContext.getConnection();
+    	Connection connection = foodMartContext.getConnectionWithDefaultRole();
         checkCalcMemberLevel(connection);
         TestUtil.withSchema(foodMartContext, SchemaModifiers.AccessControlTestModifier16::new);
         ConnectionProps props = new RolapConnectionPropsR(List.of("Role1"), true, Locale.getDefault(), Duration.ofSeconds(-1), Optional.empty(), Optional.empty());
@@ -3119,7 +3119,7 @@ class AccessControlTest {
             + "From [Sales]\n";
 
         TestUtil.withSchema(foodMartContext, SchemaModifiers.AccessControlTestModifier24::new);
-        Connection connection = foodMartContext.getConnection();
+        Connection connection = foodMartContext.getConnectionWithDefaultRole();
 
         // Control
         TestUtil

--- a/mondrian/src/test/java/mondrian/test/BasicQueryTest.java
+++ b/mondrian/src/test/java/mondrian/test/BasicQueryTest.java
@@ -297,37 +297,37 @@ public class BasicQueryTest {
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testSample0(Context context) {
-    assertQueryReturns(context.getConnection(), sampleQueries[0].query, sampleQueries[0].result );
+    assertQueryReturns(context.getConnectionWithDefaultRole(), sampleQueries[0].query, sampleQueries[0].result );
   }
 
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testSample1(Context context) {
-    assertQueryReturns(context.getConnection(), sampleQueries[1].query, sampleQueries[1].result );
+    assertQueryReturns(context.getConnectionWithDefaultRole(), sampleQueries[1].query, sampleQueries[1].result );
   }
 
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testSample2(Context context) {
-    assertQueryReturns(context.getConnection(), sampleQueries[2].query, sampleQueries[2].result );
+    assertQueryReturns(context.getConnectionWithDefaultRole(), sampleQueries[2].query, sampleQueries[2].result );
   }
 
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testSample3(Context context) {
-    assertQueryReturns(context.getConnection(), sampleQueries[3].query, sampleQueries[3].result );
+    assertQueryReturns(context.getConnectionWithDefaultRole(), sampleQueries[3].query, sampleQueries[3].result );
   }
 
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testSample4(Context context) {
-    assertQueryReturns(context.getConnection(), sampleQueries[4].query, sampleQueries[4].result );
+    assertQueryReturns(context.getConnectionWithDefaultRole(), sampleQueries[4].query, sampleQueries[4].result );
   }
 
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testSample5(Context context) {
-    assertQueryReturns(context.getConnection(),  sampleQueries[5].query, sampleQueries[5].result );
+    assertQueryReturns(context.getConnectionWithDefaultRole(),  sampleQueries[5].query, sampleQueries[5].result );
   }
 
   @ParameterizedTest
@@ -335,7 +335,7 @@ public class BasicQueryTest {
   void testSample5Snowflake(Context context) {
     SystemWideProperties.instance().FilterChildlessSnowflakeMembers = false;
     //final TestContext context = getTestContext().withFreshConnection();
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     try {
       assertQueryReturns(connection, sampleQueries[5].query, "Axis #0:\n" + "{[Time].[1997]}\n" + "Axis #1:\n"
           + "{[Measures].[Store Cost]}\n" + "{[Measures].[Store Sales]}\n" + "{[Measures].[Store Profit Rate]}\n"
@@ -377,19 +377,19 @@ public class BasicQueryTest {
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testSample6(Context context) {
-    assertQueryReturns(context.getConnection(), sampleQueries[6].query, sampleQueries[6].result );
+    assertQueryReturns(context.getConnectionWithDefaultRole(), sampleQueries[6].query, sampleQueries[6].result );
   }
 
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testSample7(Context context) {
-    assertQueryReturns(context.getConnection(), sampleQueries[7].query, sampleQueries[7].result );
+    assertQueryReturns(context.getConnectionWithDefaultRole(), sampleQueries[7].query, sampleQueries[7].result );
   }
 
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testSample8(Context context) {
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     if (getDatabaseProduct(TestUtil.getDialect(connection).getDialectName()) == DatabaseProduct.INFOBRIGHT ) {
       // Skip this test on Infobright, because [Promotion Sales] is
       // defined wrong.
@@ -401,7 +401,7 @@ public class BasicQueryTest {
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testGoodComments(Context context) {
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     assertQueryReturns(connection, "SELECT {} ON ROWS, {} ON COLUMNS FROM [Sales]/* trailing comment*/", EmptyResult );
 
     String[] comments = { "-- a basic comment\n",
@@ -536,7 +536,7 @@ public class BasicQueryTest {
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testBadComments(Context context) {
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     // Comments cannot appear inside identifiers.
     assertQueryThrows(connection, "SELECT {[Measures].[Unit Sales]} ON COLUMNS,\n" + " {[Gender].MEMBERS} ON ROWS\n"
         + "FROM [Sales]\n" + "WHERE {[/***an illegal comment****/Marital Status].[S]}", "Failed to parse query" );
@@ -557,7 +557,7 @@ public class BasicQueryTest {
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testBothAxesEmpty(Context context) {
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     assertQueryReturns(connection, "SELECT {} ON ROWS, {} ON COLUMNS FROM [Sales]", EmptyResult );
 
     // expression which evaluates to empty set
@@ -576,7 +576,7 @@ public class BasicQueryTest {
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testCompoundSlicer(Context context) {
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     // two tuples
     assertQueryReturns(connection, "SELECT {[Measures].[Unit Sales]} ON COLUMNS,\n" + " {[Gender].MEMBERS} ON ROWS\n"
         + "FROM [Sales]\n" + "WHERE {([Marital Status].[S]),\n" + "       ([Marital Status].[M])}", "Axis #0:\n"
@@ -689,7 +689,7 @@ public class BasicQueryTest {
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testCompoundSlicerNonEmpty(Context context) {
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     // With MONDRIAN-814, cell totals would be about a factor of 4 smaller,
     // and the number of rows returned would be the same (1220) if 21, 22
     // and 23 were removed from the slicer.
@@ -711,7 +711,7 @@ public class BasicQueryTest {
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testEmptyTupleSlicerFails(Context context) {
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     assertQueryThrows(connection, "select [Measures].[Unit Sales] on 0,\n" + "[Product].Children on 1\n"
         + "from [Warehouse and Sales]\n" + "where ()", "Encountered an error at (or somewhere around) input:4:8" );
   }
@@ -724,7 +724,7 @@ public class BasicQueryTest {
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testBigQuery(Context context) {
     Result result =
-        executeQuery( context.getConnection(), "SELECT {[Measures].[Unit Sales]} on columns,\n" + " {[Product].members} on rows\n"
+        executeQuery( context.getConnectionWithDefaultRole(), "SELECT {[Measures].[Unit Sales]} on columns,\n" + " {[Product].members} on rows\n"
             + "from Sales" );
     final int rowCount = result.getAxes()[1].getPositions().size();
     assertEquals( SystemWideProperties.instance().FilterChildlessSnowflakeMembers ? 2256 : 2266, rowCount );
@@ -741,7 +741,7 @@ public class BasicQueryTest {
       return;
     }
     Result result =
-        executeQuery(context.getConnection(), "select [Gender].Members on 0,\n" + "[Time].[Weekly].[1997].[6].Children on 1\n"
+        executeQuery(context.getConnectionWithDefaultRole(), "select [Gender].Members on 0,\n" + "[Time].[Weekly].[1997].[6].Children on 1\n"
             + "from [Sales]\n" + "where [Marital Status].[S]" );
     final Cell cell = result.getCell( new int[] { 0, 0 } );
     final Map<String, Hierarchy> hierarchyMap = new HashMap<>();
@@ -763,7 +763,7 @@ public class BasicQueryTest {
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testNonEmpty1(Context context) {
-    assertSize(context.getConnection(), "select\n" + "  NON EMPTY CrossJoin({[Product].[All Products].[Drink].Children},\n"
+    assertSize(context.getConnectionWithDefaultRole(), "select\n" + "  NON EMPTY CrossJoin({[Product].[All Products].[Drink].Children},\n"
         + "    {[Customers].[All Customers].[USA].[WA].[Bellingham]}) on rows,\n" + "  CrossJoin(\n"
         + "    {[Measures].[Unit Sales], [Measures].[Store Sales]},\n"
         + "    { [Promotion Media].[All Media].[Radio],\n" + "      [Promotion Media].[All Media].[TV],\n"
@@ -775,7 +775,7 @@ public class BasicQueryTest {
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testNonEmpty2(Context context) {
-    assertSize(context.getConnection(), "select\n" + "  NON EMPTY CrossJoin(\n" + "    {[Product].[All Products].Children},\n"
+    assertSize(context.getConnectionWithDefaultRole(), "select\n" + "  NON EMPTY CrossJoin(\n" + "    {[Product].[All Products].Children},\n"
         + "    {[Customers].[All Customers].[USA].[WA].[Bellingham]}) on rows,\n" + "  NON EMPTY CrossJoin(\n"
         + "    {[Measures].[Unit Sales]},\n" + "    { [Promotion Media].[All Media].[Cash Register Handout],\n"
         + "      [Promotion Media].[All Media].[Sunday Paper],\n"
@@ -787,7 +787,7 @@ public class BasicQueryTest {
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testOneDimensionalQueryWithTupleAsSlicer(Context context) {
     Result result =
-        executeQuery(context.getConnection(), "select\n" + "  [Product].[All Products].[Drink].children on columns\n" + "from Sales\n"
+        executeQuery(context.getConnectionWithDefaultRole(), "select\n" + "  [Product].[All Products].[Drink].children on columns\n" + "from Sales\n"
             + "where ([Measures].[Unit Sales], [Promotion Media].[All Media].[Street Handout], [Time].[1997])" );
     assertTrue( result.getAxes().length == 1 );
     assertTrue( result.getAxes()[0].getPositions().size() == 3 );
@@ -799,7 +799,7 @@ public class BasicQueryTest {
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testSlicerIsEvaluatedBeforeAxes(Context context) {
     // about 10 products exceeded 20000 units in 1997, only 2 for Q1
-    assertSize(context.getConnection(), "SELECT {[Measures].[Unit Sales]} on columns,\n"
+    assertSize(context.getConnectionWithDefaultRole(), "SELECT {[Measures].[Unit Sales]} on columns,\n"
         + " filter({[Product].members}, [Measures].[Unit Sales] > 20000) on rows\n" + "FROM Sales\n"
         + "WHERE [Time].[1997].[Q1]", 1, 2 );
   }
@@ -807,7 +807,7 @@ public class BasicQueryTest {
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testSlicerWithCalculatedMembers(Context context) {
-    assertSize(context.getConnection(), "WITH Member [Time].[Time].[1997].[H1] as ' Aggregate({[Time].[1997].[Q1], [Time].[1997].[Q2]})' \n"
+    assertSize(context.getConnectionWithDefaultRole(), "WITH Member [Time].[Time].[1997].[H1] as ' Aggregate({[Time].[1997].[Q1], [Time].[1997].[Q2]})' \n"
         + "  MEMBER [Measures].[Store Margin] as '[Measures].[Store Sales] - [Measures].[Store Cost]'\n"
         + "SELECT {[Gender].members} on columns,\n" + " filter({[Product].members}, [Gender].[F] > 10000) on rows\n"
         + "FROM Sales\n" + "WHERE ([Time].[1997].[H1], [Measures].[Store Margin])", 3, 6 );
@@ -818,14 +818,14 @@ public class BasicQueryTest {
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   public void _testEver(Context context) {
-    assertQueryReturns(context.getConnection(), "select\n" + " {[Measures].[Unit Sales], [Measures].[Ever]} on columns,\n"
+    assertQueryReturns(context.getConnectionWithDefaultRole(), "select\n" + " {[Measures].[Unit Sales], [Measures].[Ever]} on columns,\n"
         + " [Gender].members on rows\n" + "from Sales", "xxx" );
   }
 
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   public void _testDairy(Context context) {
-    assertQueryReturns(context.getConnection(), "with\n"
+    assertQueryReturns(context.getConnectionWithDefaultRole(), "with\n"
         + "  member [Product].[Non dairy] as '[Product].[All Products] - [Product].[Food].[Dairy]'\n"
         + "  member [Measures].[Dairy ever] as 'sum([Time].members, ([Measures].[Unit Sales],[Product].[Food]"
         + ".[Dairy]))'\n"
@@ -843,7 +843,7 @@ public class BasicQueryTest {
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testSolveOrder(Context context) {
-    assertQueryReturns(context.getConnection(), "WITH\n" + "   MEMBER [Measures].[StoreType] AS \n"
+    assertQueryReturns(context.getConnectionWithDefaultRole(), "WITH\n" + "   MEMBER [Measures].[StoreType] AS \n"
         + "   '[Store].CurrentMember.Properties(\"Store Type\")',\n" + "   SOLVE_ORDER = 2\n"
         + "   MEMBER [Measures].[ProfitPct] AS \n"
         + "   '(Measures.[Store Sales] - Measures.[Store Cost]) / Measures.[Store Sales]',\n"
@@ -881,7 +881,7 @@ public class BasicQueryTest {
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testSolveOrderNonMeasure(Context context) {
-    assertQueryReturns(context.getConnection(), "WITH\n" + "   MEMBER [Product].[ProdCalc] as '1', SOLVE_ORDER=1\n"
+    assertQueryReturns(context.getConnectionWithDefaultRole(), "WITH\n" + "   MEMBER [Product].[ProdCalc] as '1', SOLVE_ORDER=1\n"
         + "   MEMBER [Measures].[MeasuresCalc] as '2', SOLVE_ORDER=2\n"
         + "   Member [Time].[Time].[1997].[TimeCalc] as '3', SOLVE_ORDER=3\n" + "SELECT\n"
         + "   { [Product].[ProdCalc] } ON columns,\n" + "   {([Time].[1997].[TimeCalc],\n"
@@ -894,7 +894,7 @@ public class BasicQueryTest {
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testSolveOrderNonMeasure2(Context context) {
-    assertQueryReturns(context.getConnection(), "WITH\n" + "   MEMBER [Store].[StoreCalc] as '0', SOLVE_ORDER=0\n"
+    assertQueryReturns(context.getConnectionWithDefaultRole(), "WITH\n" + "   MEMBER [Store].[StoreCalc] as '0', SOLVE_ORDER=0\n"
         + "   MEMBER [Product].[ProdCalc] as '1', SOLVE_ORDER=1\n" + "SELECT\n"
         + "   { [Product].[ProdCalc] } ON columns,\n" + "   { [Store].[StoreCalc] } ON rows\n" + "FROM Sales",
 
@@ -913,7 +913,7 @@ public class BasicQueryTest {
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testSolveOrderAmbiguous1(Context context) {
-    assertQueryReturns(context.getConnection(), "WITH\n" + "   MEMBER [Promotions].[Calc] AS '1'\n" + "   MEMBER [Customers].[Calc] AS '2'\n"
+    assertQueryReturns(context.getConnectionWithDefaultRole(), "WITH\n" + "   MEMBER [Promotions].[Calc] AS '1'\n" + "   MEMBER [Customers].[Calc] AS '2'\n"
         + "SELECT\n" + "   { [Promotions].[Calc] } ON COLUMNS,\n" + "   {  [Customers].[Calc] } ON ROWS\n"
         + "FROM Sales",
 
@@ -927,7 +927,7 @@ public class BasicQueryTest {
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testSolveOrderAmbiguous2(Context context) {
-    assertQueryReturns(context.getConnection(), "WITH\n" + "   MEMBER [Promotions].[Calc] AS '1'\n" + "   MEMBER [Product].[Calc] AS '2'\n"
+    assertQueryReturns(context.getConnectionWithDefaultRole(), "WITH\n" + "   MEMBER [Promotions].[Calc] AS '1'\n" + "   MEMBER [Product].[Calc] AS '2'\n"
         + "SELECT\n" + "   { [Promotions].[Calc] } ON COLUMNS,\n" + "   { [Product].[Calc] } ON ROWS\n" + "FROM Sales",
 
         "Axis #0:\n" + "{}\n" + "Axis #1:\n" + "{[Promotions].[Calc]}\n" + "Axis #2:\n" + "{[Product].[Calc]}\n"
@@ -937,7 +937,7 @@ public class BasicQueryTest {
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testCalculatedMemberWhichIsNotAMeasure(Context context) {
-    assertQueryReturns(context.getConnection(), "WITH MEMBER [Product].[BigSeller] AS\n"
+    assertQueryReturns(context.getConnectionWithDefaultRole(), "WITH MEMBER [Product].[BigSeller] AS\n"
         + "  'IIf([Product].[Drink].[Alcoholic Beverages].[Beer and Wine] > 100, \"Yes\",\"No\")'\n"
         + "SELECT {[Product].[BigSeller],[Product].children} ON COLUMNS,\n"
         + "   {[Store].[USA].[CA].children} ON ROWS\n" + "FROM Sales", "Axis #0:\n" + "{}\n" + "Axis #1:\n"
@@ -954,7 +954,7 @@ public class BasicQueryTest {
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testMultipleCalculatedMembersWhichAreNotMeasures(Context context) {
-    assertQueryReturns(context.getConnection(), "WITH\n" + "  MEMBER [Store].[x] AS '1'\n" + "  MEMBER [Product].[x] AS '1'\n"
+    assertQueryReturns(context.getConnectionWithDefaultRole(), "WITH\n" + "  MEMBER [Store].[x] AS '1'\n" + "  MEMBER [Product].[x] AS '1'\n"
         + "SELECT {[Store].[x]} ON COLUMNS\n" + "FROM Sales", "Axis #0:\n" + "{}\n" + "Axis #1:\n" + "{[Store].[x]}\n"
             + "Row #0: 1\n" );
   }
@@ -971,7 +971,7 @@ public class BasicQueryTest {
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testMultipleCalculatedMembersWhichAreNotMeasures2(Context context) {
-    assertQueryReturns( context.getConnection(),"WITH\n" + "  MEMBER [Product].[x] AS '1'\n" + "  MEMBER [Store].[x] AS '1'\n"
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"WITH\n" + "  MEMBER [Product].[x] AS '1'\n" + "  MEMBER [Store].[x] AS '1'\n"
         + "SELECT {[Store].[x]} ON COLUMNS\n" + "FROM Sales", "Axis #0:\n" + "{}\n" + "Axis #1:\n" + "{[Store].[x]}\n"
             + "Row #0: 1\n" );
   }
@@ -983,7 +983,7 @@ public class BasicQueryTest {
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testMultipleCalculatedMembersWhichAreNotMeasures3(Context context) {
-    assertQueryReturns( context.getConnection(),"WITH\n" + "  MEMBER [Product].[x] AS '1'\n" + "  MEMBER [Store].[x] AS '1'\n"
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"WITH\n" + "  MEMBER [Product].[x] AS '1'\n" + "  MEMBER [Store].[x] AS '1'\n"
         + "SELECT {[Store].[x]} ON COLUMNS\n" + "FROM Sales", "Axis #0:\n" + "{}\n" + "Axis #1:\n" + "{[Store].[x]}\n"
             + "Row #0: 1\n" );
   }
@@ -991,21 +991,21 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testConstantString(Context context) {
-    String s = executeExpr(context.getConnection(), " \"a string\" " );
+    String s = executeExpr(context.getConnectionWithDefaultRole(), " \"a string\" " );
     assertEquals( "a string", s );
   }
 
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testConstantNumber(Context context) {
-    String s = executeExpr(context.getConnection(), " 1234 " );
+    String s = executeExpr(context.getConnectionWithDefaultRole(), " 1234 " );
     assertEquals( "1,234", s );
   }
 
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testCyclicalCalculatedMembers(Context context) {
-     executeQuery(context.getConnection(), "WITH\n" + "   MEMBER [Product].[X] AS '[Product].[Y]'\n"
+     executeQuery(context.getConnectionWithDefaultRole(), "WITH\n" + "   MEMBER [Product].[X] AS '[Product].[Y]'\n"
         + "   MEMBER [Product].[Y] AS '[Product].[X]'\n" + "SELECT\n" + "   {[Product].[X]} ON COLUMNS,\n"
         + "   {Store.[Store Name].Members} ON ROWS\n" + "FROM Sales" ) ;
   }
@@ -1018,7 +1018,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testCycle(Context context) {
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     if ( false ) {
       assertExprThrows(connection, "[Time].[1997].[Q4]", "infinite loop" );
     } else {
@@ -1030,7 +1030,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testHalfYears(Context context) {
-    executeQuery(context.getConnection(), "WITH MEMBER [Measures].[ProfitPercent] AS\n"
+    executeQuery(context.getConnectionWithDefaultRole(), "WITH MEMBER [Measures].[ProfitPercent] AS\n"
         + "     '([Measures].[Store Sales]-[Measures].[Store Cost])/([Measures].[Store Cost])',\n"
         + " FORMAT_STRING = '#.00%', SOLVE_ORDER = 1\n"
         + " Member [Time].[Time].[1997].[First Half] AS  '[Time].[1997].[Q1] + [Time].[1997].[Q2]'\n"
@@ -1041,7 +1041,7 @@ public class BasicQueryTest {
   }
 
   public void _testHalfYearsTrickyCase(Context context) {
-    executeQuery(context.getConnection(), "WITH MEMBER MEASURES.ProfitPercent AS\n"
+    executeQuery(context.getConnectionWithDefaultRole(), "WITH MEMBER MEASURES.ProfitPercent AS\n"
         + "     '([Measures].[Store Sales]-[Measures].[Store Cost])/([Measures].[Store Cost])',\n"
         + " FORMAT_STRING = '#.00%', SOLVE_ORDER = 1\n"
         + " Member [Time].[Time].[First Half 97] AS  '[Time].[1997].[Q1] + [Time].[1997].[Q2]'\n"
@@ -1054,7 +1054,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testAsSample7ButUsingVirtualCube(Context context) {
-    executeQuery(context.getConnection(), "with member [Measures].[Accumulated Sales] as 'Sum(YTD(),[Measures].[Store Sales])'\n"
+    executeQuery(context.getConnectionWithDefaultRole(), "with member [Measures].[Accumulated Sales] as 'Sum(YTD(),[Measures].[Store Sales])'\n"
         + "select\n" + "    {[Measures].[Store Sales],[Measures].[Accumulated Sales]} on columns,\n"
         + "    {Descendants([Time].[1997],[Time].[Month])} on rows\n" + "from [Warehouse and Sales]" );
   }
@@ -1062,7 +1062,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testVirtualCube(Context context) {
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
         // Note that Unit Sales is independent of Warehouse.
         "select CrossJoin(\n" + "  {[Warehouse].DefaultMember, [Warehouse].[USA].children},\n"
             + "  {[Measures].[Unit Sales], [Measures].[Store Sales], [Measures].[Units Shipped]}) on columns,\n"
@@ -1094,17 +1094,17 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testUseDimensionAsShorthandForMember(Context context) {
- executeQuery(context.getConnection(), "select {[Measures].[Unit Sales]} on columns,\n"
+ executeQuery(context.getConnectionWithDefaultRole(), "select {[Measures].[Unit Sales]} on columns,\n"
         + " {[Store], [Store].children} on rows\n" + "from [Sales]" ) ;
   }
 
   public void _testMembersFunction(Context context) {
-    executeQuery(context.getConnection(), "select {[Measures].[Unit Sales]} on columns,\n"
+    executeQuery(context.getConnectionWithDefaultRole(), "select {[Measures].[Unit Sales]} on columns,\n"
         + " {[Customers].members(0)} on rows\n" + "from [Sales]" ) ;
   }
 
   public void _testProduct2(Context context) {
-    final Axis axis = executeAxis(context.getConnection(), "{[Product2].members}" );
+    final Axis axis = executeAxis(context.getConnectionWithDefaultRole(), "{[Product2].members}" );
     System.out.println( TestUtil.toString( axis.getPositions() ) );
   }
 
@@ -1362,44 +1362,44 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testTaglib0(Context context) {
-    assertQueryReturns( context.getConnection(),taglibQueries.get( 0 ).query, taglibQueries.get( 0 ).result );
+    assertQueryReturns( context.getConnectionWithDefaultRole(),taglibQueries.get( 0 ).query, taglibQueries.get( 0 ).result );
   }
 
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testTaglib1(Context context) {
-    assertQueryReturns( context.getConnection(),taglibQueries.get( 1 ).query, taglibQueries.get( 1 ).result );
+    assertQueryReturns( context.getConnectionWithDefaultRole(),taglibQueries.get( 1 ).query, taglibQueries.get( 1 ).result );
   }
 
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testTaglib2(Context context) {
-    assertQueryReturns( context.getConnection(),taglibQueries.get( 2 ).query, taglibQueries.get( 2 ).result );
+    assertQueryReturns( context.getConnectionWithDefaultRole(),taglibQueries.get( 2 ).query, taglibQueries.get( 2 ).result );
   }
 
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testTaglib3(Context context) {
-    assertQueryReturns( context.getConnection(),taglibQueries.get( 3 ).query, taglibQueries.get( 3 ).result );
+    assertQueryReturns( context.getConnectionWithDefaultRole(),taglibQueries.get( 3 ).query, taglibQueries.get( 3 ).result );
   }
 
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testTaglib4(Context context) {
-    assertQueryReturns( context.getConnection(),taglibQueries.get( 4 ).query, taglibQueries.get( 4 ).result );
+    assertQueryReturns( context.getConnectionWithDefaultRole(),taglibQueries.get( 4 ).query, taglibQueries.get( 4 ).result );
   }
 
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testTaglib5(Context context) {
-    assertQueryReturns( context.getConnection(),taglibQueries.get( 5 ).query, taglibQueries.get( 5 ).result );
+    assertQueryReturns( context.getConnectionWithDefaultRole(),taglibQueries.get( 5 ).query, taglibQueries.get( 5 ).result );
   }
 
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testCellValue(Context context) {
     Result result =
-        executeQuery(context.getConnection(), "select {[Measures].[Unit Sales],[Measures].[Store Sales]} on columns,\n"
+        executeQuery(context.getConnectionWithDefaultRole(), "select {[Measures].[Unit Sales],[Measures].[Store Sales]} on columns,\n"
             + " {[Gender].[M]} on rows\n" + "from Sales" );
     Cell cell = result.getCell( new int[] { 0, 0 } );
     Object value = cell.getValue();
@@ -1415,7 +1415,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testDynamicFormat(Context context) {
-    assertQueryReturns( context.getConnection(),"with member [Measures].[USales] as [Measures].[Unit Sales],\n"
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"with member [Measures].[USales] as [Measures].[Unit Sales],\n"
         + "  format_string = iif([Measures].[Unit Sales] > 50000, \"\\<b\\>#.00\\<\\/b\\>\", \"\\<i\\>#"
         + ".00\\<\\/i\\>\")\n" + "select \n" + "  {[Measures].[USales]} on columns,\n"
         + "  {[Store Type].members} on rows\n" + "from Sales",
@@ -1432,7 +1432,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testFormatOfNulls(Context context) {
-    assertQueryReturns( context.getConnection(),"with member [Measures]._Foo as '([Measures].[Store Sales])',\n"
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"with member [Measures]._Foo as '([Measures].[Store Sales])',\n"
         + " format_string = '$#,##0.00;($#,##0.00);ZERO;NULL;Nil'\n" + "select\n"
         + " {[Measures].[_Foo]} on columns,\n" + " {[Customers].[Country].members} on rows\n" + "from Sales",
         "Axis #0:\n" + "{}\n" + "Axis #1:\n" + "{[Measures].[_Foo]}\n" + "Axis #2:\n" + "{[Customers].[Canada]}\n"
@@ -1440,7 +1440,7 @@ public class BasicQueryTest {
             + "Row #2: $565,238.13\n" );
 
     // explicit null value
-    assertQueryReturns( context.getConnection(),"with member [Measures].[Foo] as null,\n" + " format_string = 'a;b;c;d'\n"
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"with member [Measures].[Foo] as null,\n" + " format_string = 'a;b;c;d'\n"
         + "select {[Measures].[Foo]} on columns\n" + "from Sales", "Axis #0:\n" + "{}\n" + "Axis #1:\n"
             + "{[Measures].[Foo]}\n" + "Row #0: d\n" );
   }
@@ -1452,7 +1452,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testFormatOfNil(Context context) {
-    assertQueryReturns( context.getConnection(),"with member measures.formatTest as '0.000001',\n" + " FORMAT_STRING='#.##;(#.##)' \n"
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"with member measures.formatTest as '0.000001',\n" + " FORMAT_STRING='#.##;(#.##)' \n"
         + "select { measures.formatTest } on 0 from sales ", "Axis #0:\n" + "{}\n" + "Axis #1:\n"
             + "{[Measures].[formatTest]}\n" + "Row #0: .\n" );
   }
@@ -1465,7 +1465,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testBugMondrian14(Context context) {
-    assertQueryReturns( context.getConnection(),"with member [Measures].[USales] as '[Measures].[Unit Sales]',\n"
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"with member [Measures].[USales] as '[Measures].[Unit Sales]',\n"
         + " format_string = iif([Measures].[Sales Count] > 30, \"#.00 good\",\"#.00 bad\")\n"
         + "select {[Measures].[USales], [Measures].[Store Cost], [Measures].[Store Sales]} ON columns,\n"
         + " Crossjoin({[Promotion Media].[All Media].[Radio], [Promotion Media].[All Media].[TV], [Promotion Media]. "
@@ -1504,7 +1504,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testBugMondrian34(Context context) {
-    assertQueryReturns( context.getConnection(),"with member [Measures].[xxx] as '[Measures].[Store Sales]',\n"
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"with member [Measures].[xxx] as '[Measures].[Store Sales]',\n"
         + " format_string = IIf([Measures].[Unit Sales] > 100000, \"AAA######.00\",\"BBB###.00\")\n"
         + "select {[Measures].[xxx]} ON columns,\n" + " {[Product].children} ON rows\n"
         + "from [Sales] where [Time].[1997]",
@@ -1521,7 +1521,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testBugMondrian36(Context context) {
-    assertQueryReturns( context.getConnection(),"select {[Measures].[Unit Sales]} ON columns,\n" + " {[Gender].Children} ON rows\n"
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"select {[Measures].[Unit Sales]} ON columns,\n" + " {[Gender].Children} ON rows\n"
         + "from [Sales]\n" + "where ([Time].[1997], [Customers])", "Axis #0:\n"
             + "{[Time].[1997], [Customers].[All Customers]}\n" + "Axis #1:\n" + "{[Measures].[Unit Sales]}\n"
             + "Axis #2:\n" + "{[Gender].[F]}\n" + "{[Gender].[M]}\n" + "Row #0: 131,558\n" + "Row #1: 135,215\n" );
@@ -1534,8 +1534,8 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testBugMondrian46(Context context) {
-    TestUtil.flushSchemaCache(context.getConnection());
-    assertQueryReturns( context.getConnection(),"select {[Measures].[Customer Count]} ON columns,\n"
+    TestUtil.flushSchemaCache(context.getConnectionWithDefaultRole());
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"select {[Measures].[Customer Count]} ON columns,\n"
         + "  {([Promotion Media].[All Media], [Product].[All Products])} ON rows\n" + "from [Sales]\n"
         + "where [Time].[1997]", "Axis #0:\n" + "{[Time].[1997]}\n" + "Axis #1:\n" + "{[Measures].[Customer Count]}\n"
             + "Axis #2:\n" + "{[Promotion Media].[All Media], [Product].[All Products]}\n" + "Row #0: 5,581\n" );
@@ -1551,7 +1551,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testStoreCube(Context context) {
-    assertQueryReturns( context.getConnection(),"select {[Measures].members} on columns,\n" + " {[Store Type].members} on rows\n"
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"select {[Measures].members} on columns,\n" + " {[Store Type].members} on rows\n"
         + "from [Store]" + "where [Store].[USA].[CA]",
 
         "Axis #0:\n" + "{[Store].[USA].[CA]}\n" + "Axis #1:\n" + "{[Measures].[Store Sqft]}\n"
@@ -1620,7 +1620,7 @@ public class BasicQueryTest {
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testBugMondrian8(Context context) {
     // minimal test case
-    assertQueryReturns( context.getConnection(),"select {[Measures].[Unit Sales]} ON columns,\n"
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"select {[Measures].[Unit Sales]} ON columns,\n"
         + "{[Product].[All Products].[Drink].[Beverages].[Drinks].[Flavored Drinks].children} ON rows\n"
         + "from [Sales]",
 
@@ -1633,7 +1633,7 @@ public class BasicQueryTest {
             + "Row #1: 469\n" + "Row #2: 506\n" + "Row #3: 466\n" + "Row #4: 560\n" );
 
     // shorter test case
-    executeQuery(context.getConnection(), "select {[Measures].[Unit Sales], [Measures].[Store Cost], [Measures].[Store Sales]} ON columns,"
+    executeQuery(context.getConnectionWithDefaultRole(), "select {[Measures].[Unit Sales], [Measures].[Store Cost], [Measures].[Store Sales]} ON columns,"
         + "ToggleDrillState({"
         + "([Promotion Media].[All Media].[Radio], [Product].[All Products].[Drink].[Beverages].[Drinks].[Flavored "
         + "Drinks])" + "}, {[Product].[All Products].[Drink].[Beverages].[Drinks].[Flavored Drinks]}) ON rows "
@@ -1647,7 +1647,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testBug636687(Context context) {
-    executeQuery(context.getConnection(), "select {[Measures].[Unit Sales], [Measures].[Store Cost],[Measures].[Store Sales]} ON columns, "
+    executeQuery(context.getConnectionWithDefaultRole(), "select {[Measures].[Unit Sales], [Measures].[Store Cost],[Measures].[Store Sales]} ON columns, "
         + "Order(" + "{([Store].[All Stores].[USA].[CA], [Product].[All Products].[Drink].[Alcoholic Beverages]), "
         + "([Store].[All Stores].[USA].[CA], [Product].[All Products].[Drink].[Beverages]), "
         + "Crossjoin({[Store].[All Stores].[USA].[CA].Children}, {[Product].[All Products].[Drink].[Beverages]}), "
@@ -1659,7 +1659,7 @@ public class BasicQueryTest {
         + "([Store].[All Stores].[USA].[WA], [Product].[All Products].[Drink].[Beverages]), "
         + "([Store].[All Stores].[USA].[WA], [Product].[All Products].[Drink].[Dairy])}, "
         + "[Measures].[Store Cost], BDESC) ON rows " + "from [Sales] " + "where ([Time].[1997])" );
-    executeQuery(context.getConnection(), "select {[Measures].[Unit Sales], [Measures].[Store Cost], [Measures].[Store Sales]} ON columns, "
+    executeQuery(context.getConnectionWithDefaultRole(), "select {[Measures].[Unit Sales], [Measures].[Store Cost], [Measures].[Store Sales]} ON columns, "
         + "Order(" + "{([Store].[All Stores].[USA].[WA], [Product].[All Products].[Drink].[Beverages]), "
         + "([Store].[All Stores].[USA].[CA], [Product].[All Products].[Drink].[Beverages]), "
         + "([Store].[All Stores].[USA].[OR], [Product].[All Products].[Drink].[Beverages]), "
@@ -1684,7 +1684,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testBug769114(Context context) {
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
         "select {[Measures].[Unit Sales], [Measures].[Store Cost], [Measures].[Store Sales]} ON columns,\n"
             + " Order(TopCount({[Product].[Product Category].Members}, 10.0, [Measures].[Unit Sales]), [Measures].[Store "
             + "Sales], ASC) ON rows\n" + "from [Sales]\n" + "where [Time].[1997]", "Axis #0:\n" + "{[Time].[1997]}\n"
@@ -1719,7 +1719,7 @@ public class BasicQueryTest {
       return;
     }
     final long start = System.currentTimeMillis();
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     final String queryString =
         "select {[Measures].[Unit Sales],\n" + " [Measures].[Store Cost],\n"
             + " [Measures].[Store Sales]} ON columns,\n"
@@ -1817,7 +1817,7 @@ public class BasicQueryTest {
                 + "</Dimension>", null ));
      */
         withSchema(context, SchemaModifiers.BasicQueryTestModifier1::new);
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
     if ( !TestUtil.getDialect(connection).allowsFromQuery() ) {
       return;
     }
@@ -1854,7 +1854,7 @@ public class BasicQueryTest {
           "ProdAmbiguousLevelName.[All ProdAmbiguousLevelNames].Drink.calc" };
     for ( String withMemberName : alternateReferences ) {
       for ( String queryMemberName : alternateReferences ) {
-        assertQueryReturns(context.getConnection(),"with member " + withMemberName + " as '1' " + " select " + queryMemberName
+        assertQueryReturns(context.getConnectionWithDefaultRole(),"with member " + withMemberName + " as '1' " + " select " + queryMemberName
             + " on 0 from sales", "Axis #0:\n" + "{}\n" + "Axis #1:\n"
                 + "{[ProdAmbiguousLevelName].[Drink].[Drink].[calc]}\n" + "Row #0: 1\n" );
       }
@@ -1873,7 +1873,7 @@ public class BasicQueryTest {
     if ( context.getConfig().readAggregates() ) {
       return;
     }
-    if ( TestUtil.getDialect(context.getConnection()).allowsFromQuery() ) {
+    if ( TestUtil.getDialect(context.getConnectionWithDefaultRole()).allowsFromQuery() ) {
       return;
     }
             /*
@@ -1919,7 +1919,7 @@ public class BasicQueryTest {
              */
         withSchema(context, SchemaModifiers.BasicQueryTestModifier3::new);
 
-        assertQueryReturns( context.getConnection(),"select {[Measures].[Unit Sales]} on columns,\n"
+        assertQueryReturns( context.getConnectionWithDefaultRole(),"select {[Measures].[Unit Sales]} on columns,\n"
         + " {[ProductView].[Drink].[Beverages].children} on rows\n" + "from Sales",
 
         "Axis #0:\n" + "{}\n" + "Axis #1:\n" + "{[Measures].[Unit Sales]}\n" + "Axis #2:\n"
@@ -1933,7 +1933,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testCountDistinct(Context context) {
-    assertQueryReturns( context.getConnection(),"select {[Measures].[Unit Sales], [Measures].[Customer Count]} on columns,\n"
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"select {[Measures].[Unit Sales], [Measures].[Customer Count]} on columns,\n"
         + " {[Gender].members} on rows\n" + "from Sales", "Axis #0:\n" + "{}\n" + "Axis #1:\n"
             + "{[Measures].[Unit Sales]}\n" + "{[Measures].[Customer Count]}\n" + "Axis #2:\n"
             + "{[Gender].[All Gender]}\n" + "{[Gender].[F]}\n" + "{[Gender].[M]}\n" + "Row #0: 266,773\n"
@@ -1953,7 +1953,7 @@ public class BasicQueryTest {
     // turn off caching
         ((TestConfig)context.getConfig()).setDisableCaching(true);
 
-    assertQueryReturns( context.getConnection(),"select {[Measures].[Unit Sales], [Measures].[Customer Count]} on rows,\n"
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"select {[Measures].[Unit Sales], [Measures].[Customer Count]} on rows,\n"
         + "NON EMPTY {[Time].[1997].[Q1].[1]} ON COLUMNS\n" + "from Sales", "Axis #0:\n" + "{}\n" + "Axis #1:\n"
             + "{[Time].[1997].[Q1].[1]}\n" + "Axis #2:\n" + "{[Measures].[Unit Sales]}\n"
             + "{[Measures].[Customer Count]}\n" + "Row #0: 21,628\n" + "Row #1: 1,396\n" );
@@ -1964,7 +1964,7 @@ public class BasicQueryTest {
       ((TestConfig)context.getConfig()).setUseAggregates(true);
     }
 
-    assertQueryReturns( context.getConnection(),"select {[Measures].[Unit Sales], [Measures].[Customer Count]} on rows,\n"
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"select {[Measures].[Unit Sales], [Measures].[Customer Count]} on rows,\n"
         + "NON EMPTY {[Time].[1997].[Q1].[1]} ON COLUMNS\n" + "from Sales", "Axis #0:\n" + "{}\n" + "Axis #1:\n"
             + "{[Time].[1997].[Q1].[1]}\n" + "Axis #2:\n" + "{[Measures].[Unit Sales]}\n"
             + "{[Measures].[Customer Count]}\n" + "Row #0: 21,628\n" + "Row #1: 1,396\n" );
@@ -2005,7 +2005,7 @@ public class BasicQueryTest {
     TestUtil.withSchema(context, SchemaModifiers.BasicQueryTestModifier14::new);
     ((TestConfig)context.getConfig()).setUseAggregates(true);
     ((TestConfig)context.getConfig()).setReadAggregates(true);
-    executeQuery(context.getConnection(), mdx);
+    executeQuery(context.getConnectionWithDefaultRole(), mdx);
   }
 
     @ParameterizedTest
@@ -2043,7 +2043,7 @@ public class BasicQueryTest {
     ((TestConfig)context.getConfig()).setReadAggregates(true);
 
     // no exception is thrown
-    executeQuery(context.getConnection(), mdx);
+    executeQuery(context.getConnectionWithDefaultRole(), mdx);
   }
 
     @ParameterizedTest
@@ -2103,7 +2103,7 @@ public class BasicQueryTest {
 
 
     TestUtil.withSchema(context, SchemaModifiers.BasicQueryTestModifier16::new);
-    assertQueryReturns( context.getConnection(),mdx, result );
+    assertQueryReturns( context.getConnectionWithDefaultRole(),mdx, result );
     context.getSchemaCache().clear();
   }
 
@@ -2155,14 +2155,14 @@ public class BasicQueryTest {
                 + "{[Time].[1997].[Q1]}\n" + "{[Time].[1997].[Q2]}\n" + "{[Time].[1997].[Q3]}\n" + "{[Time].[1997].[Q4]}\n"
                 + "Row #0: 66,291\n" + "Row #1: 62,610\n" + "Row #2: 65,848\n" + "Row #3: 72,024\n";
 
-    assertQueryReturns( context.getConnection(),mdx, desiredResult );
+    assertQueryReturns( context.getConnectionWithDefaultRole(),mdx, desiredResult );
 
     // check that consistent with fact table
     ((TestConfig)context.getConfig()).setUseAggregates(false);
     ((TestConfig)context.getConfig()).setReadAggregates(false);
     context.getSchemaCache().clear();
 
-    assertQueryReturns(context.getConnection(), mdx, desiredResultWithoutAgg );
+    assertQueryReturns(context.getConnectionWithDefaultRole(), mdx, desiredResultWithoutAgg );
   }
 
     @ParameterizedTest
@@ -2208,7 +2208,7 @@ public class BasicQueryTest {
             + "{[Time].[1997].[Q1]}\n" + "{[Time].[1997].[Q2]}\n" + "{[Time].[1997].[Q3]}\n" + "{[Time].[1997].[Q4]}\n"
             + "Row #0: 478,334,320\n" + "Row #1: 425,292,956\n" + "Row #2: 472,759,506\n" + "Row #3: 570,911,254\n";
 
-    assertQueryReturns( context.getConnection(),mdx, desiredResult );
+    assertQueryReturns( context.getConnectionWithDefaultRole(),mdx, desiredResult );
   }
 
     @ParameterizedTest
@@ -2253,7 +2253,7 @@ public class BasicQueryTest {
             + "{[Time].[1997].[Q1]}\n" + "{[Time].[1997].[Q2]}\n" + "{[Time].[1997].[Q3]}\n" + "{[Time].[1997].[Q4]}\n"
             + "Row #0: 22,157.417\n" + "Row #1: 20,880.448\n" + "Row #2: 22,036.988\n" + "Row #3: 24,368.758\n";
 
-    assertQueryReturns( context.getConnection(),mdx, desiredResult );
+    assertQueryReturns( context.getConnectionWithDefaultRole(),mdx, desiredResult );
   }
 
   /**
@@ -2293,7 +2293,7 @@ public class BasicQueryTest {
     if ( !isDefaultNullMemberRepresentation() ) {
       return;
     }
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     Result result =
         executeQuery(connection,  "select {[Measures].[Unit Sales]} on columns,\n" + "{[Store Size in SQFT].members} on rows\n"
             + "from Sales" );
@@ -2346,7 +2346,7 @@ public class BasicQueryTest {
   void testCrossjoinWithDescendantsAndUnknownMember(Context context) {
     ((TestConfig)context.getConfig()).setIgnoreInvalidMembersDuringQuery(true);
     ((TestConfig)context.getConfig()).setIgnoreInvalidMembers(true);
-    assertQueryReturns( context.getConnection(),"select {[Measures].[Unit Sales]} on columns,\n" + "NON EMPTY CrossJoin(\n"
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"select {[Measures].[Unit Sales]} on columns,\n" + "NON EMPTY CrossJoin(\n"
         + " Descendants([Product].[All Products], [Product].[Product Family]),\n"
         + " Descendants([Store].[All Stores].[Foo], [Store].[Store State])) on rows\n" + "from [Sales]", "Axis #0:\n"
             + "{}\n" + "Axis #1:\n" + "{[Measures].[Unit Sales]}\n" + "Axis #2:\n" );
@@ -2359,7 +2359,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testSlicerOverride(Context context) {
-    assertQueryReturns( context.getConnection(),"with member [Measures].[Radio Unit Sales] as \n"
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"with member [Measures].[Radio Unit Sales] as \n"
         + " '([Measures].[Unit Sales], [Promotion Media].[Radio])'\n"
         + "select {[Measures].[Unit Sales], [Measures].[Radio Unit Sales]} on columns,\n"
         + " filter([Product].[Product Department].members, [Promotion Media].[Radio] > 50) on rows\n" + "from Sales\n"
@@ -2373,7 +2373,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testMembersOfLargeDimensionTheHardWay(Context context) {
-    final Connection connection = context.getConnection();
+    final Connection connection = context.getConnectionWithDefaultRole();
     // Avoid this test if memory is scarce.
     if ( Bug.avoidMemoryOverflow( getDialect(connection), context.getConfig().memoryMonitor() ) ) {
       return;
@@ -2389,7 +2389,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testUnparse(Context context) {
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     Query query =
         connection.parseQuery( "with member [Measures].[Rendite] as \n"
             + " '(([Measures].[Store Sales] - [Measures].[Store Cost])) / [Measures].[Store Cost]',\n"
@@ -2418,7 +2418,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testUnparse2(Context context) {
-      Connection connection = context.getConnection();
+      Connection connection = context.getConnectionWithDefaultRole();
       Query query =
         connection.parseQuery( "with member [Measures].[Foo] as '1', " + "format_string='##0.00', "
             + "funny=IIf(1=1,\"x\"\"y\",\"foo\") " + "select {[Measures].[Foo]} on columns from Sales" );
@@ -2452,7 +2452,7 @@ public class BasicQueryTest {
    * from the Sales cube, presenting it side by side with the budget information from the Budget cube.
    */
   public void _testLookupCube(Context context) {
-    assertQueryReturns( context.getConnection(),"WITH MEMBER Measures.[Store Unit Sales] AS \n"
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"WITH MEMBER Measures.[Store Unit Sales] AS \n"
         + " 'LookupCube(\"Sales\", \"(\" + MemberToStr(Store.CurrentMember) + \", Measures.[Unit Sales])\")'\n"
         + "SELECT\n" + " {Measures.Amount, Measures.[Store Unit Sales]} ON COLUMNS,\n" + " Store.CA.CHILDREN ON ROWS\n"
         + "FROM Budget", "" );
@@ -2484,7 +2484,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testBasketAnalysis(Context context) {
-    assertQueryReturns( context.getConnection(),"WITH MEMBER [Measures].[Qualified Count] AS\n"
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"WITH MEMBER [Measures].[Qualified Count] AS\n"
         + " 'COUNT(FILTER(DESCENDANTS(Customers.CURRENTMEMBER, [Customers].[Name]),\n"
         + "               ([Measures].[Store Sales]) > 10000 OR ([Measures].[Unit Sales]) > 10))'\n"
         + "MEMBER [Measures].[Qualified Sales] AS\n"
@@ -2518,7 +2518,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testBasketAnalysisAfterFlush(Context context) {
-    flushSchemaCache(context.getConnection());
+    flushSchemaCache(context.getConnectionWithDefaultRole());
     testBasketAnalysis(context);
   }
 
@@ -2548,7 +2548,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testStringComparisons(Context context) {
-    assertQueryReturns( context.getConnection(),"SELECT {Measures.[Unit Sales]} ON COLUMNS,\n" + "  FILTER([Product].[Product Name].MEMBERS,\n"
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"SELECT {Measures.[Unit Sales]} ON COLUMNS,\n" + "  FILTER([Product].[Product Name].MEMBERS,\n"
         + "         INSTR(LCASE([Product].CURRENTMEMBER.NAME), \"fruit\") <> 0) ON ROWS \n" + "FROM Sales",
         "Axis #0:\n" + "{}\n" + "Axis #1:\n" + "{[Measures].[Unit Sales]}\n" + "Axis #2:\n"
             + "{[Product].[Food].[Canned Products].[Fruit].[Canned Fruit].[Applause].[Applause Canned Mixed Fruit]}\n"
@@ -2593,7 +2593,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testMid(Context context) {
-    assertQueryReturns( context.getConnection(),"with\n" + "member measures.x as 'Mid(\"yahoo\",5, 1)'\n"
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"with\n" + "member measures.x as 'Mid(\"yahoo\",5, 1)'\n"
         + "select {measures.x} ON COLUMNS from [Sales] ", "Axis #0:\n" + "{}\n" + "Axis #1:\n" + "{[Measures].[x]}\n"
             + "Row #0: o\n" );
   }
@@ -2619,7 +2619,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testPercentagesAsMeasures(Context context) {
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
         // todo: "Store.[USA].[CA]" should be "Store.CA"
         "WITH MEMBER Measures.[Unit Sales Percent] AS\n" + "  '((Store.CURRENTMEMBER, Measures.[Unit Sales]) /\n"
             + "    (Store.CURRENTMEMBER.PARENT, Measures.[Unit Sales])) ',\n" + "  FORMAT_STRING = 'Percent'\n"
@@ -2676,7 +2676,7 @@ public class BasicQueryTest {
    * satisfy the needs of this query.
    */
   public void _testCumlativeSums(Context context) {
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
         // todo: "[Store].[USA].[CA]" should be "Store.CA"; implement "AS"
         "WITH MEMBER Measures.[Cumulative No of Employees] AS\n"
             + "  'SUM(HEAD(ORDER({[Store].Siblings}, [Measures].[Number of Employees], BDESC) AS OrderedSiblings,\n"
@@ -2723,7 +2723,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testLogicalOps(Context context) {
-    assertQueryReturns(context.getConnection(),"WITH MEMBER [Product].[Food OR Drink] AS\n"
+    assertQueryReturns(context.getConnectionWithDefaultRole(),"WITH MEMBER [Product].[Food OR Drink] AS\n"
         + "  '([Product].[Food], Measures.[Unit Sales]) + ([Product].[Drink], Measures.[Unit Sales])'\n"
         + "SELECT {Measures.[Unit Sales]} ON COLUMNS,\n"
         + "  DESCENDANTS(Time.[1997], [Quarter], SELF_AND_BEFORE) ON ROWS\n" + "FROM Sales\n"
@@ -2745,7 +2745,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testLogicalAnd(Context context) {
-    assertQueryReturns(context.getConnection(),"SELECT {Measures.[Unit Sales]} ON COLUMNS,\n"
+    assertQueryReturns(context.getConnectionWithDefaultRole(),"SELECT {Measures.[Unit Sales]} ON COLUMNS,\n"
         + "  DESCENDANTS([Time].[1997], [Quarter], SELF_AND_BEFORE) ON ROWS\n" + "FROM Sales\n"
         + "WHERE ([Product].[Drink], [Store].USA)",
 
@@ -2769,7 +2769,7 @@ public class BasicQueryTest {
    * sold both Good products and Pearl products.
    */
   public void _testSet(Context context) {
-    assertQueryReturns(context.getConnection(),"WITH SET [Good AND Pearl Stores] AS\n" + "  'FILTER(Store.Members,\n"
+    assertQueryReturns(context.getConnectionWithDefaultRole(),"WITH SET [Good AND Pearl Stores] AS\n" + "  'FILTER(Store.Members,\n"
         + "          ([Product].[Good], Measures.[Unit Sales]) > 0 AND \n"
         + "          ([Product].[Pearl], Measures.[Unit Sales]) > 0)'\n"
         + "SELECT DESCENDANTS([Time].[1997], [Quarter], SELF_AND_BEFORE) ON COLUMNS,\n"
@@ -2794,7 +2794,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testCustomMemberProperties(Context context) {
-    assertQueryReturns( context.getConnection(),"SELECT {[Measures].[Units Shipped], [Measures].[Units Ordered]} ON COLUMNS,\n"
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"SELECT {[Measures].[Units Shipped], [Measures].[Units Ordered]} ON COLUMNS,\n"
         + "  NON EMPTY [Store].[Store Name].MEMBERS\n"
         + "    DIMENSION PROPERTIES [Store].[Store Name].[Store Sqft] ON ROWS\n" + "FROM Warehouse", "Axis #0:\n"
             + "{}\n" + "Axis #1:\n" + "{[Measures].[Units Shipped]}\n" + "{[Measures].[Units Ordered]}\n"
@@ -2832,7 +2832,7 @@ public class BasicQueryTest {
    * readily apparent and easily accessible in client applications that do not support member properties.
    */
   public void _testMemberPropertyAsCalcMember(Context context) {
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
         // todo: implement <member>.PROPERTIES
         "WITH MEMBER Measures.[Store SqFt] AS '[Store].CURRENTMEMBER.PROPERTIES(\"Store SQFT\")'\n"
             + "SELECT { [Measures].[Store SQFT], [Measures].[Units Shipped], [Measures].[Units Ordered] }  ON "
@@ -2885,7 +2885,7 @@ public class BasicQueryTest {
    * determine the order of the members.
    */
   public void _testDrillingDownMoreThanOneLevel(Context context) {
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
         // todo: implement "GENERATE"
         "SELECT  {[Measures].[Unit Sales]} ON COLUMNS,\n" + "  EXCEPT(GENERATE([Customers].[Country].MEMBERS,\n"
             + "                  {DESCENDANTS([Customers].CURRENTMEMBER, [Customers].[City], SELF_AND_BEFORE)}),\n"
@@ -2916,7 +2916,7 @@ public class BasicQueryTest {
    * stores in unit sales for each country.
    */
   public void _testTopmost(Context context) {
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
         // todo: implement "GENERATE"
         "WITH MEMBER Measures.[Country Name] AS \n" + "  'Ancestor(Store.CurrentMember, [Store Country]).Name'\n"
             + "SELECT {Measures.[Country Name], Measures.[Unit Sales]} ON COLUMNS,\n"
@@ -2954,7 +2954,7 @@ public class BasicQueryTest {
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testTopmost2(Context context) {
     context.getSchemaCache().clear();
-    assertQueryReturns( context.getConnection(),"SELECT {Measures.[Unit Sales]} ON COLUMNS,\n" + "  CROSSJOIN(Customers.CHILDREN,\n"
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"SELECT {Measures.[Unit Sales]} ON COLUMNS,\n" + "  CROSSJOIN(Customers.CHILDREN,\n"
         + "    TOPCOUNT(DESCENDANTS([Store].CURRENTMEMBER, [Store].[Store Name]),\n"
         + "             1, [Measures].[Unit Sales])) ON ROWS\n" + "FROM Sales",
 
@@ -2991,7 +2991,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testRank(Context context) {
-    assertQueryReturns( context.getConnection(),"SELECT {[Measures].[Unit Sales]} ON COLUMNS, \n"
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"SELECT {[Measures].[Unit Sales]} ON COLUMNS, \n"
         + "  ORDER([Store].[Store Name].MEMBERS, (Measures.[Unit Sales]), BDESC) ON ROWS\n" + "FROM Sales\n"
         + "WHERE [Product].[Non-Consumable]", "Axis #0:\n" + "{[Product].[Non-Consumable]}\n" + "Axis #1:\n"
             + "{[Measures].[Unit Sales]}\n" + "Axis #2:\n" + "{[Store].[USA].[OR].[Salem].[Store 13]}\n"
@@ -3039,7 +3039,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testDifferentCalculationsForDifferentLevels(Context context) {
-    assertQueryReturns(context.getConnection(),"WITH MEMBER Measures.[Average Units Ordered] AS\n"
+    assertQueryReturns(context.getConnectionWithDefaultRole(),"WITH MEMBER Measures.[Average Units Ordered] AS\n"
         + "  'AVG(DESCENDANTS([Store].CURRENTMEMBER, [Store].[Store Name]), [Measures].[Units Ordered])',\n"
         + "  FORMAT_STRING='#.00'\n"
         + "SELECT {[Measures].[Units ordered], Measures.[Average Units Ordered]} ON COLUMNS,\n"
@@ -3065,7 +3065,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testDifferentCalculations2(Context context) {
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
         // todo: "[Store].[USA].[CA]" should be "[Store].CA",
         // "[Product].[Drink].[Alcoholic Beverages].[Beer and Wine].[Beer]"
         // should be "[Product].[Beer]"
@@ -3116,7 +3116,7 @@ public class BasicQueryTest {
    * query.
    */
   public void _testDifferentCalculationsForDifferentDimensions(Context context) {
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
         // todo: implement "NONEMPTYCROSSJOIN"
         "WITH MEMBER [Measures].[Avg Units Shipped] AS\n" + "  '[Measures].[Units Shipped] / \n"
             + "    COUNT(DESCENDANTS([Time].CURRENTMEMBER, [Time].[Month], SELF))'\n"
@@ -3137,7 +3137,7 @@ public class BasicQueryTest {
    * query.
    */
   public void _testDifferentCalculationsForDifferentDimensions2(Context context) {
-    assertQueryReturns( context.getConnection(),"WITH MEMBER Measures.[Closing Balance] AS\n" + "  '([Measures].[Units Ordered], \n"
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"WITH MEMBER Measures.[Closing Balance] AS\n" + "  '([Measures].[Units Ordered], \n"
         + "    CLOSINGPERIOD([Time].[Month], [Time].CURRENTMEMBER)) -\n" + "   ([Measures].[Units Shipped], \n"
         + "    CLOSINGPERIOD([Time].[Month], [Time].CURRENTMEMBER))'\n"
         + "SELECT {[Measures].[Closing Balance]} ON COLUMNS,\n" + "  Product.MEMBERS ON ROWS\n" + "FROM Warehouse",
@@ -3178,7 +3178,7 @@ public class BasicQueryTest {
    * and nine-month total, two calculated members are created in the following MDX query.
    */
   public void _testDateRange(Context context) {
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
         // todo: implement "AddCalculatedMembers"
         "WITH Member [Time].[Time].[1997].[Six Month] AS\n" + "  'SUM([Time].[1]:[Time].[6])'\n"
             + "Member [Time].[Time].[1997].[Nine Month] AS\n" + "  'SUM([Time].[1]:[Time].[9])'\n"
@@ -3211,7 +3211,7 @@ public class BasicQueryTest {
    * current period.
    */
   public void _testRolling(Context context) {
-    assertQueryReturns(context.getConnection(),"WITH SET Rolling12 AS\n" + "  'LASTPERIODS(12, TAIL(FILTER([Time].[Month].MEMBERS, \n"
+    assertQueryReturns(context.getConnectionWithDefaultRole(),"WITH SET Rolling12 AS\n" + "  'LASTPERIODS(12, TAIL(FILTER([Time].[Month].MEMBERS, \n"
         + "    ([Customers].[All Customers], \n" + "    [Education Level].[All Education Level],\n"
         + "    [Gender].[All Gender],\n" + "    [Marital Status].[All Marital Status],\n"
         + "    [Product].[All Products], \n" + "    [Promotion Media].[All Media],\n"
@@ -3245,7 +3245,7 @@ public class BasicQueryTest {
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testDifferentCalcsForDifferentTimePeriods(Context context) {
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
         // note: "[Product].[Drink Forecast - Standard]"
         // was "[Drink Forecast - Standard]"
         "WITH MEMBER [Product].[Drink Forecast - Standard] AS\n" + "  '[Product].[All Products].[Drink] * 2'\n"
@@ -3303,7 +3303,7 @@ public class BasicQueryTest {
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   public void _testDc4dtp2(Context context) {
-    assertQueryReturns(context.getConnection(),"WITH MEMBER [Product].[Drink Forecast - Standard] AS\n"
+    assertQueryReturns(context.getConnectionWithDefaultRole(),"WITH MEMBER [Product].[Drink Forecast - Standard] AS\n"
         + "  '[Product].[All Products].[Drink] * 2'\n" + "MEMBER [Product].[Drink Forecast - Dynamic] AS \n"
         + "  '[Product].[All Products].[Drink] * \n"
         + "   [Time].CURRENTMEMBER.PROPERTIES(\"Dynamic Forecast Multiplier\")'\n"
@@ -3396,7 +3396,7 @@ public class BasicQueryTest {
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   public void _testWarehouseProfit(Context context) {
-    assertQueryReturns( context.getConnection(),"select \n"
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"select \n"
         + "{[Measures].[Warehouse Cost], [Measures].[Warehouse Sales], [Measures].[Warehouse Profit]}\n"
         + " ON COLUMNS from [Warehouse]",
         "Axis #0:\n"
@@ -3431,7 +3431,7 @@ public class BasicQueryTest {
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   public void _testYtdGrowth(Context context) {
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
         // todo: implement "ParallelPeriod"
         "WITH MEMBER [Measures].[YTD Unit Sales] AS\n" + "  'COALESCEEMPTY(SUM(YTD(), [Measures].[Unit Sales]), 0)'\n"
             + "MEMBER [Measures].[Previous YTD Unit Sales] AS\n"
@@ -3462,7 +3462,7 @@ public class BasicQueryTest {
   public void dont_testParallelMutliple(Context context) {
 	  context.getSchemaCache().clear();
       ((TestConfig)context.getConfig()).setMaxEvalDepth(MAX_EVAL_DEPTH_VALUE);
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     for ( int i = 0; i < 5; i++ ) {
       runParallelQueries(connection, 1, 1, false );
       runParallelQueries(connection, 3, 2, false );
@@ -3474,13 +3474,13 @@ public class BasicQueryTest {
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   public void dont_testParallelNot(Context context) {
-    runParallelQueries(context.getConnection(), 1, 1, false );
+    runParallelQueries(context.getConnectionWithDefaultRole(), 1, 1, false );
   }
 
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   public void dont_testParallelSomewhat(Context context) {
-    runParallelQueries(context.getConnection(), 3, 2, false );
+    runParallelQueries(context.getConnectionWithDefaultRole(), 3, 2, false );
   }
 
   @ParameterizedTest
@@ -3488,14 +3488,14 @@ public class BasicQueryTest {
   public void dont_testParallelFlushCache(Context context) {
 	context.getSchemaCache().clear();
     ((TestConfig)context.getConfig()).setMaxEvalDepth(MAX_EVAL_DEPTH_VALUE);
-    runParallelQueries(context.getConnection(), 4, 6, true );
+    runParallelQueries(context.getConnectionWithDefaultRole(), 4, 6, true );
   }
 
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   public void dont_testParallelVery(Context context) {
       ((TestConfig)context.getConfig()).setMaxEvalDepth( MAX_EVAL_DEPTH_VALUE);
-    runParallelQueries(context.getConnection(), 6, 10, false );
+    runParallelQueries(context.getConnectionWithDefaultRole(), 6, 10, false );
   }
 
   private void runParallelQueries(final Connection connection, final int threadCount, final int iterationCount, final boolean flush ) {
@@ -3540,7 +3540,7 @@ public class BasicQueryTest {
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testDependsOn(Context context) {
-    assertQueryReturns(context.getConnection(),"with member [Customers].[my] as \n"
+    assertQueryReturns(context.getConnectionWithDefaultRole(),"with member [Customers].[my] as \n"
         + "  'Aggregate(Filter([Customers].[City].Members, (([Measures].[Unit Sales] / ([Measures].[Unit Sales], "
         + "[Product].[All Products])) > 0.1)))' \n" + "select  \n" + "  {[Measures].[Unit Sales]} ON columns, \n"
         + "  {[Product].[All Products].[Food].[Deli], [Product].[All Products].[Food].[Frozen Foods]} ON rows \n"
@@ -3590,15 +3590,15 @@ public class BasicQueryTest {
     // With bug 1755778, the following test below fails because it returns
     // only row that have a null value (see "wrongResultWithFilter").
     // It should return the "expectedResultWithFilter" value.
-    assertQueryReturns( context.getConnection(),queryWithFilter, expectedResultWithFilter );
+    assertQueryReturns( context.getConnectionWithDefaultRole(),queryWithFilter, expectedResultWithFilter );
 
     // To see the test case return the correct result comment out the line
     // above and uncomment out the lines below following. If a similar
     // query without the filter is executed (queryWithoutFilter) prior to
     // running the query with the filter then the correct result set is
     // returned
-    assertQueryReturns( context.getConnection(),queryWithoutFilter, expectedResultWithoutFilter );
-    assertQueryReturns( context.getConnection(),queryWithFilter, expectedResultWithFilter );
+    assertQueryReturns( context.getConnectionWithDefaultRole(),queryWithoutFilter, expectedResultWithoutFilter );
+    assertQueryReturns( context.getConnectionWithDefaultRole(),queryWithFilter, expectedResultWithFilter );
   }
 
   /**
@@ -3608,7 +3608,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testFilteredCrossJoin(Context context) {
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     flushSchemaCache(connection);
     Result result =
         executeQuery(connection, "select {[Measures].[Store Sales]} on columns,\n" + "  NON EMPTY Crossjoin(\n"
@@ -3631,7 +3631,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testNonEmptyCrossJoin(Context context) {
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     if ( !context.getConfig().enableNativeCrossJoin() ) {
       // If we try to evaluate the crossjoin in memory we run out of
       // memory.
@@ -3655,7 +3655,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testNonEmptyNonEmptyCrossJoin1(Context context) {
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     flushSchemaCache(connection);
     Result result =
         executeQuery(connection, "select {[Education Level].[All Education Levels].[Graduate Degree]} on columns,\n"
@@ -3669,7 +3669,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testNonEmptyNonEmptyCrossJoin2(Context context) {
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     flushSchemaCache(connection);
     Result result =
         executeQuery(connection, "select {[Education Level].[All Education Levels].[Graduate Degree]} on columns,\n"
@@ -3683,7 +3683,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testNonEmptyNonEmptyCrossJoin3(Context context) {
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     flushSchemaCache(connection);
     Result result =
         executeQuery(connection, "select {[Education Level].[All Education Levels].[Graduate Degree]} on columns,\n"
@@ -3697,7 +3697,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testNonEmptyNonEmptyCrossJoin4(Context context) {
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     flushSchemaCache(connection);
     Result result =
         executeQuery(connection, "select {[Education Level].[All Education Levels].[Graduate Degree]} on columns,\n"
@@ -3716,7 +3716,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testHierDifferentKeyClass(Context context) {
-      Connection connection = context.getConnection();
+      Connection connection = context.getConnectionWithDefaultRole();
     Result result =
         executeQuery(connection, "with member [Time].[Time].[1997].[Q1].[xxx] as\n"
             + "'Aggregate({[Time].[1997].[Q1].[1], [Time].[1997].[Q1].[2]})'\n"
@@ -3734,7 +3734,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testOverlappingCalculatedMembers(Context context) {
-    assertQueryReturns( context.getConnection(),"WITH MEMBER [Store].[Total] AS 'SUM([Store].[Store Country].MEMBERS)' "
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"WITH MEMBER [Store].[Total] AS 'SUM([Store].[Store Country].MEMBERS)' "
         + "MEMBER [Store Type].[Total] AS 'SUM([Store Type].[Store Type].MEMBERS)' "
         + "MEMBER [Gender].[Total] AS 'SUM([Gender].[Gender].MEMBERS)' "
         + "MEMBER [Measures].[x] AS '[Measures].[Store Sales]' " + "SELECT {[Measures].[x]} ON COLUMNS , "
@@ -3750,7 +3750,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testEmptyProperty(Context context) {
-    assertQueryReturns( context.getConnection(),"select     {[Measures].[Unit Sales]} on columns, " + "filter([Store].[Store Name].members,"
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"select     {[Measures].[Unit Sales]} on columns, " + "filter([Store].[Store Name].members,"
         + "[Store].currentmember.properties(\"Store Manager\")=\"Smith\") on rows" + " from Sales", "Axis #0:\n"
             + "{}\n" + "Axis #1:\n" + "{[Measures].[Unit Sales]}\n" + "Axis #2:\n"
             + "{[Store].[USA].[WA].[Bellingham].[Store 2]}\n" + "Row #0: 2,237\n" );
@@ -3764,7 +3764,7 @@ public class BasicQueryTest {
     // Create a second usage of the "Store" shared dimension called "Other
     // Store". Attach it to the "unit_sales" column (which has values [1,
     // 6] whereas store has values [1, 24].
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     /*
     ((BaseTestContext)context).update(SchemaUpdater.createSubstitutingCube( "Sales",
             "<DimensionUsage name=\"Other Store\" source=\"Store\" foreignKey=\"unit_sales\" />" ));
@@ -3859,7 +3859,7 @@ public class BasicQueryTest {
             + "  </CalculatedMember>\n" + "</Cube>", null, null, null, null );
      */
     TestUtil.withSchema(context, SchemaModifiers.BasicQueryTestModifier20::new);
-    SchemaReader scr = context.getConnection().getSchema().lookupCube( cubeName, true ).getSchemaReader( null );
+    SchemaReader scr = context.getConnectionWithDefaultRole().getSchema().lookupCube( cubeName, true ).getSchemaReader( null );
     Member member = scr.getMemberByUniqueName( IdImpl.toList( "Measures", "Unit Sales" ), true );
     Object visible = member.getPropertyValue( Property.VISIBLE.name );
     assertEquals( Boolean.FALSE, visible );
@@ -3888,7 +3888,7 @@ public class BasicQueryTest {
     withSchema(context, SchemaModifiers.BasicQueryTestModifier5::new);
 
     String mdx = "select {[Gender3].[All Gender]} on columns from Sales";
-    Result result = executeQuery(context.getConnection(), mdx);
+    Result result = executeQuery(context.getConnectionWithDefaultRole(), mdx);
     Axis axis0 = result.getAxes()[0];
     Position pos0 = axis0.getPositions().get( 0 );
     Member allGender = pos0.get( 0 );
@@ -3909,7 +3909,7 @@ public class BasicQueryTest {
        */
         withSchema(context, SchemaModifiers.BasicQueryTestModifier10::new);
         String mdx = "select {[Gender4].[All Gender]} on columns from Sales";
-    Result result = executeQuery(context.getConnection(), mdx );
+    Result result = executeQuery(context.getConnectionWithDefaultRole(), mdx );
     Axis axis0 = result.getAxes()[0];
     Position pos0 = axis0.getPositions().get( 0 );
     Member allGender = pos0.get( 0 );
@@ -3952,7 +3952,7 @@ public class BasicQueryTest {
     */
     TestUtil.withSchema(context, SchemaModifiers.BasicQueryTestModifier21::new);
     //withCube( "Sales_DimWithoutAll" );
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     // the default member of the Gender dimension is the first member
     assertExprReturns(connection, "Sales_DimWithoutAll", "[Gender].CurrentMember.Name", "F" );
     assertExprReturns(connection, "Sales_DimWithoutAll", "[Product].CurrentMember.Name", "Drink" );
@@ -3980,7 +3980,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testMemberOnAxis(Context context) {
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
         "select [Measures].[Sales Count] on 0, non empty [Store].[Store State].members on 1 from [Sales]", "Axis #0:\n"
             + "{}\n" + "Axis #1:\n" + "{[Measures].[Sales Count]}\n" + "Axis #2:\n" + "{[Store].[USA].[CA]}\n"
             + "{[Store].[USA].[OR]}\n" + "{[Store].[USA].[WA]}\n" + "Row #0: 24,442\n" + "Row #1: 21,611\n"
@@ -3990,7 +3990,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testScalarOnAxisFails(Context context) {
-    assertQueryThrows(context.getConnection(),
+    assertQueryThrows(context.getConnectionWithDefaultRole(),
         "select [Measures].[Sales Count] + 1 on 0, non empty [Store].[Store State].members on 1 from [Sales]",
         "Axis 'COLUMNS' expression is not a set" );
   }
@@ -4001,7 +4001,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testSameDimOnTwoAxesFails(Context context) {
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     assertQueryThrows(connection, "select {[Measures].[Unit Sales]} on columns,\n" + " {[Measures].[Store Sales]} on rows\n"
         + "from [Sales]", "Hierarchy '[Measures]' appears in more than one independent axis" );
 
@@ -4029,14 +4029,14 @@ public class BasicQueryTest {
   }
 
   public void _testSetArgToTupleFails(Context context) {
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     assertQueryThrows(connection, "select CrossJoin(\n" + "    {[Product].children},\n"
         + "    {[Measures].[Unit Sales]}) on columns,\n" + "    {([Product],\n" + "      [Store].members)} on rows\n"
         + "from [Sales]", "Dimension '[Product]' appears in more than one independent axis" );
   }
 
   public void _badArgsToTupleFails(Context context) {
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     // clash within slicer
     assertQueryThrows(connection, "select {[Measures].[Unit Sales]} on columns,\n" + " {[Store].Members} on rows\n"
         + "from [Sales]\n" + "where ([Time].[1997].[Q1], [Product], [Time].[1997].[Q2])",
@@ -4053,7 +4053,7 @@ public class BasicQueryTest {
   void testNullMember(Context context) {
     context.getSchemaCache().clear();
     if ( isDefaultNullMemberRepresentation() ) {
-      assertQueryReturns( context.getConnection(),"SELECT \n" + "{[Measures].[Store Cost]} ON columns, \n"
+      assertQueryReturns( context.getConnectionWithDefaultRole(),"SELECT \n" + "{[Measures].[Store Cost]} ON columns, \n"
           + "{[Store Size in SQFT].[All Store Size in SQFTs].[#null]} ON rows \n" + "FROM [Sales] \n"
           + "WHERE [Time].[1997]", "Axis #0:\n" + "{[Time].[1997]}\n" + "Axis #1:\n" + "{[Measures].[Store Cost]}\n"
               + "Axis #2:\n" + "{[Store Size in SQFT].[#null]}\n" + "Row #0: 33,307.69\n" );
@@ -4064,7 +4064,7 @@ public class BasicQueryTest {
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testNullMemberWithOneNonNull(Context context) {
     if ( isDefaultNullMemberRepresentation() ) {
-      assertQueryReturns( context.getConnection(),"SELECT \n" + "{[Measures].[Store Cost]} ON columns, \n"
+      assertQueryReturns( context.getConnectionWithDefaultRole(),"SELECT \n" + "{[Measures].[Store Cost]} ON columns, \n"
           + "{[Store Size in SQFT].[All Store Size in SQFTs].[#null],"
           + "[Store Size in SQFT].[ALL Store Size in SQFTs].[39696]} ON rows \n" + "FROM [Sales] \n"
           + "WHERE [Time].[1997]", "Axis #0:\n" + "{[Time].[1997]}\n" + "Axis #1:\n" + "{[Measures].[Store Cost]}\n"
@@ -4111,7 +4111,7 @@ public class BasicQueryTest {
             + "      formatString=\"#,###.00\"/>\n" + "</Cube>", null, null, null, null );
        */
     TestUtil.withSchema(context, SchemaModifiers.BasicQueryTestModifier22::new);
-    assertQueryReturns(context.getConnection(),"select {\n" + " [Customers].[All Customers].[USA],\n"
+    assertQueryReturns(context.getConnectionWithDefaultRole(),"select {\n" + " [Customers].[All Customers].[USA],\n"
         + " [Customers].[All Customers].[USA].[OR],\n" + " [Customers].[All Customers].[USA].[CA],\n"
         + " [Customers].[All Customers].[USA].[CA].[Altadena],\n"
         + " [Customers].[All Customers].[USA].[CA].[Burbank],\n"
@@ -4127,7 +4127,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testOverrideDimension(Context context) {
-    assertQueryReturns( context.getConnection(),"with member  [Gender].[test] as '\n" + "  aggregate(\n"
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"with member  [Gender].[test] as '\n" + "  aggregate(\n"
         + "  filter (crossjoin( [Gender].[Gender].members, [Time].[Time].members), \n"
         + "      [time].[Time].CurrentMember = [Time].[1997].[Q1]   AND\n" + "[measures].[unit sales] > 50) )\n"
         + "'\n" + "select \n" + "  { [time].[year].members } on 0,\n" + "  { [gender].[test] }\n" + " on 1  \n"
@@ -4148,7 +4148,7 @@ public class BasicQueryTest {
     TestUtil.withSchema(context, SchemaModifiers.BasicQueryTestModifier23::new);
     Throwable throwable = null;
     try {
-      assertSimpleQuery(context.getConnection());
+      assertSimpleQuery(context.getConnectionWithDefaultRole());
     } catch ( Throwable e ) {
       throwable = e;
     }
@@ -4173,7 +4173,7 @@ public class BasicQueryTest {
     TestUtil.withSchema(context, SchemaModifiers.BasicQueryTestModifier24::new);
     Throwable throwable = null;
     try {
-      assertSimpleQuery(context.getConnection());
+      assertSimpleQuery(context.getConnectionWithDefaultRole());
     } catch ( Throwable e ) {
       throwable = e;
     }
@@ -4196,7 +4196,7 @@ public class BasicQueryTest {
             + "from [Sales]";
 
     String mdx3 = "select {[Measures].[Unit Sales]} on columns\n" + "from [Sales]\n" + "where ([Time].[1997].[QTOO])";
-      Connection connection = context.getConnection();
+      Connection connection = context.getConnectionWithDefaultRole();
     // By default, reference to invalid member should cause
     // query failure.
     assertQueryThrows(connection, mdx, "MDX object '[Time].[1997].[QTOO]' not found in cube 'Sales'" );
@@ -4207,11 +4207,11 @@ public class BasicQueryTest {
 
     ((TestConfig)context.getConfig()).setIgnoreInvalidMembersDuringQuery(true);
 
-    assertQueryReturns( context.getConnection(),mdx, "Axis #0:\n" + "{}\n" + "Axis #1:\n" + "{[Measures].[Unit Sales]}\n" + "Axis #2:\n"
+    assertQueryReturns( context.getConnectionWithDefaultRole(),mdx, "Axis #0:\n" + "{}\n" + "Axis #1:\n" + "{[Measures].[Unit Sales]}\n" + "Axis #2:\n"
         + "{[Time].[1997].[Q1]}\n" + "Row #0: 66,291\n" );
 
     // Illegal member in slicer
-    assertQueryReturns( context.getConnection(),mdx3, "Axis #0:\n" + "Axis #1:\n" + "{[Measures].[Unit Sales]}\n" + "Row #0: \n" );
+    assertQueryReturns( context.getConnectionWithDefaultRole(),mdx3, "Axis #0:\n" + "Axis #1:\n" + "{[Measures].[Unit Sales]}\n" + "Row #0: \n" );
 
     // Verify that invalid members in query do NOT prevent
     // usage of native NECJ (LER-5165).
@@ -4219,7 +4219,7 @@ public class BasicQueryTest {
         ((TestConfig)context.getConfig())
             .setAlertNativeEvaluationUnsupported("ERROR");
 
-        assertQueryReturns( context.getConnection(),mdx2, "Axis #0:\n" + "{}\n" + "Axis #1:\n" + "{[Measures].[Unit Sales]}\n" + "Axis #2:\n"
+        assertQueryReturns( context.getConnectionWithDefaultRole(),mdx2, "Axis #0:\n" + "{}\n" + "Axis #1:\n" + "{[Measures].[Unit Sales]}\n" + "Axis #2:\n"
         + "{[Time].[1997].[Q1], [Customers].[USA].[CA]}\n" + "{[Time].[1997].[Q1], [Customers].[USA].[OR]}\n"
         + "{[Time].[1997].[Q1], [Customers].[USA].[WA]}\n" + "Row #0: 16,890\n" + "Row #1: 19,287\n"
         + "Row #2: 30,114\n" );
@@ -4265,13 +4265,13 @@ public class BasicQueryTest {
         // Use a fresh connection to make sure bad member ordinals haven't
     // been assigned by previous tests.
     //final TestContext context = testContext.withFreshConnection().withCube( "HR" );
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
 
     try {
       // After running of MDX1
       // members cache will contain items
       // for [Position].[Position Title].members
-      assertQueryReturns( context.getConnection(),  MDX1, "Axis #0:\n" + "{}\n" + "Axis #1:\n" + "{[Measures].[0]}\n" + "Axis #2:\n"
+      assertQueryReturns( context.getConnectionWithDefaultRole(),  MDX1, "Axis #0:\n" + "{}\n" + "Axis #1:\n" + "{[Measures].[0]}\n" + "Axis #2:\n"
           + "{[Store Type].[Mid-Size Grocery], [Position].[Store Full Time Staf].[Store Permanent Checker]}\n"
           + "{[Store Type].[Mid-Size Grocery], [Position].[Store Full Time Staf].[Store Temporary Checker]}\n"
           + "{[Store Type].[Mid-Size Grocery], [Position].[Store Full Time Staf].[Store Permanent Stocker]}\n"
@@ -4299,7 +4299,7 @@ public class BasicQueryTest {
 
       // Run MDX2 - all [Position].[Position Title].Members should be sorted
       // correctly by ordinalColumn inside Management Role groups
-      assertQueryReturns( context.getConnection(), MDX2, "Axis #0:\n" + "{}\n" + "Axis #1:\n" + "{[Measures].[0]}\n" + "Axis #2:\n"
+      assertQueryReturns( context.getConnectionWithDefaultRole(), MDX2, "Axis #0:\n" + "{}\n" + "Axis #1:\n" + "{[Measures].[0]}\n" + "Axis #2:\n"
           + "{[Position].[Middle Management].[HQ Information Systems]}\n"
           + "{[Position].[Middle Management].[HQ Marketing]}\n"
           + "{[Position].[Middle Management].[HQ Human Resources]}\n"
@@ -4333,7 +4333,7 @@ public class BasicQueryTest {
     // Use a fresh connection to make sure bad member ordinals haven't
     // been assigned by previous tests.
     //final TestContext context = getTestContext().withFreshConnection();
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     try {
       tryMemberOrdinalCaching( connection );
     } finally {
@@ -4397,7 +4397,7 @@ public class BasicQueryTest {
             + SleepUdf.class.getName() + "\"/>", null );
      */
     TestUtil.withSchema(context, SchemaModifiers.BasicQueryTestModifier25::new);
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
 
     final Query query = connection.parseQuery( queryString );
     final Throwable[] throwables = { null };
@@ -4505,7 +4505,7 @@ public class BasicQueryTest {
     throws Exception {
     // avoid cache to ensure sql executes
     //TestContext context = getTestContext().withFreshConnection();
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     flushSchemaCache(connection);
 
     RolapConnection conn = (RolapConnection) connection;
@@ -4611,7 +4611,7 @@ public class BasicQueryTest {
     Throwable throwable = null;
     ((TestConfig)context.getConfig()).setQueryTimeout(2);
     try {
-    	executeQueryTimeoutTest(context.getConnection(), query);
+    	executeQueryTimeoutTest(context.getConnectionWithDefaultRole(), query);
     } catch ( Throwable ex ) {
       throwable = ex;
     }
@@ -4621,7 +4621,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testFormatInheritance(Context context) {
-    assertQueryReturns( context.getConnection(),"with member measures.foo as 'measures.bar' " + "member measures.bar as "
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"with member measures.foo as 'measures.bar' " + "member measures.bar as "
         + "'measures.profit' select {measures.foo} on 0 from sales", "Axis #0:\n" + "{}\n" + "Axis #1:\n"
             + "{[Measures].[foo]}\n" + "Row #0: $339,610.90\n" );
   }
@@ -4629,7 +4629,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testFormatInheritanceWithIIF(Context context) {
-    assertQueryReturns( context.getConnection(),"with member measures.foo as 'measures.bar' " + "member measures.bar as "
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"with member measures.foo as 'measures.bar' " + "member measures.bar as "
         + "'iif(not isempty(measures.profit),measures.profit,null)' " + "select from sales where measures.foo",
         "Axis #0:\n" + "{[Measures].[foo]}\n" + "$339,610.90" );
   }
@@ -4641,7 +4641,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testFormatInheritanceWorksWithFirstFormatItFinds(Context context) {
-    assertQueryReturns( context.getConnection(),"with member measures.foo as 'measures.bar' " + "member measures.bar as "
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"with member measures.foo as 'measures.bar' " + "member measures.bar as "
         + "'iif(measures.profit>3000,measures.[unit sales],measures.[Customer Count])' "
         + "select {[Store].[All Stores].[USA].[WA].children} on 0 " + "from sales where measures.foo", "Axis #0:\n"
             + "{[Measures].[foo]}\n" + "Axis #1:\n" + "{[Store].[USA].[WA].[Bellingham]}\n"
@@ -4660,15 +4660,15 @@ public class BasicQueryTest {
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testFormatStringAppliedToStringValue(Context context) {
     // "23" as an integer value
-    assertQueryReturns( context.getConnection(),"with member [Measures].[Test] as '23', FORMAT_STRING = '|<|arrow=\"up\"'\n"
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"with member [Measures].[Test] as '23', FORMAT_STRING = '|<|arrow=\"up\"'\n"
         + "select [Measures].[Test] on 0\n" + "from [Sales]", "Axis #0:\n" + "{}\n" + "Axis #1:\n"
             + "{[Measures].[Test]}\n" + "Row #0: |23|arrow=up\n" );
     // "23" as a string value: converted to lower case
-    assertQueryReturns( context.getConnection(),"with member [Measures].[Test] as '\"23\"', FORMAT_STRING = '|<|arrow=\"up\"'\n"
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"with member [Measures].[Test] as '\"23\"', FORMAT_STRING = '|<|arrow=\"up\"'\n"
         + "select [Measures].[Test] on 0\n" + "from [Sales]", "Axis #0:\n" + "{}\n" + "Axis #1:\n"
             + "{[Measures].[Test]}\n" + "Row #0: |23|arrow=up\n" );
     // string value "Foo Bar" -- converted to lower case
-    assertQueryReturns( context.getConnection(),"with member [Measures].[Test] as '\"Foo \" || \"Bar\"', FORMAT_STRING = '|<|arrow=\"up\"'\n"
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"with member [Measures].[Test] as '\"Foo \" || \"Bar\"', FORMAT_STRING = '|<|arrow=\"up\"'\n"
         + "select [Measures].[Test] on 0\n" + "from [Sales]", "Axis #0:\n" + "{}\n" + "Axis #1:\n"
             + "{[Measures].[Test]}\n" + "Row #0: |foo bar|arrow=up\n" );
   }
@@ -4679,7 +4679,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testAvgCastProblem(Context context) {
-    assertQueryReturns( context.getConnection(),"with member measures.bar as "
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"with member measures.bar as "
         + "'iif(measures.profit>3000,min([Education Level].[Education Level].Members),min([Education Level]"
         + ".[Education Level].Members))' " + "select {[Store].[All Stores].[USA].[WA].children} on 0 "
         + "from sales where measures.bar", "Axis #0:\n" + "{[Measures].[bar]}\n" + "Axis #1:\n"
@@ -4696,7 +4696,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testFormatInheritanceUseSecondIfFirstHasNoFormat(Context context) {
-    assertQueryReturns( context.getConnection(),"with member measures.foo as 'measures.bar+measures.blah'" + " member measures.bar as '10'"
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"with member measures.foo as 'measures.bar+measures.blah'" + " member measures.bar as '10'"
         + " member measures.blah as '20',format_string='$##.###.00' " + "select from sales where measures.foo",
         "Axis #0:\n" + "{[Measures].[foo]}\n" + "$30.00" );
   }
@@ -4708,7 +4708,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testFormatInheritanceUseFirstValid(Context context) {
-    assertQueryReturns( context.getConnection(),"with member measures.foo as '13+31*measures.[Unit Sales]/"
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"with member measures.foo as '13+31*measures.[Unit Sales]/"
         + "iif(measures.profit>0,measures.profit,measures.[Customer Count])'"
         + " select {[Store].[All Stores].[USA].[CA].children} on 0 " + "from sales where measures.foo", "Axis #0:\n"
             + "{[Measures].[foo]}\n" + "Axis #1:\n" + "{[Store].[USA].[CA].[Alameda]}\n"
@@ -4741,7 +4741,7 @@ public class BasicQueryTest {
     ((TestConfig)context.getConfig()).setIterationLimit(11);
 
     Throwable throwable = null;
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     try {
       Query query = connection.parseQuery( queryString );
       query.setResultStyle( ResultStyle.LIST );
@@ -4760,7 +4760,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testGetCaptionUsingMemberDotCaption(Context context) {
-    assertQueryReturns( context.getConnection(),"SELECT Filter(Store.allmembers, "
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"SELECT Filter(Store.allmembers, "
         + "[store].currentMember.caption = \"USA\") on 0 FROM SALES", "Axis #0:\n" + "{}\n" + "Axis #1:\n"
             + "{[Store].[USA]}\n" + "Row #0: 266,773\n" );
   }
@@ -4768,7 +4768,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testGetCaptionUsingMemberDotPropertiesCaption(Context context) {
-    assertQueryReturns( context.getConnection(),"SELECT Filter(Store.allmembers, "
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"SELECT Filter(Store.allmembers, "
         + "[store].currentMember.properties(\"caption\") = \"USA\") " + "on 0 FROM SALES", "Axis #0:\n" + "{}\n"
             + "Axis #1:\n" + "{[Store].[USA]}\n" + "Row #0: 266,773\n" );
   }
@@ -4790,7 +4790,7 @@ public class BasicQueryTest {
     String queryWithoutFilter = "select store.members on 0 from " + "DefaultMeasureTesting";
     String queryWithDeflaultMeasureFilter =
         "select store.members on 0 " + "from DefaultMeasureTesting where [measures].[Supply Time]";
-    assertQueriesReturnSimilarResults(context.getConnection(), queryWithoutFilter, queryWithDeflaultMeasureFilter);
+    assertQueriesReturnSimilarResults(context.getConnectionWithDefaultRole(), queryWithoutFilter, queryWithDeflaultMeasureFilter);
   }
 
     @ParameterizedTest
@@ -4813,7 +4813,7 @@ public class BasicQueryTest {
     String queryWithoutFilter = "select store.members on 0 from " + "DefaultMeasureTesting";
     String queryWithFirstMeasure =
         "select store.members on 0 " + "from DefaultMeasureTesting where [measures].[Store Invoice]";
-    assertQueriesReturnSimilarResults(context.getConnection(), queryWithoutFilter, queryWithFirstMeasure);
+    assertQueriesReturnSimilarResults(context.getConnectionWithDefaultRole(), queryWithoutFilter, queryWithFirstMeasure);
   }
 
     @ParameterizedTest
@@ -4838,7 +4838,7 @@ public class BasicQueryTest {
         "select store.members on 0 " + "from DefaultMeasureTesting where [measures].[Store Invoice]";
     String queryWithDefaultMeasureFilter =
         "select store.members on 0 " + "from DefaultMeasureTesting where [measures].[Supply Time]";
-      Connection connection = context.getConnection();
+      Connection connection = context.getConnectionWithDefaultRole();
     if ( SystemWideProperties.instance().CaseSensitive ) {
       assertQueriesReturnSimilarResults(connection, queryWithoutFilter, queryWithFirstMeasure);
     } else {
@@ -4852,7 +4852,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testNumericToLogicalConversion(Context context) {
-    assertQueryReturns(context.getConnection(),"select " + "{[Measures].[Unit Sales]} on columns, " + "Filter(Descendants("
+    assertQueryReturns(context.getConnectionWithDefaultRole(),"select " + "{[Measures].[Unit Sales]} on columns, " + "Filter(Descendants("
         + "[Product].[Food].[Baked Goods].[Bread]), " + "Count([Product].currentMember.children)) on Rows "
         + "from [Sales]", "Axis #0:\n" + "{}\n" + "Axis #1:\n" + "{[Measures].[Unit Sales]}\n" + "Axis #2:\n"
             + "{[Product].[Food].[Baked Goods].[Bread]}\n" + "{[Product].[Food].[Baked Goods].[Bread].[Bagels]}\n"
@@ -4882,7 +4882,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testRollupQuery(Context context) {
-    assertQueryReturns( context.getConnection(),"SELECT {[Product].[Product Department].MEMBERS} ON AXIS(0),\n"
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"SELECT {[Product].[Product Department].MEMBERS} ON AXIS(0),\n"
         + "{{[Gender].[Gender].MEMBERS}, {[Gender].[All Gender]}} ON AXIS(1)\n"
         + "FROM [Sales 2] WHERE {[Measures].[Unit Sales]}", "Axis #0:\n" + "{[Measures].[Unit Sales]}\n" + "Axis #1:\n"
             + "{[Product].[Drink].[Alcoholic Beverages]}\n" + "{[Product].[Drink].[Beverages]}\n"
@@ -4936,7 +4936,7 @@ public class BasicQueryTest {
         withSchema(context, SchemaModifiers.BasicQueryTestModifier11::new);
 
     Result result =
-        executeQuery(context.getConnection(), "WITH SET [#DataSet#] AS "
+        executeQuery(context.getConnectionWithDefaultRole(), "WITH SET [#DataSet#] AS "
             + "   'NonEmptyCrossjoin({Descendants([Customer_2].[All Customers], 2)}, "
             + "   {[Product].[All Products]})' "
             + "SELECT {[Measures].[Unit Sales], [Measures].[Store Sales]} on columns, "
@@ -4957,11 +4957,11 @@ public class BasicQueryTest {
         "Axis #0:\n" + "{}\n" + "Axis #1:\n" + "{[Measures].[Unit Sales]}\n" + "Axis #2:\n"
             + "{[Product].[All Products], [Time].[1997].[Q2].[5]}\n" + "Row #0: 21,081\n";
 
-    assertQueryReturns( context.getConnection(),"select NON EMPTY {[Measures].[Unit Sales]} ON COLUMNS,\n" + "NON EMPTY Crossjoin("
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"select NON EMPTY {[Measures].[Unit Sales]} ON COLUMNS,\n" + "NON EMPTY Crossjoin("
         + "  {Product.[All Products]},\n" + "  Filter(" + "    Descendants(Time.[Time], [Time].[Month]), "
         + "    Time.[Time].CurrentMember.Name = '5')) ON ROWS\n" + "from [Sales] ", desiredResult );
 
-    assertQueryReturns( context.getConnection(),"select NON EMPTY {[Measures].[Unit Sales]} ON COLUMNS,\n" + "NON EMPTY Filter("
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"select NON EMPTY {[Measures].[Unit Sales]} ON COLUMNS,\n" + "NON EMPTY Filter("
         + "  Crossjoin(" + "    {Product.[All Products]},\n" + "    Descendants(Time.[Time], [Time].[Month])),"
         + "  Time.[Time].CurrentMember.Name = '5') ON ROWS\n" + "from [Sales] ", desiredResult );
   }
@@ -4969,14 +4969,14 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testDuplicateAxisFails(Context context) {
-    assertQueryThrows(context.getConnection(), "select [Gender].Members on columns," + " [Measures].Members on columns " + "from [Sales]",
+    assertQueryThrows(context.getConnectionWithDefaultRole(), "select [Gender].Members on columns," + " [Measures].Members on columns " + "from [Sales]",
         "Duplicate axis name 'COLUMNS'." );
   }
 
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testInvalidAxisFails(Context context) {
-      Connection connection = context.getConnection();
+      Connection connection = context.getConnectionWithDefaultRole();
     assertQueryThrows(connection, "select [Gender].Members on 0," + " [Measures].Members on 10 " + "from [Sales]",
         "Axis numbers specified in a query must be sequentially specified,"
             + " and cannot contain gaps. Axis 1 (ROWS) is missing." );
@@ -5003,7 +5003,7 @@ public class BasicQueryTest {
             + "{[Gender].[F]}\n" + "{[Gender].[M]}\n" + "Row #0: 131,558\n" + "Row #0: 36,759\n" + "Row #1: 135,215\n"
             + "Row #1: 37,989\n";
 
-    assertQueryReturns( context.getConnection(),"with member [Measures].[Sum Sqft] as '" + "sum("
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"with member [Measures].[Sum Sqft] as '" + "sum("
         + "  Descendants([Store].CurrentMember, [Store].Levels(5)),"
         + "  [Store].CurrentMember.Properties(\"Store Sqft\")) '\n"
         + "select {[Store].[USA], [Store].[USA].[CA]} on 0,\n" + " [Gender].Children on 1\n" + "from [Sales]",
@@ -5011,14 +5011,14 @@ public class BasicQueryTest {
 
     // same query, except get level by name not ordinal, should give same
     // result
-    assertQueryReturns( context.getConnection(),"with member [Measures].[Sum Sqft] as '" + "sum("
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"with member [Measures].[Sum Sqft] as '" + "sum("
         + "  Descendants([Store].CurrentMember, [Store].Levels(\"Store Name\")),"
         + "  [Store].CurrentMember.Properties(\"Store Sqft\")) '\n"
         + "select {[Store].[USA], [Store].[USA].[CA]} on 0,\n" + " [Gender].Children on 1\n" + "from [Sales]",
         expected );
 
     // same query, except level is hard-coded; same result again
-    assertQueryReturns( context.getConnection(),"with member [Measures].[Sum Sqft] as '" + "sum("
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"with member [Measures].[Sum Sqft] as '" + "sum("
         + "  Descendants([Store].CurrentMember, [Store].[Store Name]),"
         + "  [Store].CurrentMember.Properties(\"Store Sqft\")) '\n"
         + "select {[Store].[USA], [Store].[USA].[CA]} on 0,\n" + " [Gender].Children on 1\n" + "from [Sales]",
@@ -5026,7 +5026,7 @@ public class BasicQueryTest {
 
     // same query, except using the level-less form of the DESCENDANTS
     // function; same result again
-    assertQueryReturns( context.getConnection(),"with member [Measures].[Sum Sqft] as '" + "sum("
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"with member [Measures].[Sum Sqft] as '" + "sum("
         + "  Descendants([Store].CurrentMember, , LEAVES)," + "  [Store].CurrentMember.Properties(\"Store Sqft\")) '\n"
         + "select {[Store].[USA], [Store].[USA].[CA]} on 0,\n" + " [Gender].Children on 1\n" + "from [Sales]",
         expected );
@@ -5035,7 +5035,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testIifWithTupleFirstAndMemberNextWithMeasure(Context context) {
-    assertQueryReturns( context.getConnection(),"WITH\n" + "MEMBER [Gender].agg "
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"WITH\n" + "MEMBER [Gender].agg "
         + "AS 'IIF(1=1, ([Gender].[All Gender],measures.[unit sales])," + "([Gender].[All Gender]))', SOLVE_ORDER = 4 "
         + "SELECT {[Measures].[unit sales]} ON 0, " + "{{[Gender].[Gender].MEMBERS},{([Gender].agg)}} on 1 FROM sales",
         "Axis #0:\n" + "{}\n" + "Axis #1:\n" + "{[Measures].[Unit Sales]}\n" + "Axis #2:\n" + "{[Gender].[F]}\n"
@@ -5046,7 +5046,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testIifWithMemberFirstAndTupleNextWithMeasure(Context context) {
-    assertQueryReturns( context.getConnection(),"WITH\n" + "MEMBER [Gender].agg " + "AS 'IIF(1=1, ([Gender].[All Gender]),"
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"WITH\n" + "MEMBER [Gender].agg " + "AS 'IIF(1=1, ([Gender].[All Gender]),"
         + "([Gender].[All Gender],measures.[unit sales]))', SOLVE_ORDER = 4 "
         + "SELECT {[Measures].[unit sales]} ON 0, " + "{{[Gender].[Gender].MEMBERS},{([Gender].agg)}} on 1 FROM sales",
         "Axis #0:\n" + "{}\n" + "Axis #1:\n" + "{[Measures].[Unit Sales]}\n" + "Axis #2:\n" + "{[Gender].[F]}\n"
@@ -5057,7 +5057,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testIifWithMemberFirstAndTupleNextWithoutMeasure(Context context) {
-    assertQueryReturns( context.getConnection(),"WITH\n" + "MEMBER [Gender].agg " + "AS 'IIF(1=1, ([Gender].[All Gender]),"
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"WITH\n" + "MEMBER [Gender].agg " + "AS 'IIF(1=1, ([Gender].[All Gender]),"
         + "([Gender].[All Gender],[Time].[1997]))', SOLVE_ORDER = 4 " + "SELECT {[Measures].[unit sales]} ON 0, "
         + "{{[Gender].[Gender].MEMBERS},{([Gender].agg)}} on 1 FROM sales", "Axis #0:\n" + "{}\n" + "Axis #1:\n"
             + "{[Measures].[Unit Sales]}\n" + "Axis #2:\n" + "{[Gender].[F]}\n" + "{[Gender].[M]}\n"
@@ -5067,7 +5067,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testIifWithTupleFirstAndMemberNextWithoutMeasure(Context context) {
-    assertQueryReturns( context.getConnection(),"WITH\n" + "MEMBER [Gender].agg " + "AS 'IIF(1=1, "
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"WITH\n" + "MEMBER [Gender].agg " + "AS 'IIF(1=1, "
         + "([Store].[All Stores].[USA], [Gender].[All Gender]), " + "([Gender].[All Gender]))', " + "SOLVE_ORDER = 4 "
         + "SELECT {[Measures].[unit sales]} ON 0, " + "{([Gender].agg)} on 1 FROM sales", "Axis #0:\n" + "{}\n"
             + "Axis #1:\n" + "{[Measures].[Unit Sales]}\n" + "Axis #2:\n" + "{[Gender].[agg]}\n"
@@ -5077,7 +5077,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testIifWithTuplesOfUnequalSizes(Context context) {
-    assertQueryReturns( context.getConnection(),"WITH\n" + "MEMBER [Gender].agg "
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"WITH\n" + "MEMBER [Gender].agg "
         + "AS 'IIF(Measures.currentMember is [Measures].[Unit Sales], "
         + "([Store].[All Stores],[Gender].[All Gender],measures.[unit sales]),"
         + "([Store].[All Stores],[Gender].[All Gender]))', SOLVE_ORDER = 4 "
@@ -5090,7 +5090,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testIifWithTuplesOfUnequalSizesAndOrder(Context context) {
-    assertQueryReturns( context.getConnection(),"WITH\n" + "MEMBER [Gender].agg "
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"WITH\n" + "MEMBER [Gender].agg "
         + "AS 'IIF(Measures.currentMember is [Measures].[Unit Sales], "
         + "([Store].[All Stores],[Gender].[M],measures.[unit sales]),"
         + "([Gender].[M],[Store].[All Stores]))', SOLVE_ORDER = 4 " + "SELECT {[Measures].[unit sales]} ON 0, "
@@ -5103,7 +5103,7 @@ public class BasicQueryTest {
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testEmptyAggregationListDueToFilterDoesNotThrowException(Context context) {
     ((TestConfig)context.getConfig()).setIgnoreMeasureForNonJoiningDimension(true);
-    assertQueryReturns( context.getConnection(),"WITH \n" + "MEMBER [GENDER].[AGG] "
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"WITH \n" + "MEMBER [GENDER].[AGG] "
         + "AS 'AGGREGATE(FILTER([S1], (NOT ISEMPTY([MEASURES].[STORE SALES]))))' " + "SET [S1] "
         + "AS 'CROSSJOIN({[GENDER].[GENDER].MEMBERS},{[STORE].[CANADA].CHILDREN})' " + "SELECT\n"
         + "{[MEASURES].[STORE SALES]} ON COLUMNS,\n" + "{[GENDER].[AGG]} ON ROWS\n" + "FROM [WAREHOUSE AND SALES]",
@@ -5121,18 +5121,18 @@ public class BasicQueryTest {
     final String expectedResult =
         "Axis #0:\n" + "{}\n" + "Axis #1:\n" + "{[Measures].[Unit Sales]}\n" + "Axis #2:\n"
             + "{[Store].[All Stores], [Product].[All Products], [Customers].[All Customers]}\n" + "Row #0: 266,773\n";
-    assertQueryReturns( context.getConnection(),"select {[Measures].[Unit Sales]} ON COLUMNS, " + "NON EMPTY Crossjoin({[Store].[All Stores]}"
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"select {[Measures].[Unit Sales]} ON COLUMNS, " + "NON EMPTY Crossjoin({[Store].[All Stores]}"
         + ", Crossjoin({[Product].[All Products]}, {[Customers].[All Customers]})) ON ROWS " + "from [Sales]",
         expectedResult );
     // without NON EMPTY
-    assertQueryReturns( context.getConnection(),"select {[Measures].[Unit Sales]} ON COLUMNS, " + "  Crossjoin({[Store].[All Stores]}"
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"select {[Measures].[Unit Sales]} ON COLUMNS, " + "  Crossjoin({[Store].[All Stores]}"
         + ", Crossjoin({[Product].[All Products]}, {[Customers].[All Customers]})) ON ROWS " + "from [Sales]",
         expectedResult );
     // using * operator
-    assertQueryReturns( context.getConnection(),"select {[Measures].[Unit Sales]} ON COLUMNS, " + "NON EMPTY [Store].[All Stores] "
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"select {[Measures].[Unit Sales]} ON COLUMNS, " + "NON EMPTY [Store].[All Stores] "
         + " * [Product].[All Products]" + " * [Customers].[All Customers] ON ROWS " + "from [Sales]", expectedResult );
     // combining tuple
-    assertQueryReturns( context.getConnection(),"select {[Measures].[Unit Sales]} ON COLUMNS, " + "NON EMPTY [Store].[All Stores] "
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"select {[Measures].[Unit Sales]} ON COLUMNS, " + "NON EMPTY [Store].[All Stores] "
         + " * {([Product].[All Products]," + "     [Customers].[All Customers])} ON ROWS " + "from [Sales]",
         expectedResult );
     // combining two members with tuple
@@ -5140,13 +5140,13 @@ public class BasicQueryTest {
         "Axis #0:\n" + "{}\n" + "Axis #1:\n" + "{[Measures].[Unit Sales]}\n" + "Axis #2:\n"
             + "{[Store].[All Stores], [Product].[All Products], [Customers].[All Customers], [Gender].[All Gender]}\n"
             + "Row #0: 266,773\n";
-    assertQueryReturns( context.getConnection(),"select {[Measures].[Unit Sales]} ON COLUMNS, " + "NON EMPTY [Store].[All Stores] "
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"select {[Measures].[Unit Sales]} ON COLUMNS, " + "NON EMPTY [Store].[All Stores] "
         + " * [Product].[All Products]" + " * {([Customers].[All Customers], [Gender].[All Gender])} ON ROWS "
         + "from [Sales]", expectedResult4 );
-    assertQueryReturns( context.getConnection(),"select {[Measures].[Unit Sales]} ON COLUMNS, " + "NON EMPTY [Store].[All Stores] "
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"select {[Measures].[Unit Sales]} ON COLUMNS, " + "NON EMPTY [Store].[All Stores] "
         + " * {([Product].[All Products], [Customers].[All Customers])}" + " * [Gender].[All Gender] ON ROWS "
         + "from [Sales]", expectedResult4 );
-    assertQueryReturns( context.getConnection(),"select {[Measures].[Unit Sales]} ON COLUMNS, "
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"select {[Measures].[Unit Sales]} ON COLUMNS, "
         + "NON EMPTY {([Store].[All Stores], [Product].[All Products])}" + " * [Customers].[All Customers]"
         + " * [Gender].[All Gender] ON ROWS " + "from [Sales]", expectedResult4 );
   }
@@ -5158,7 +5158,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testHeterogeneousAxis(Context context) {
-      Connection connection = context.getConnection();
+      Connection connection = context.getConnectionWithDefaultRole();
     // SSAS2005 gives error:
     // Query (1, 8) Two sets specified in the function have different
     // dimensionality.
@@ -5172,7 +5172,7 @@ public class BasicQueryTest {
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testQueryWithNullMember(Context context) {
     // https://jira.pentaho.com/browse/MONDRIAN-2643
-    assertQueryReturns( context.getConnection(),"WITH\n"
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"WITH\n"
         + " SET [*NATIVE_CJ_SET] AS 'FILTER( FILTER([Store Size in SQFT].[Store Sqft].MEMBERS,\n" + "\n"
         + "CASE WHEN ([Store Size in SQFT].CURRENTMEMBER  IS NULL )\n" + "THEN 1=0 ELSE\n"
         + "CAST([Store Size in SQFT].CURRENTMEMBER.CAPTION AS NUMERIC)  > 3500\n" + "END\n" + "\n"
@@ -5202,7 +5202,7 @@ public class BasicQueryTest {
     if ( !SystemWideProperties.instance().SsasCompatibleNaming ) {
       return;
     }
-    assertQueryReturns( context.getConnection(),"select [Time].[Year].Members on columns,\n" + "[Time].[Weekly].[1997].[6].Children on rows\n"
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"select [Time].[Year].Members on columns,\n" + "[Time].[Weekly].[1997].[6].Children on rows\n"
         + "from [Sales]", "Axis #0:\n" + "{}\n" + "Axis #1:\n" + "{[Time].[1997]}\n" + "{[Time].[1998]}\n"
             + "Axis #2:\n" + "{[Time].[Weekly].[1997].[6].[1]}\n" + "{[Time].[Weekly].[1997].[6].[26]}\n"
             + "{[Time].[Weekly].[1997].[6].[27]}\n" + "{[Time].[Weekly].[1997].[6].[28]}\n"
@@ -5225,10 +5225,10 @@ public class BasicQueryTest {
             + "  </SQL></MeasureExpression></Measure>", null, null ));
        */
       withSchema(context, SchemaModifiers.BasicQueryTestModifier12::new);
-      assertQueryReturns(context.getConnection(),"select " + "Crossjoin([Gender].[Gender].Members, [Measures].[zero]) ON COLUMNS\n"
+      assertQueryReturns(context.getConnectionWithDefaultRole(),"select " + "Crossjoin([Gender].[Gender].Members, [Measures].[zero]) ON COLUMNS\n"
         + "from [Sales] " + "  \n", "Axis #0:\n" + "{}\n" + "Axis #1:\n" + "{[Gender].[F], [Measures].[zero]}\n"
             + "{[Gender].[M], [Measures].[zero]}\n" + "Row #0: 0\n" + "Row #0: 0\n" );
-    assertQueryReturns( context.getConnection(),"select [Measures].[zero] ON COLUMNS,\n" + "  {[Gender].[All Gender]}  ON ROWS\n"
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"select [Measures].[zero] ON COLUMNS,\n" + "  {[Gender].[All Gender]}  ON ROWS\n"
         + "from [Sales] " + " ", "Axis #0:\n" + "{}\n" + "Axis #1:\n" + "{[Measures].[zero]}\n" + "Axis #2:\n"
             + "{[Gender].[All Gender]}\n" + "Row #0: 0\n" );
   }
@@ -5248,10 +5248,10 @@ public class BasicQueryTest {
             null, null, null );
        */
       TestUtil.withSchema(context, SchemaModifiers.BasicQueryTestModifier28::new);
-      assertQueryReturns( context.getConnection(),"select " + "Crossjoin([Gender].[Gender].Members, [Measures].[zero]) ON COLUMNS\n"
+      assertQueryReturns( context.getConnectionWithDefaultRole(),"select " + "Crossjoin([Gender].[Gender].Members, [Measures].[zero]) ON COLUMNS\n"
         + "from [FooBarZerOneAnything] ", "Axis #0:\n" + "{}\n" + "Axis #1:\n" + "{[Gender].[F], [Measures].[zero]}\n"
             + "{[Gender].[M], [Measures].[zero]}\n" + "Row #0: 0\n" + "Row #0: 0\n" );
-      assertQueryReturns( context.getConnection(),"select [Measures].[zero] ON COLUMNS,\n" + "  {[Gender].[All Gender]}  ON ROWS\n"
+      assertQueryReturns( context.getConnectionWithDefaultRole(),"select [Measures].[zero] ON COLUMNS,\n" + "  {[Gender].[All Gender]}  ON ROWS\n"
         + "from [FooBarZerOneAnything] ", "Axis #0:\n" + "{}\n" + "Axis #1:\n" + "{[Measures].[zero]}\n" + "Axis #2:\n"
             + "{[Gender].[All Gender]}\n" + "Row #0: 0\n" );
   }
@@ -5361,7 +5361,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testHighCardSqlTupleReaderLeakingConnections(Context context) {
-    assertQueryReturns( context.getConnection(),"WITH MEMBER [Measures].[NegativeSales] AS '- [Measures].[Store Sales]' "
+    assertQueryReturns( context.getConnectionWithDefaultRole(),"WITH MEMBER [Measures].[NegativeSales] AS '- [Measures].[Store Sales]' "
         + "MEMBER [Product].[SameName] AS 'Aggregate(Filter("
         + "[Product].[Product Name].members,([Measures].[Store Sales] > 0)))' " + "MEMBER [Measures].[SameName] AS "
         + "'([Measures].[Store Sales],[Product].[SameName])' "
@@ -5384,7 +5384,7 @@ public class BasicQueryTest {
             + "      [Store].[All Stores].[USA].[WA].[Seattle].[Store 15],"
             + "      [Time.Weekly].[All Time.Weeklys].[1997].[24].[3]" + "  )" + "  }" + "  on 0,"
             + "  [Measures].[units shipped] on 1" + " from warehouse";
-    assertQueryReturns( context.getConnection(),mdx, "Axis #0:\n" + "{}\n" + "Axis #1:\n"
+    assertQueryReturns( context.getConnectionWithDefaultRole(),mdx, "Axis #0:\n" + "{}\n" + "Axis #1:\n"
         + "{[Product].[Food].[Produce].[Vegetables].[Fresh Vegetables]" + ".[Tell Tale].[Tell Tale Tomatos], "
         + "[Warehouse].[USA].[WA].[Seattle].[Quality Warehousing and " + "Trucking], "
         + "[Store].[USA].[WA].[Seattle].[Store 15], " + "[Time.Weekly].[1997].[24].[3]}\n" + "Axis #2:\n"
@@ -5400,7 +5400,7 @@ public class BasicQueryTest {
                 + "<Formula>([Gender].LastChild)</Formula>" + "</CalculatedMember>" ));
      */
       withSchema(context, SchemaModifiers.BasicQueryTestModifier9::new);
-      assertQueryReturns( context.getConnection(),"select {[Gender].[M]} on 0 from sales", "Axis #0:\n" + "{}\n" + "Axis #1:\n"
+      assertQueryReturns( context.getConnectionWithDefaultRole(),"select {[Gender].[M]} on 0 from sales", "Axis #0:\n" + "{}\n" + "Axis #1:\n"
         + "{[Gender].[M]}\n" + "Row #0: 135,215\n" );
   }
 
@@ -5411,7 +5411,7 @@ public class BasicQueryTest {
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testConcurrentStatementRun(Context context) throws Exception {
-    final Connection connection = context.getConnection();
+    final Connection connection = context.getConnectionWithDefaultRole();
 
     final String mdxQuery =
         "select {TopCount([Customers].Members, 10, [Measures].[Unit Sales])} on columns from [Sales]";
@@ -5453,28 +5453,28 @@ public class BasicQueryTest {
   void testRollup(Context context) {
     switch ( 2 ) {
       case 0:
-        assertQueryReturns( context.getConnection(),"select [Gender].Children * [Product].Children on 0\n" + "from [Sales]", "Axis #0:\n"
+        assertQueryReturns( context.getConnectionWithDefaultRole(),"select [Gender].Children * [Product].Children on 0\n" + "from [Sales]", "Axis #0:\n"
             + "{}\n" + "Axis #1:\n" + "{[Gender].[F], [Product].[Drink]}\n" + "{[Gender].[F], [Product].[Food]}\n"
             + "{[Gender].[F], [Product].[Non-Consumable]}\n" + "{[Gender].[M], [Product].[Drink]}\n"
             + "{[Gender].[M], [Product].[Food]}\n" + "{[Gender].[M], [Product].[Non-Consumable]}\n"
             + "Row #0: 12,202\n" + "Row #0: 94,814\n" + "Row #0: 24,542\n" + "Row #0: 12,395\n" + "Row #0: 97,126\n"
             + "Row #0: 25,694\n" );
         // now, should be able to answer this one by rolling up gender
-        assertQueryReturns( context.getConnection(),"select [Product].Children on 0\n" + "from [Sales]", "Axis #0:\n" + "{}\n" + "Axis #1:\n"
+        assertQueryReturns( context.getConnectionWithDefaultRole(),"select [Product].Children on 0\n" + "from [Sales]", "Axis #0:\n" + "{}\n" + "Axis #1:\n"
             + "{[Product].[Drink]}\n" + "{[Product].[Food]}\n" + "{[Product].[Non-Consumable]}\n" + "Row #0: 24,597\n"
             + "Row #0: 191,940\n" + "Row #0: 50,236\n" );
         break;
       case 1:
-        assertQueryReturns( context.getConnection(),"select [Gender].[M] * [Product].Children on 0\n" + "from [Sales]", "Axis #0:\n" + "{}\n"
+        assertQueryReturns( context.getConnectionWithDefaultRole(),"select [Gender].[M] * [Product].Children on 0\n" + "from [Sales]", "Axis #0:\n" + "{}\n"
             + "Axis #1:\n" + "{[Gender].[M], [Product].[Drink]}\n" + "{[Gender].[M], [Product].[Food]}\n"
             + "{[Gender].[M], [Product].[Non-Consumable]}\n" + "Row #0: 12,395\n" + "Row #0: 97,126\n"
             + "Row #0: 25,694\n" );
-        assertQueryReturns( context.getConnection(),"select [Gender].[F] * [Product].Children on 0\n" + "from [Sales]", "Axis #0:\n" + "{}\n"
+        assertQueryReturns( context.getConnectionWithDefaultRole(),"select [Gender].[F] * [Product].Children on 0\n" + "from [Sales]", "Axis #0:\n" + "{}\n"
             + "Axis #1:\n" + "{[Gender].[F], [Product].[Drink]}\n" + "{[Gender].[F], [Product].[Food]}\n"
             + "{[Gender].[F], [Product].[Non-Consumable]}\n" + "Row #0: 12,202\n" + "Row #0: 94,814\n"
             + "Row #0: 24,542\n" );
         // now, should be able to answer this one by rolling up gender
-        assertQueryReturns( context.getConnection(),"select [Product].Children on 0\n" + "from [Sales]", "Axis #0:\n" + "{}\n" + "Axis #1:\n"
+        assertQueryReturns( context.getConnectionWithDefaultRole(),"select [Product].Children on 0\n" + "from [Sales]", "Axis #0:\n" + "{}\n" + "Axis #1:\n"
             + "{[Product].[Drink]}\n" + "{[Product].[Food]}\n" + "{[Product].[Non-Consumable]}\n" + "Row #0: 24,597\n"
             + "Row #0: 191,940\n" + "Row #0: 50,236\n" );
         break;
@@ -5483,12 +5483,12 @@ public class BasicQueryTest {
         String[] states = { "USA", "Canada", "Mexico" };
         for ( String state : states ) {
           for ( String gender : genders ) {
-            executeQuery(context.getConnection(), "select [Gender].[" + gender + "] * [Store].[" + state
+            executeQuery(context.getConnectionWithDefaultRole(), "select [Gender].[" + gender + "] * [Store].[" + state
                 + "] * [Product].Children on 0\n" + "from [Sales]" );
           }
         }
         // now, should be able to answer this one by rolling up gender
-        assertQueryReturns( context.getConnection(),"select [Product].Children on 0\n" + "from [Sales]", "Axis #0:\n" + "{}\n" + "Axis #1:\n"
+        assertQueryReturns( context.getConnectionWithDefaultRole(),"select [Product].Children on 0\n" + "from [Sales]", "Axis #0:\n" + "{}\n" + "Axis #1:\n"
             + "{[Product].[Drink]}\n" + "{[Product].[Food]}\n" + "{[Product].[Non-Consumable]}\n" + "Row #0: 24,597\n"
             + "Row #0: 191,940\n" + "Row #0: 50,236\n" );
         break;
@@ -5509,7 +5509,7 @@ public class BasicQueryTest {
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testStatistics(Context context) {
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     final String product = getDialect(connection).getDialectName();
     final String dialectClassName = getDialect(connection).getClass().getName();
 
@@ -5554,7 +5554,7 @@ public class BasicQueryTest {
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testResultLimit(Context context) throws Exception {
     SystemWideProperties.instance().ResultLimit = 1000;
-    assertAxisThrows(context.getConnection(), "CrossJoin([Product].[Brand Name].Members, [Gender].[Gender].Members)",
+    assertAxisThrows(context.getConnectionWithDefaultRole(), "CrossJoin([Product].[Brand Name].Members, [Gender].[Gender].Members)",
         "result (1,001) exceeded limit (1,000)" );
   }
 
@@ -5562,7 +5562,7 @@ public class BasicQueryTest {
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testResultLimitWithinLimit(Context context) {
     SystemWideProperties.instance().ResultLimit = 5000;
-    executeQuery(context.getConnection(),
+    executeQuery(context.getConnectionWithDefaultRole(),
         "select CrossJoin([Product].[Brand Name].Members, [Gender].[Gender].Members) on columns from [Sales]" );
   }
 
@@ -5603,13 +5603,13 @@ public class BasicQueryTest {
     Future<Result> task1 = es.submit( new Callable<Result>() {
       @Override
 	public Result call() throws Exception {
-        return executeQuery(context.getConnection(), query );
+        return executeQuery(context.getConnectionWithDefaultRole(), query );
       }
     } );
     Future<Result> task2 = es.submit( new Callable<Result>() {
       @Override
 	public Result call() throws Exception {
-        return executeQuery(context.getConnection(), query );
+        return executeQuery(context.getConnectionWithDefaultRole(), query );
       }
     } );
 
@@ -5637,14 +5637,14 @@ public class BasicQueryTest {
     String[] equivalentMemberNames =
         { "gender.gender.F", "gender.gender.f", "gender.[All gender].F", "gender.[All gender].f" };
     for ( String memberName : equivalentMemberNames ) {
-      assertQueryReturns(context.getConnection(),"select " + memberName + " on 0 from sales", "Axis #0:\n" + "{}\n" + "Axis #1:\n"
+      assertQueryReturns(context.getConnectionWithDefaultRole(),"select " + memberName + " on 0 from sales", "Axis #0:\n" + "{}\n" + "Axis #1:\n"
           + "{[Gender].[F]}\n" + "Row #0: 131,558\n" );
     }
     // also verify case.sensitive=true is honored
     SystemWideProperties.instance().CaseSensitive = true;
     String[] wrongCase = { "gender.gender.f", "gender.[All gender].f" };
     for ( String memberName : wrongCase ) {
-      assertExprThrows(context.getConnection(), "select " + memberName + " on 0 from sales", "Failed to parse query" );
+      assertExprThrows(context.getConnectionWithDefaultRole(), "select " + memberName + " on 0 from sales", "Failed to parse query" );
     }
     SystemWideProperties.instance().CaseSensitive = false;
   }
@@ -5677,7 +5677,7 @@ public class BasicQueryTest {
       @Override
 	public void run( ExecutorService exec, Query q1, AtomicBoolean fail, AtomicBoolean success, Runnable r1,
           Runnable r2 ) throws Exception {
-        flushSchemaCache(context.getConnection());
+        flushSchemaCache(context.getConnectionWithDefaultRole());
 
         // Run the first query
         exec.submit( r1 );
@@ -5719,7 +5719,7 @@ public class BasicQueryTest {
       @Override
 	public void run( ExecutorService exec, Query q1, AtomicBoolean fail, AtomicBoolean success, Runnable r1,
           Runnable r2 ) throws Exception {
-        flushSchemaCache(context.getConnection());
+        flushSchemaCache(context.getConnectionWithDefaultRole());
 
         // Run the first query
         exec.submit( r1 );
@@ -5756,7 +5756,7 @@ public class BasicQueryTest {
   }
 
   private void runMondrian1506(Context context, Mondrian1506Lambda lambda ) throws Exception {
-    if ( getDatabaseProduct(getDialect(context.getConnection()).getDialectName()) != DatabaseProduct.MYSQL ) {
+    if ( getDatabaseProduct(getDialect(context.getConnectionWithDefaultRole()).getDialectName()) != DatabaseProduct.MYSQL ) {
       // This only works on MySQL because of Sleep()
       return;
     }
@@ -5782,7 +5782,7 @@ public class BasicQueryTest {
         } );
 
     // We are testing the old Query API.
-    final Connection connection = context.getConnection();
+    final Connection connection = context.getConnectionWithDefaultRole();
     final Query q1 = connection.parseQuery( mdx );
     final Query q2 = connection.parseQuery( mdx );
 
@@ -5836,7 +5836,7 @@ public class BasicQueryTest {
             null ));
      */
 	  withSchema(context, SchemaModifiers.BasicQueryTestModifier7::new);
-      Connection connection = context.getConnection();
+      Connection connection = context.getConnectionWithDefaultRole();
     executeQuery(connection, "select " + "Crossjoin([Gender].[Gender].Members, [Measures].[zero]) ON COLUMNS\n"
         + "from [Sales] " + " \n" );
     // Some DBs return 0 when we ask for null. Like Oracle.
@@ -5849,7 +5849,7 @@ public class BasicQueryTest {
         returnedValue = "";
     }
 
-    assertQueryReturns(context.getConnection(),"select [Measures].[zero] ON COLUMNS,\n" + " {[Gender].[All Gender]} ON ROWS\n"
+    assertQueryReturns(context.getConnectionWithDefaultRole(),"select [Measures].[zero] ON COLUMNS,\n" + " {[Gender].[All Gender]} ON ROWS\n"
         + "from [Sales] " + " ", "Axis #0:\n" + "{}\n" + "Axis #1:\n" + "{[Measures].[zero]}\n" + "Axis #2:\n"
             + "{[Gender].[All Gender]}\n" + "Row #0: " + returnedValue + "\n" );
   }
@@ -5933,7 +5933,7 @@ public class BasicQueryTest {
             + "{[Yearly Income].[*TOTAL_MEMBER_SEL~SUM]}), {([Gender].[*DEFAULT_MEMBER], [Education Level]"
             + ".[*DEFAULT_MEMBER])}), [*SORTED_ROW_AXIS])))))) ON ROWS\n" + "from [Sales]\n"
             + "where [*CJ_SLICER_AXIS]\n";
-    executeQuery(context.getConnection(), mdx);
+    executeQuery(context.getConnectionWithDefaultRole(), mdx);
   }
 
   /**
@@ -5943,7 +5943,7 @@ public class BasicQueryTest {
     @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testNameExpressionSnowflake(Context context) {
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     Dialect dialect = getDialect(connection);
     /*
       ((BaseTestContext)context).update(SchemaUpdater.createSubstitutingCube( "Sales",
@@ -5976,7 +5976,7 @@ public class BasicQueryTest {
     CatalogMapping catalog = ((RolapContext) context).getCatalogMapping();
     ((TestContext)context).setCatalogMappingSupplier(new SchemaModifiers.BasicQueryTestModifier8(catalog, dialect));
 
-        connection = context.getConnection();
+        connection = context.getConnectionWithDefaultRole();
     assertAxisReturns(connection, "[Example.Example Hierarchy].[Non-Zero]",
         "[Example.Example Hierarchy].[Non-Zero]" );
     assertAxisReturns(connection, "[Example.Example Hierarchy].[Non-Zero].Children",
@@ -6031,7 +6031,7 @@ public class BasicQueryTest {
             + "Row #2: 107,366.33\n";
     //TestContext testContext = TestContext.instance().withFreshConnection().withSchema( schema );
     TestUtil.withSchema(context, SchemaModifiers.BasicQueryTestModifier31::new);
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     assertQueryReturns(connection, mdxWithoutBug, expectedResultInNoBugCube );
     assertQueryReturns(connection, mdxWithBug, expectedResultInBugCube );
   }
@@ -6044,7 +6044,7 @@ public class BasicQueryTest {
             + "select [Measures].[Gender Current Member] on 0\n" + "from [Sales]\n"
             + "where { [Gender].[M], [Gender].[F] }";
     try {
-      executeQuery(context.getConnection(), mdx );
+      executeQuery(context.getConnectionWithDefaultRole(), mdx );
       fail( "MondrianException is expected" );
     } catch ( OlapRuntimeException e ) {
       assertEquals( "The " + "MDX function CURRENTMEMBER failed "
@@ -6065,7 +6065,7 @@ public class BasicQueryTest {
             + "where { [Gender].[M], [Gender].[F] }";
 
     try {
-      assertQueryReturns(context.getConnection(), mdx, "Axis #0:\n" + "{[Gender].[M]}\n" + "{[Gender].[F]}\n" + "Axis #1:\n"
+      assertQueryReturns(context.getConnectionWithDefaultRole(), mdx, "Axis #0:\n" + "{[Gender].[M]}\n" + "{[Gender].[F]}\n" + "Axis #1:\n"
           + "{[Measures].[Gender Current Member]}\n" + "Row #0: #null\n" );
     } catch ( OlapRuntimeException e ) {
       fail( "MondrianException is not expected" );
@@ -6086,7 +6086,7 @@ public class BasicQueryTest {
             + "{ [Measures].[Drink Sales Current Period]," + " [Measures].[Drink Sales Current Period] } on 0\n"
             + "from [Sales]\n" + "where { [Time].[1997].[Q4],[Time].[1997].[Q3] }\n";
     try {
-      executeQuery(context.getConnection(), mdx);
+      executeQuery(context.getConnectionWithDefaultRole(), mdx);
       fail( "MondrianException is expected" );
     } catch ( OlapRuntimeException e ) {
       assertEquals( "The " + "MDX function CURRENTMEMBER failed "
@@ -6110,7 +6110,7 @@ public class BasicQueryTest {
             + "from [Sales]\n" + "where { [Time].[1997].[Q4],[Time].[1997].[Q3] }\n";
 
     try {
-      assertQueryReturns(context.getConnection(), mdx, "Axis #0:\n" + "{[Time].[1997].[Q4]}\n" + "{[Time].[1997].[Q3]}\n"
+      assertQueryReturns(context.getConnectionWithDefaultRole(), mdx, "Axis #0:\n" + "{[Time].[1997].[Q4]}\n" + "{[Time].[1997].[Q3]}\n"
           + "Axis #1:\n" + "{[Measures].[Drink Sales Current Period]}\n"
           + "{[Measures].[Drink Sales Current Period]}\n" + "Row #0: \n" + "Row #0: \n" );
     } catch ( OlapRuntimeException e ) {
@@ -6123,7 +6123,7 @@ public class BasicQueryTest {
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testMondrian625(Context context) {
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     assertQueriesReturnSimilarResults(connection, "select\n" + "    {[Measures].[Unit Sales]} ON COLUMNS,\n"
         + "    {Descendants([Customers].[All Customers], 4)} ON ROWS\n" + "from\n" + "    [Sales]\n" + "where\n"
         + "    ([Time].[1997].[Q4].[12])", "select\n" + "    {[Measures].[Unit Sales]} ON COLUMNS,\n"
@@ -6186,7 +6186,7 @@ public class BasicQueryTest {
             + "Row #5: 41,580\n" + "Row #6: 2,237\n" + "Row #7: 23,591\n" + "Row #8: 35,257\n" + "Row #9: 24,576\n";
 
     TestUtil.withSchema(context, SchemaModifiers.BasicQueryTestModifier32::new);
-    assertQueryReturns( context.getConnection(),mdx, result );
+    assertQueryReturns( context.getConnectionWithDefaultRole(),mdx, result );
   }
 
   /**

--- a/mondrian/src/test/java/mondrian/test/CacheTest.java
+++ b/mondrian/src/test/java/mondrian/test/CacheTest.java
@@ -57,7 +57,7 @@ class CacheTest {
     void testNQueriesWaitingForSameSegmentRepeat(Context foodMartContext)
         throws ExecutionException, InterruptedException
     {
-		Connection connection = foodMartContext.getConnection();
+		Connection connection = foodMartContext.getConnectionWithDefaultRole();
         final int parallel = 10;
         final ThreadPoolExecutor executor =
             new ThreadPoolExecutor(

--- a/mondrian/src/test/java/mondrian/test/CaptionTest.java
+++ b/mondrian/src/test/java/mondrian/test/CaptionTest.java
@@ -43,7 +43,7 @@ class CaptionTest{
     void testMeasureCaption(Context context) {
         withSchema(context, MyFoodmartModifier::new);
         final Connection monConnection =
-                context.getConnection();
+                context.getConnectionWithDefaultRole();
         String mdxQuery =
                 "SELECT {[Measures].[Unit Sales]} ON COLUMNS, "
                         + "{[Time].[1997].[Q1]} ON ROWS FROM [Sales]";
@@ -64,7 +64,7 @@ class CaptionTest{
     void testDimCaption(Context context) {
         withSchema(context, MyFoodmartModifier::new);
         final Connection monConnection =
-                context.getConnection();
+                context.getConnectionWithDefaultRole();
         String mdxQuery =
                 "SELECT {[Measures].[Unit Sales]} ON COLUMNS, "
                         + "{[Promotion Media].[All Media]} ON ROWS FROM [Sales]";
@@ -90,7 +90,7 @@ class CaptionTest{
                         + "FROM [Sales]";
         withSchema(context, MyFoodmartModifier::new);
         final Connection monConnection =
-                context.getConnection();
+                context.getConnectionWithDefaultRole();
         Query monQuery = monConnection.parseQuery(mdxQuery);
         Result monResult = monConnection.execute(monQuery);
         Axis[] axes = monResult.getAxes();
@@ -114,7 +114,7 @@ class CaptionTest{
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testLevelCaptionExpression(Context context) {
 
-        switch (getDatabaseProduct(getDialect(context.getConnection()).getDialectName())) {
+        switch (getDatabaseProduct(getDialect(context.getConnectionWithDefaultRole()).getDialectName())) {
             case ACCESS:
             case ORACLE:
             case MARIADB:
@@ -127,7 +127,7 @@ class CaptionTest{
         }
         withSchema(context, MyFoodmartModifier::new);
         final Connection monConnection =
-                context.getConnection();
+                context.getConnectionWithDefaultRole();
         String mdxQuery =
                 "SELECT {[Measures].[Unit Sales]} ON COLUMNS, "
                         + "{[Time].[Year].Members} ON ROWS FROM [Sales]";

--- a/mondrian/src/test/java/mondrian/test/CompatibilityTest.java
+++ b/mondrian/src/test/java/mondrian/test/CompatibilityTest.java
@@ -76,7 +76,7 @@ class CompatibilityTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testCubeCase(Context foodMartContext) {
-    	Connection connection = foodMartContext.getConnection();
+    	Connection connection = foodMartContext.getConnectionWithDefaultRole();
         String queryFrom = "select {[Measures].[Unit Sales]} on columns from ";
         String result =
             "Axis #0:\n"
@@ -97,7 +97,7 @@ class CompatibilityTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testCubeBrackets(Context foodMartContext) {
-    	Connection connection = foodMartContext.getConnection();
+    	Connection connection = foodMartContext.getConnectionWithDefaultRole();
         String queryFrom = "select {[Measures].[Unit Sales]} on columns from ";
         String result =
             "Axis #0:\n"
@@ -118,7 +118,7 @@ class CompatibilityTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testReservedWord(Context foodMartContext) {
-    	Connection connection = foodMartContext.getConnection();
+    	Connection connection = foodMartContext.getConnectionWithDefaultRole();
     	TestUtil.assertAxisThrows(
     		connection,
             "with member [Measures].ordinal as '1'\n"
@@ -141,7 +141,7 @@ class CompatibilityTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testDimensionCase(Context foodMartContext) {
-    	Connection connection = foodMartContext.getConnection();
+    	Connection connection = foodMartContext.getConnectionWithDefaultRole();
         checkAxis(connection, "[Measures].[Unit Sales]", "[Measures].[Unit Sales]");
         checkAxis(connection, "[Measures].[Unit Sales]", "[MEASURES].[Unit Sales]");
         checkAxis(connection, "[Measures].[Unit Sales]", "[mEaSuReS].[Unit Sales]");
@@ -159,7 +159,7 @@ class CompatibilityTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testDimensionBrackets(Context foodMartContext) {
-    	Connection connection = foodMartContext.getConnection();
+    	Connection connection = foodMartContext.getConnectionWithDefaultRole();
         checkAxis(connection, "[Measures].[Unit Sales]", "Measures.[Unit Sales]");
         checkAxis(connection, "[Measures].[Unit Sales]", "MEASURES.[Unit Sales]");
         checkAxis(connection, "[Measures].[Unit Sales]", "mEaSuReS.[Unit Sales]");
@@ -177,7 +177,7 @@ class CompatibilityTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testMemberCase(Context foodMartContext) {
-    	Connection connection = foodMartContext.getConnection();
+    	Connection connection = foodMartContext.getConnectionWithDefaultRole();
         checkAxis(connection, "[Measures].[Unit Sales]", "[Measures].[UNIT SALES]");
         checkAxis(connection, "[Measures].[Unit Sales]", "[Measures].[uNiT sAlEs]");
         checkAxis(connection, "[Measures].[Unit Sales]", "[Measures].[unit sales]");
@@ -204,7 +204,7 @@ class CompatibilityTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testCalculatedMemberCase(Context foodMartContext) {
-    	Connection connection = foodMartContext.getConnection();
+    	Connection connection = foodMartContext.getConnectionWithDefaultRole();
         SystemWideProperties.instance().CaseSensitive = false;
         TestUtil.assertQueryReturns(
     		connection,
@@ -241,7 +241,7 @@ class CompatibilityTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testSolveOrderCase(Context foodMartContext) {
-    	Connection connection = foodMartContext.getConnection();
+    	Connection connection = foodMartContext.getConnectionWithDefaultRole();
         checkSolveOrder(connection, "SOLVE_ORDER");
         checkSolveOrder(connection, "SoLvE_OrDeR");
         checkSolveOrder(connection, "solve_order");
@@ -273,7 +273,7 @@ class CompatibilityTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testMemberBrackets(Context foodMartContext) {
-    	Connection connection = foodMartContext.getConnection();
+    	Connection connection = foodMartContext.getConnectionWithDefaultRole();
         checkAxis(connection, "[Measures].[Profit]", "[Measures].Profit");
         checkAxis(connection, "[Measures].[Profit]", "[Measures].pRoFiT");
         checkAxis(connection, "[Measures].[Profit]", "[Measures].PROFIT");
@@ -304,7 +304,7 @@ class CompatibilityTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testHierarchyNames(Context foodMartContext) {
-    	Connection connection = foodMartContext.getConnection();
+    	Connection connection = foodMartContext.getConnectionWithDefaultRole();
         checkAxis(connection, "[Customers].[All Customers]", "[Customers].[All Customers]");
         checkAxis(
     		connection,
@@ -344,7 +344,7 @@ class CompatibilityTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testCaseInsensitiveNullMember(Context foodMartContext) throws SQLException, IOException {
-    	Connection connection = foodMartContext.getConnection();
+    	Connection connection = foodMartContext.getConnectionWithDefaultRole();
         DataSource dataSource = connection.getDataSource();
         final Dialect dialect = foodMartContext.getDialect();
         if (getDatabaseProduct(dialect.getDialectName()) == DatabaseProduct.LUCIDDB) {
@@ -397,7 +397,7 @@ class CompatibilityTest {
             null);
          */
         TestUtil.withSchema(foodMartContext, SchemaModifiers.Ssas2005CompatibilityTestModifier4::new);
-        connection = foodMartContext.getConnection();
+        connection = foodMartContext.getConnectionWithDefaultRole();
 
         // This test should work irrespective of the case-sensitivity setting.
         //props.CaseSensitive;
@@ -424,7 +424,7 @@ class CompatibilityTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testNullNameColumn(Context foodMartContext) {
-    	Connection connection = foodMartContext.getConnection();
+    	Connection connection = foodMartContext.getConnectionWithDefaultRole();
         DataSource dataSource = connection.getDataSource();
         final Dialect dialect = foodMartContext.getDialect();
         switch (getDatabaseProduct(dialect.getDialectName())) {
@@ -490,7 +490,7 @@ class CompatibilityTest {
             + "</Cube>", null, null, null, null);
         */
         TestUtil.withSchema(foodMartContext, SchemaModifiers.CompatibilityTestModifier::new);
-        connection = foodMartContext.getConnection();
+        connection = foodMartContext.getConnectionWithDefaultRole();
 
         TestUtil.assertQueryReturns(
     		connection,
@@ -515,7 +515,7 @@ class CompatibilityTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testNullCollation(Context foodMartContext) {
-    	Connection connection = foodMartContext.getConnection();
+    	Connection connection = foodMartContext.getConnectionWithDefaultRole();
         DataSource dataSource = connection.getDataSource();
         final Dialect dialect = foodMartContext.getDialect();
         if (dialect.supportsGroupByExpressions()) {
@@ -526,7 +526,7 @@ class CompatibilityTest {
         }
         final String cubeName = "Store_NullsCollation";
         TestUtil.withSchema(foodMartContext, SchemaModifiers.CompatibilityTestModifier2::new);
-        connection = foodMartContext.getConnection();
+        connection = foodMartContext.getConnectionWithDefaultRole();
 
         TestUtil.assertQueryReturns(
     		connection,
@@ -564,7 +564,7 @@ class CompatibilityTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testPropertyCaseSensitivity(Context foodMartContext) {
-    	Connection connection = foodMartContext.getConnection();
+    	Connection connection = foodMartContext.getConnectionWithDefaultRole();
         boolean caseSensitive = props.CaseSensitive;
 
         // A user-defined property of a member.
@@ -620,7 +620,7 @@ class CompatibilityTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testWithDimensionPrefix(Context foodMartContext) {
-    	Connection connection = foodMartContext.getConnection();
+    	Connection connection = foodMartContext.getConnectionWithDefaultRole();
         assertAxisWithDimensionPrefix(connection, true);
         assertAxisWithDimensionPrefix(connection, false);
     }
@@ -637,7 +637,7 @@ class CompatibilityTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testWithNoDimensionPrefix(Context context) {
     	context.getSchemaCache().clear();
-    	Connection connection = context.getConnection();
+    	Connection connection = context.getConnectionWithDefaultRole();
         ((TestConfig)context.getConfig()).setNeedDimensionPrefix(false);
         TestUtil.assertAxisReturns(connection, "{[M]}", "[Gender].[M]");
         TestUtil.assertAxisReturns(connection, "{M}", "[Gender].[M]");

--- a/mondrian/src/test/java/mondrian/test/CompoundSlicerTest.java
+++ b/mondrian/src/test/java/mondrian/test/CompoundSlicerTest.java
@@ -56,7 +56,7 @@ class CompoundSlicerTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testSimulatedCompoundSlicer(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         assertQueryReturns(connection,
                 "with\n"
                         + "  member [Measures].[Price per Unit] as\n"
@@ -140,7 +140,7 @@ class CompoundSlicerTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCompoundSlicerExcept(Context context) {
-        Connection  connection = context.getConnection();
+        Connection  connection = context.getConnectionWithDefaultRole();
         final String expected =
                 "Axis #0:\n"
                         + "{[Promotion Media].[Bulk Mail]}\n"
@@ -234,7 +234,7 @@ class CompoundSlicerTest {
         withSchema(context, SchemaModifiers.CompoundSlicerTestModifier1::new);
 
         // the cell formatter for the measure should still be used
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "select from sales where "
                         + " measures.[Unit Sales Foo Bar] * Gender.Gender.members ",
                 "Axis #0:\n"
@@ -242,7 +242,7 @@ class CompoundSlicerTest {
                         + "{[Measures].[Unit Sales Foo Bar], [Gender].[M]}\n"
                         + "foo266773.0bar");
 
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "select from sales where "
                         + " Gender.Gender.members * measures.[Unit Sales Foo Bar]",
                 "Axis #0:\n"
@@ -255,7 +255,7 @@ class CompoundSlicerTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testMondrian1226(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "with set a as '([Time].[1997].[Q1] : [Time].[1997].[Q2])'\n"
                         +    "member Time.x as Aggregate(a,[Measures].[Store Sales])\n"
                         +    "member Measures.x1 as ([Time].[1997].[Q1],"
@@ -292,7 +292,7 @@ class CompoundSlicerTest {
         //  The first has a measure which overrides the Time context,
         // and gives expected results (since the Time dimension is
         // the "placeholder" dimension.
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "with member measures.HalfTime as '[Time].[1997].[Q1]/2'"
                         + " select measures.HalfTime on 0 from sales where "
                         + "({[Time].[1997].[Q1] : [Time].[1997].[Q2]} * gender.[All Gender]) ",
@@ -305,7 +305,7 @@ class CompoundSlicerTest {
 
         // The second query has a measure overriding gender, which
         // fails since context is not set appropriately for gender.
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "with member measures.HalfMan as 'Gender.m/2'"
                         +    " select measures.HalfMan on 0 from sales where "
                         +    "({[Time].[1997].[Q1] : [Time].[1997].[Q2]} "
@@ -327,7 +327,7 @@ class CompoundSlicerTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCompoundSlicerOverTuples(Context context) {
         // reference query
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "select [Measures].[Unit Sales] on 0,\n"
                         + "    TopCount(\n"
                         + "      [Product].[Product Category].Members\n"
@@ -364,7 +364,7 @@ class CompoundSlicerTest {
         // The actual query. Note that the set in the slicer has two dimensions.
         // This could not be expressed using calculated members and the
         // Aggregate function.
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "with\n"
                         + "  member [Measures].[Price per Unit] as\n"
                         + "    [Measures].[Store Sales] / [Measures].[Unit Sales]\n"
@@ -408,7 +408,7 @@ class CompoundSlicerTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testEmptySetSlicerReturnsNull(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "select [Measures].[Unit Sales] on 0,\n"
                         + "[Product].Children on 1\n"
                         + "from [Sales]\n"
@@ -432,7 +432,7 @@ class CompoundSlicerTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testEmptySetSlicerViaExpressionReturnsNull(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "select [Measures].[Unit Sales] on 0,\n"
                         + "[Product].Children on 1\n"
                         + "from [Sales]\n"
@@ -457,7 +457,7 @@ class CompoundSlicerTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCompoundSlicer(Context context) {
         // Reference query.
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "select [Measures].[Unit Sales] on 0,\n"
                         + "[Gender].Members on 1\n"
                         + "from [Sales]\n"
@@ -474,7 +474,7 @@ class CompoundSlicerTest {
                         + "Row #1: 12,202\n"
                         + "Row #2: 12,395\n");
         // Reference query.
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "select [Measures].[Unit Sales] on 0,\n"
                         + "[Gender].Members on 1\n"
                         + "from [Sales]\n"
@@ -493,7 +493,7 @@ class CompoundSlicerTest {
 
         // Sum members at same level.
         // Note that 216,537 = 24,597 (drink) + 191,940 (food).
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "select [Measures].[Unit Sales] on 0,\n"
                         + "[Gender].Members on 1\n"
                         + "from [Sales]\n"
@@ -513,7 +513,7 @@ class CompoundSlicerTest {
 
         // sum list that contains duplicates
         // duplicates are ignored (checked SSAS 2005)
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "select [Measures].[Unit Sales] on 0,\n"
                         + "[Gender].Members on 1\n"
                         + "from [Sales]\n"
@@ -549,7 +549,7 @@ class CompoundSlicerTest {
         // sum list that contains a null member -
         // null member is ignored;
         // confirmed behavior with ssas 2005
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "select [Measures].[Unit Sales] on 0,\n"
                         + "[Gender].Members on 1\n"
                         + "from [Sales]\n"
@@ -568,7 +568,7 @@ class CompoundSlicerTest {
                         + "Row #2: 109,521\n");
 
         // Reference query.
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "select [Measures].[Unit Sales] on 0,\n"
                         + "[Gender].Members on 1\n"
                         + "from [Sales]\n"
@@ -592,7 +592,7 @@ class CompoundSlicerTest {
         // SSAS 2005 doesn't simply sum them: it behaves behavior as if
         // predicates are pushed down to the fact table. Mondrian double-counts,
         // and that is a bug.
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "select [Measures].[Unit Sales] on 0,\n"
                         + "[Gender].Members on 1\n"
                         + "from [Sales]\n"
@@ -630,7 +630,7 @@ class CompoundSlicerTest {
 
         // The correct behavior of the aggregate function is to double-count.
         // SSAS 2005 and Mondrian give the same behavior.
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "with member [Product].[Foo] as\n"
                         + "  Aggregate({\n"
                         + "    [Product].[Drink],\n"
@@ -660,7 +660,7 @@ class CompoundSlicerTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testSlicerContainsNullMember(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "select [Measures].[Unit Sales] on 0,\n"
                         + "[Gender].Members on 1\n"
                         + "from [Sales]\n"
@@ -693,14 +693,14 @@ class CompoundSlicerTest {
                         + "where null";
         if (Bug.Ssas2005Compatible) {
             // SSAS returns a cell set containing null cells.
-            assertQueryReturns(context.getConnection(),
+            assertQueryReturns(context.getConnectionWithDefaultRole(),
                     mdx,
                     "xxx");
         } else {
             // Mondrian gives an error. This is not unreasonable. It is very
             // low priority to make Mondrian consistent with SSAS 2005 in this
             // behavior.
-            assertQueryThrows(context.getConnection(),
+            assertQueryThrows(context.getConnectionWithDefaultRole(),
                     mdx,
                     "Function does not support NULL member parameter");
         }
@@ -714,7 +714,7 @@ class CompoundSlicerTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testSlicerContainsPartiallyNullMember(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "select [Measures].[Unit Sales] on 0,\n"
                         + "[Gender].Members on 1\n"
                         + "from [Sales]\n"
@@ -737,7 +737,7 @@ class CompoundSlicerTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCompoundSlicerWithDistinctCount(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         // Reference query.
         assertQueryReturns(connection,
                 "select [Measures].[Customer Count] on 0,\n"
@@ -802,7 +802,7 @@ class CompoundSlicerTest {
          */
         withSchema(context, SchemaModifiers.CompoundSlicerTestModifier2::new);
         // basic query with avg
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "select from [Sales]\n"
                         + "where [Measures].[Avg Unit Sales]",
                 "Axis #0:\n"
@@ -811,7 +811,7 @@ class CompoundSlicerTest {
 
         // roll up using compound slicer
         // (should give a real value, not an error)
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         assertQueryReturns(connection,
                 "select from [Sales]\n"
                         + "where [Measures].[Avg Unit Sales]\n"
@@ -915,7 +915,7 @@ class CompoundSlicerTest {
                         + "Row #27: 248\n"
                         + "Row #28: 247\n"
                         + "Row #29: 247\n";
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "select NON EMPTY {[Measures].[Unit Sales]} ON COLUMNS, \n"
                         + "  Subset(Order([Customers].[Name].Members, [Measures].[Unit Sales], BDESC), 10.0, 30.0) ON ROWS \n"
                         + "from [Sales] \n"
@@ -923,7 +923,7 @@ class CompoundSlicerTest {
                 expected);
 
         // Equivalent query.
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "select NON EMPTY {[Measures].[Unit Sales]} ON COLUMNS, \n"
                         + "  Tail(\n"
                         + "    TopCount([Customers].[Name].Members, 40, [Measures].[Unit Sales]),\n"
@@ -937,7 +937,7 @@ class CompoundSlicerTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testTopCount(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "select NON EMPTY {[Measures].[Unit Sales]} ON COLUMNS, \n"
                         + "  TopCount([Customers].[USA].[WA].[Spokane].Children, 10, [Measures].[Unit Sales]) ON ROWS \n"
                         + "from [Sales] \n"
@@ -974,7 +974,7 @@ class CompoundSlicerTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testTopCountAllSlicers(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "select NON EMPTY {[Measures].[Unit Sales]} ON COLUMNS, \n"
                         + "  TopCount([Customers].[USA].[WA].[Spokane].Children, 10, [Measures].[Unit Sales]) ON ROWS \n"
                         + "from [Sales] \n"
@@ -1015,7 +1015,7 @@ class CompoundSlicerTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testTopCountWithAggregatedMemberCMRange(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "with set TO_AGGREGATE as '([Time].[1997].[Q1] : [Time].[1997].[Q2])'\n"
                         + "member Time.x as Aggregate(TO_AGGREGATE, [Measures].[Store Sales])\n"
                         + "member Measures.x1 as ([Time].[1997].[Q1], [Measures].[Store Sales])\n"
@@ -1048,7 +1048,7 @@ class CompoundSlicerTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testTopCountWithAggregatedMember2(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "with\n"
                         + "member Time.x as Aggregate([Time].[1997].[Q1] : [Time].[1997].[Q2], [Measures].[Store Sales])\n"
                         + "member Measures.x1 as ([Time].[1997].[Q1], [Measures].[Store Sales])\n"
@@ -1081,7 +1081,7 @@ class CompoundSlicerTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testTopCountWithAggregatedMemberEnumCMSet(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "with set TO_AGGREGATE as '{[Time].[1997].[Q1] , [Time].[1997].[Q2]}'\n"
                         + "member Time.x as Aggregate(TO_AGGREGATE, [Measures].[Store Sales])\n"
                         + "member Measures.x1 as ([Time].[1997].[Q1], [Measures].[Store Sales])\n"
@@ -1114,7 +1114,7 @@ class CompoundSlicerTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testTopCountWithAggregatedMemberEnumSet(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "with\n"
                         + "member Time.x as Aggregate({[Time].[1997].[Q1] , [Time].[1997].[Q2]}, [Measures].[Store Sales])\n"
                         + "member Measures.x1 as ([Time].[1997].[Q1], [Measures].[Store Sales])\n"
@@ -1147,7 +1147,7 @@ class CompoundSlicerTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testTopCountWithAggregatedMember5(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "with\n"
                         + "member Time.x as Aggregate([Time].[1997].[Q1] : [Time].[1997].[Q2], [Measures].[Store Sales])\n"
                         + "member Measures.x1 as ([Time].[1997].[Q1], [Measures].[Store Sales])\n"
@@ -1182,7 +1182,7 @@ class CompoundSlicerTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testTopCountWithAggregatedMemberCacheKey(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "with\n"
                         + "member Time.x as Aggregate({[Time].[1997].[Q1] , [Time].[1997].[Q2]}, [Measures].[Store Sales])\n"
                         + "member Measures.x1 as ([Time].[1997].[Q1], [Measures].[Store Sales])\n"
@@ -1207,7 +1207,7 @@ class CompoundSlicerTest {
                         + "Row #1: 226.20\n"
                         + "Row #1: 236.64\n");
 
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "with\n"
                         + "member Time.x as Aggregate(Union({[Time].[1997].[Q4]},[Time].[1997].[Q1] : [Time].[1997].[Q2]),[Measures].[Store Sales]) \n"
                         + "member Measures.x1 as ([Time].[1997].[Q1],[Measures].[Store Sales]) \n"
@@ -1243,7 +1243,7 @@ class CompoundSlicerTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testBugMondrian900(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "select NON EMPTY {[Measures].[Unit Sales]} ON COLUMNS,\n"
                         + "  Tail(Filter([Customers].[Name].Members, ([Measures].[Unit Sales] IS EMPTY)), 3) ON ROWS \n"
                         + "from [Sales]\n"
@@ -1271,7 +1271,7 @@ class CompoundSlicerTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testSlicerWithCalcMembers(Context context) throws Exception {
         //2 calc mems
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "WITH "
                         + "MEMBER [Store].[aggCA] AS "
                         + "'Aggregate({[Store].[USA].[CA].[Los Angeles], "
@@ -1285,7 +1285,7 @@ class CompoundSlicerTest {
                         + "53,859");
 
         // mix calc and non-calc
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "WITH "
                         + "MEMBER [Store].[aggCA] AS "
                         + "'Aggregate({[Store].[USA].[CA].[Los Angeles], "
@@ -1297,7 +1297,7 @@ class CompoundSlicerTest {
                         + "53,859");
 
         // multi-position slicer with mix of calc and non-calc
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "WITH "
                         + "MEMBER [Store].[aggCA] AS "
                         + "'Aggregate({[Store].[USA].[CA].[Los Angeles], "
@@ -1313,7 +1313,7 @@ class CompoundSlicerTest {
                         + "53,859");
 
         // named set with calc mem and non-calc
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "with member Time.aggTime as "
                         + "'aggregate({ [Time].[1997].[Q1], [Time].[1997].[Q2] })'"
                         + "set [timeMembers] as "
@@ -1325,7 +1325,7 @@ class CompoundSlicerTest {
                         + "194,749");
 
         // calculated measure in slicer
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
                 " SELECT FROM SALES WHERE "
                         + "[Measures].[Profit] * { [Store].[USA].[CA], [Store].[USA].[OR]}",
                 "Axis #0:\n"
@@ -1337,7 +1337,7 @@ class CompoundSlicerTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCompoundSlicerAndNamedSet(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "WITH SET [aSet] as 'Filter( Except([Store].[Store Country].Members, [Store].[Store Country].[Canada]), Measures.[Store Sales] > 0)'\n"
                         + "SELECT\n"
                         + "  { Measures.[Unit Sales] } ON COLUMNS,\n"
@@ -1357,7 +1357,7 @@ class CompoundSlicerTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDistinctCountMeasureInSlicer(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "select gender.members on 0 "
                         + "from sales where "
                         + "NonEmptyCrossJoin(Measures.[Customer Count], "
@@ -1377,7 +1377,7 @@ class CompoundSlicerTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDistinctCountWithAggregateMembersAndCompSlicer(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "with member time.agg as 'Aggregate({Time.[1997].Q1, Time.[1997].Q2})' "
                         + "member Store.agg as 'Aggregate(Head(Store.[USA].children,2))' "
                         + "select NON EMPTY CrossJoin( time.agg, CrossJoin( store.agg, measures.[customer count]))"
@@ -1396,7 +1396,7 @@ class CompoundSlicerTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testVirtualCubeWithCountDistinctUnsatisfiable(Context context) {
         virtualCubeWithDC(context);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "select {measures.[Customer Count], "
                         + "measures.[Unit Sales by Customer]} on 0 from [warehouse and sales] "
                         + "WHERE {[Time].[1997].Q1, [Time].[1997].Q2} "
@@ -1417,7 +1417,7 @@ class CompoundSlicerTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testVirtualCubeWithCountDistinctSatisfiable(Context context) {
         virtualCubeWithDC(context);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "select {measures.[Customer Count], "
                         + "measures.[Unit Sales by Customer]} on 0 from [warehouse and sales] "
                         + "WHERE {[Time].[1997].Q1, [Time].[1997].Q2} "
@@ -1438,7 +1438,7 @@ class CompoundSlicerTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testVirtualCubeWithCountDistinctPartiallySatisfiable(Context context) {
         virtualCubeWithDC(context);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "select {measures.[Warehouse Sales], "
                         + "measures.[Unit Sales by Customer]} on 0 from [warehouse and sales] "
                         + "WHERE {[Time].[1997].Q1, [Time].[1997].Q2} "
@@ -1478,7 +1478,7 @@ class CompoundSlicerTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCompoundSlicerWithComplexAggregation(Context context) {
         virtualCubeWithDC(context);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "with\n"
                         + "member time.agg as 'Aggregate( { ( Gender.F, Time.[1997].Q1), (Gender.M, Time.[1997].Q2) })'\n"
                         + "select measures.[customer count] on 0\n"
@@ -1500,7 +1500,7 @@ class CompoundSlicerTest {
                 + "SELECT filter(customers.[name].members, measures.[unit sales] > 100) on 0 "
                 + "FROM sales where store.agg";
 
-        verifySameNativeAndNot(context.getConnection(),
+        verifySameNativeAndNot(context.getConnectionWithDefaultRole(),
                 query,
                 "Compound aggregated member should return same results with native filter on/off");
     }
@@ -1513,7 +1513,7 @@ class CompoundSlicerTest {
                 + "SELECT filter(customers.[name].members, measures.[unit sales] > 100) on 0 "
                 + "FROM sales where store.agg";
 
-        verifySameNativeAndNot(context.getConnection(),
+        verifySameNativeAndNot(context.getConnectionWithDefaultRole(),
                 query,
                 "Compound aggregated member should return same results with native filter on/off");
     }
@@ -1523,7 +1523,7 @@ class CompoundSlicerTest {
     void testNativeFilterWithNullMember(Context context) {
         // The [Store Sqft] attribute include a null member.  This member should not be excluded
         // by the filter function in this query.
-        verifySameNativeAndNot(context.getConnection(), "WITH\n"
+        verifySameNativeAndNot(context.getConnectionWithDefaultRole(), "WITH\n"
                 + "SET [*NATIVE_CJ_SET] AS 'FILTER(FILTER([Store Size in SQFT].[Store Sqft].MEMBERS,[Store Size in SQFT]"
                 + ".CURRENTMEMBER.CAPTION NOT MATCHES (\"(?i).*20319.*\")), NOT ISEMPTY ([Measures].[Unit Sales]))'\n"
                 + "SET [*SORTED_ROW_AXIS] AS 'ORDER([*CJ_ROW_AXIS],[Store Size in SQFT].CURRENTMEMBER.ORDERKEY,BASC)'\n"

--- a/mondrian/src/test/java/mondrian/test/ConcurrentMdxTest.java
+++ b/mondrian/src/test/java/mondrian/test/ConcurrentMdxTest.java
@@ -1322,7 +1322,7 @@ class ConcurrentMdxTest {
                             // Throttle a bit (randomly)
                             Thread.sleep(random.nextInt(50));
                             Connection connection =
-                                    context.getConnection();
+                                    context.getConnectionWithDefaultRole();
                             statement = connection.createStatement();
                             statements.add(statement);
                             statement.executeQuery(mdxQuery.query);

--- a/mondrian/src/test/java/mondrian/test/DeadlockTest.java
+++ b/mondrian/src/test/java/mondrian/test/DeadlockTest.java
@@ -52,7 +52,7 @@ class DeadlockTest {
             new Runnable() {
             @Override
 			public void run() {
-                executeQuery(context.getConnection(),
+                executeQuery(context.getConnectionWithDefaultRole(),
                     "With\n"
                     + "Set [*NATIVE_CJ_SET] as 'NonEmptyCrossJoin([*BASE_MEMBERS_Store],NonEmptyCrossJoin([*BASE_MEMBERS_Product],[*BASE_MEMBERS_Time]))'\n"
                     + "Set [*BASE_MEMBERS_Product] as '[Product].[Product Subcategory].Members'\n"

--- a/mondrian/src/test/java/mondrian/test/DemoTest.java
+++ b/mondrian/src/test/java/mondrian/test/DemoTest.java
@@ -32,7 +32,7 @@ class DemoTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandExpressiveNamesCatalog.class, dataloader = ExpressiveNamesDataLoader.class )
     void testSample0(Context context) {
-        assertQueryReturns(context.getConnection(), sampleQueries[0].query, sampleQueries[0].result );
+        assertQueryReturns(context.getConnectionWithDefaultRole(), sampleQueries[0].query, sampleQueries[0].result );
     }
 
 }

--- a/mondrian/src/test/java/mondrian/test/DialectTest.java
+++ b/mondrian/src/test/java/mondrian/test/DialectTest.java
@@ -85,7 +85,7 @@ class DialectTest {
 
 
   protected DataSource getDataSource(Context context) {
-    return context.getConnection().getDataSource();
+    return context.getConnectionWithDefaultRole().getDataSource();
   }
 
   @AfterEach
@@ -715,7 +715,7 @@ class DialectTest {
       withSchema(context, SchemaModifiers.DialectTestModifier1::new);
     // if date literal is incorrect the following query will give the error
     // ORA-01861: literal does not match format string
-    Result result = executeQuery(context.getConnection(),
+    Result result = executeQuery(context.getConnectionWithDefaultRole(),
             "select Time.[All Times].FirstChild on 0 from DateLiteralTest" );
     String firstChild =
             result.getAxes()[ 0 ].getPositions().get( 0 ).get( 0 )
@@ -736,7 +736,7 @@ class DialectTest {
       return;
     }
     withSchema(context, SchemaModifiers.DialectTestModifier2::new);
-    Result result = executeQuery(context.getConnection(),
+    Result result = executeQuery(context.getConnectionWithDefaultRole(),
             "select StoreSqft.[All StoreSqfts].children on 0 from BigIntTest" );
     RolapMember secondChild =
             (RolapMember) result.getAxes()[ 0 ].getPositions().get( 1 ).get( 0 );
@@ -744,7 +744,7 @@ class DialectTest {
     assertTrue( secondChild.getKey() instanceof Long );
     assertEquals( 2147503966L, ( (Long) secondChild.getKey() ).longValue() );
 
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select StoreSqft.[All StoreSqfts].children on 0, "
                     + "{measures.[Big Unit Sales]} on 1 from BigIntTest",
             "Axis #0:\n"

--- a/mondrian/src/test/java/mondrian/test/DrillThroughExcludeFilterTest.java
+++ b/mondrian/src/test/java/mondrian/test/DrillThroughExcludeFilterTest.java
@@ -76,7 +76,7 @@ class DrillThroughExcludeFilterTest {
 
         withSchema(context, SchemaModifiers.DrillThroughExcludeFilterTestModifier::new);
 
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         Result result = executeQuery(connection,
             "WITH"
             + "   SET [*NATIVE_CJ_SET_WITH_SLICER] "

--- a/mondrian/src/test/java/mondrian/test/DrillThroughFieldListTest.java
+++ b/mondrian/src/test/java/mondrian/test/DrillThroughFieldListTest.java
@@ -58,7 +58,7 @@ class DrillThroughFieldListTest {
         + "[Measures].[Unit Sales] ON COLUMNS,\n"
         + "[Time].[Quarter].[Q1] ON ROWS\n"
         + "FROM [Sales]";
-    Result result = executeQuery(context.getConnection(), mdx);
+    Result result = executeQuery(context.getConnectionWithDefaultRole(), mdx);
 
     RolapCell rCell = (RolapCell)result.getCell(new int[] { 0, 0 });
 
@@ -73,7 +73,7 @@ class DrillThroughFieldListTest {
         .asList(returnMeasureAttribute, returnLevelAttribute);
 
     String expectedSql;
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     switch (getDatabaseProduct(getDialect(connection).getDialectName())) {
     case MARIADB:
     case MYSQL:
@@ -130,7 +130,7 @@ class DrillThroughFieldListTest {
         + "{[Measures].[Unit Sales], [Measures].[Store Cost]} ON COLUMNS,\n"
         + "[Time].[Quarter].[Q1] ON ROWS\n"
         + "FROM [Sales]";
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     Result result = executeQuery(connection, mdx);
 
     RolapCell rCell = (RolapCell)result.getCell(new int[] { 0, 0 });
@@ -207,7 +207,7 @@ class DrillThroughFieldListTest {
         + "NONEMPTYCROSSJOIN({[Time].[Quarter].[Q1]},"
         + " {[Product].[Product Name].[Good Imported Beer]}) ON ROWS\n"
         + "FROM [Sales]";
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     Result result = executeQuery(connection, mdx);
 
     RolapCell rCell = (RolapCell)result.getCell(new int[] { 0, 0 });
@@ -290,7 +290,7 @@ class DrillThroughFieldListTest {
     String mdx = "SELECT\n"
         + "Measures.[Store Sqft] on COLUMNS\n"
         + "FROM [Store]";
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     Result result = executeQuery(connection, mdx);
 
     RolapCell rCell = (RolapCell)result.getCell(new int[] { 0 });
@@ -338,7 +338,7 @@ class DrillThroughFieldListTest {
         + " [Measures].[Unit Sales] ON COLUMNS\n"
         + " FROM [Warehouse and Sales]\n"
         + " WHERE [Gender].[F]";
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     Result result = executeQuery(connection, mdx);
 
     RolapCell rCell = (RolapCell)result.getCell(new int[] { 0 });

--- a/mondrian/src/test/java/mondrian/test/DrillThroughTest.java
+++ b/mondrian/src/test/java/mondrian/test/DrillThroughTest.java
@@ -145,7 +145,7 @@ class DrillThroughTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testTrivialCalcMemberDrillThrough(Context context) {
     	context.getSchemaCache().clear();
-        Result result = executeQuery(context.getConnection(),
+        Result result = executeQuery(context.getConnectionWithDefaultRole(),
             "WITH MEMBER [Measures].[Formatted Unit Sales]"
             + " AS '[Measures].[Unit Sales]', FORMAT_STRING='$#,###.000'\n"
             + "MEMBER [Measures].[Twice Unit Sales]"
@@ -200,13 +200,13 @@ class DrillThroughTest {
             + " and `product`.`product_class_id` = `product_class`.`product_class_id`"
             + " and `product_class`.`product_family` = 'Drink' "
             + "order by "
-            + (getDialect(context.getConnection()).requiresOrderByAlias()
+            + (getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
                 ? "`Year` ASC,"
                 + " `Product Family` ASC"
                 : "`time_by_day`.`the_year` ASC,"
                 + " `product_class`.`product_family` ASC");
 
-        assertSqlEquals(context.getConnection(), expectedSql, sql, 7978);
+        assertSqlEquals(context.getConnectionWithDefaultRole(), expectedSql, sql, 7978);
 
         // Can drill through a trivial calc member.
         final Cell calcCell = result.getCell(new int[]{1, 0});
@@ -227,13 +227,13 @@ class DrillThroughTest {
             + " and `product`.`product_class_id` = `product_class`.`product_class_id`"
             + " and `product_class`.`product_family` = 'Drink' "
             + "order by "
-            + (getDialect(context.getConnection()).requiresOrderByAlias()
+            + (getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
                 ? "`Year` ASC,"
                 + " `Product Family` ASC"
                 : "`time_by_day`.`the_year` ASC,"
                 + " `product_class`.`product_family` ASC");
 
-        assertSqlEquals(context.getConnection(), expectedSql, sql, 7978);
+        assertSqlEquals(context.getConnectionWithDefaultRole(), expectedSql, sql, 7978);
 
         assertEquals(7978, calcCell.getDrillThroughCount() );
     }
@@ -242,7 +242,7 @@ class DrillThroughTest {
     void testTrivialCalcMemberNotMeasure(Context context) {
         // [Product].[My Food] is trivial because it maps to a single member.
         // First, on ROWS axis.
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         Result result = executeQuery(connection,
             "with member [Product].[My Food]\n"
             + " AS [Product].[Food], FORMAT_STRING = '#,###'\n"
@@ -312,13 +312,13 @@ class DrillThroughTest {
         // around IN list items.
     	context.getSchemaCache().clear();
         ((TestConfig)context.getConfig()).setGenerateFormattedSql(true);
-        Result result = executeQuery(context.getConnection(),
+        Result result = executeQuery(context.getConnectionWithDefaultRole(),
             "select from sales where "
             + "{[Promotion Media].[Bulk Mail],[Promotion Media].[Cash Register Handout]}");
         final Cell cell = result.getCell(new int[]{});
         assertTrue(cell.canDrillThrough());
         assertEquals(3584, cell.getDrillThroughCount());
-        assertSqlEquals(context.getConnection(),
+        assertSqlEquals(context.getConnectionWithDefaultRole(),
             "select\n"
             + "    time_by_day.the_year as Year,\n"
             + "    promotion.media_type as Media Type,\n"
@@ -337,7 +337,7 @@ class DrillThroughTest {
             + "    ((promotion.media_type in "
             + "('Bulk Mail', 'Cash Register Handout')))\n"
             + "order by\n"
-            + (getDialect(context.getConnection()).requiresOrderByAlias()
+            + (getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
                 ? "    Year ASC"
                 : "    time_by_day.the_year ASC"),
             cell.getDrillThroughSQL(false), 3584);
@@ -346,7 +346,7 @@ class DrillThroughTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testDrillThrough(Context context) {
-        Result result = executeQuery(context.getConnection(),
+        Result result = executeQuery(context.getConnectionWithDefaultRole(),
             "WITH MEMBER [Measures].[Price] AS '[Measures].[Store Sales] / ([Measures].[Store Sales], [Time].[Time].PrevMember)'\n"
             + "SELECT {[Measures].[Unit Sales], [Measures].[Price]} on columns,\n"
             + " {[Product].Children} on rows\n"
@@ -368,13 +368,13 @@ class DrillThroughTest {
             + " and `sales_fact_1997`.`product_id` = `product`.`product_id`"
             + " and `product`.`product_class_id` = `product_class`.`product_class_id`"
             + " and `product_class`.`product_family` = 'Drink' "
-            + (getDialect(context.getConnection()).requiresOrderByAlias()
+            + (getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
                 ? "order by `Year` ASC,"
                 + " `Product Family` ASC"
                 : "order by `time_by_day`.`the_year` ASC,"
                 + " `product_class`.`product_family` ASC");
 
-        assertSqlEquals(context.getConnection(), expectedSql, sql, 7978);
+        assertSqlEquals(context.getConnectionWithDefaultRole(), expectedSql, sql, 7978);
 
         // Cannot drill through a calc member.
         final Cell calcCell = result.getCell(new int[]{1, 1});
@@ -411,7 +411,7 @@ class DrillThroughTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testDrillThrough2(Context context) {
-        Result result = executeQuery(context.getConnection(),
+        Result result = executeQuery(context.getConnectionWithDefaultRole(),
             "WITH MEMBER [Measures].[Price] AS '[Measures].[Store Sales] / ([Measures].[Unit Sales], [Time].[Time].PrevMember)'\n"
             + "SELECT {[Measures].[Unit Sales], [Measures].[Price]} on columns,\n"
             + " {[Product].Children} on rows\n"
@@ -466,7 +466,7 @@ class DrillThroughTest {
             + " and `sales_fact_1997`.`promotion_id` = `promotion`.`promotion_id`"
             + " and `sales_fact_1997`.`customer_id` = `customer`.`customer_id` "
             + "order by"
-            + (getDialect(context.getConnection()).requiresOrderByAlias()
+            + (getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
                 ? " `Store Country` ASC,"
                 + " `Store State` ASC,"
                 + " `Store City` ASC,"
@@ -525,7 +525,7 @@ class DrillThroughTest {
                 + " `customer`.`marital_status` ASC,"
                 + " `customer`.`yearly_income` ASC");
 
-        assertSqlEquals(context.getConnection(), expectedSql, sql, 7978);
+        assertSqlEquals(context.getConnectionWithDefaultRole(), expectedSql, sql, 7978);
 
         // Drillthrough SQL is null for cell based on calc member
         sql = result.getCell(new int[]{1, 1}).getDrillThroughSQL(true);
@@ -535,7 +535,7 @@ class DrillThroughTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testDrillThrough3(Context context) {
-        Result result = executeQuery(context.getConnection(),
+        Result result = executeQuery(context.getConnectionWithDefaultRole(),
             "select {[Measures].[Unit Sales], [Measures].[Store Cost], [Measures].[Store Sales]} ON COLUMNS, \n"
             + "Hierarchize(Union(Union(Crossjoin({[Promotion Media].[All Media]}, {[Product].[All Products]}), \n"
             + "Crossjoin({[Promotion Media].[All Media]}, [Product].[All Products].Children)), Crossjoin({[Promotion Media].[All Media]}, [Product].[All Products].[Drink].Children))) ON ROWS \n"
@@ -599,7 +599,7 @@ class DrillThroughTest {
             + "`sales_fact_1997`.`promotion_id` = `promotion`.`promotion_id` and "
             + "`sales_fact_1997`.`customer_id` = `customer`.`customer_id` "
             + "order by"
-            + (getDialect(context.getConnection()).requiresOrderByAlias()
+            + (getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
                 ? " `Store Country` ASC,"
                 + " `Store State` ASC,"
                 + " `Store City` ASC,"
@@ -657,7 +657,7 @@ class DrillThroughTest {
                 + " `customer`.`education` ASC,"
                 + " `customer`.`yearly_income` ASC");
 
-        assertSqlEquals(context.getConnection(), expectedSql, sql, 141);
+        assertSqlEquals(context.getConnectionWithDefaultRole(), expectedSql, sql, 141);
     }
 
     /**
@@ -671,7 +671,7 @@ class DrillThroughTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testDrillThroughBugMondrian180(Context context) {
-        Result result = executeQuery(context.getConnection(),
+        Result result = executeQuery(context.getConnectionWithDefaultRole(),
             "with set [Date Range] as '{[Time].[1997].[Q1], [Time].[1997].[Q2]}'\n"
             + "member [Time].[Time].[Date Range] as 'Aggregate([Date Range])'\n"
             + "select {[Measures].[Unit Sales]} ON COLUMNS,\n"
@@ -738,7 +738,7 @@ class DrillThroughTest {
             + " `sales_fact_1997`.`promotion_id` = `promotion`.`promotion_id` and"
             + " `sales_fact_1997`.`customer_id` = `customer`.`customer_id`"
             + " order by"
-            + (getDialect(context.getConnection()).requiresOrderByAlias()
+            + (getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
                 ? " `Store State` ASC,"
                 + " `Store City` ASC,"
                 + " `Store Name` ASC,"
@@ -795,7 +795,7 @@ class DrillThroughTest {
                 + " `customer`.`education` ASC,"
                 + " `customer`.`yearly_income` ASC");
 
-        assertSqlEquals(context.getConnection(), expectedSql, sql, 6815);
+        assertSqlEquals(context.getConnectionWithDefaultRole(), expectedSql, sql, 6815);
     }
 
     /**
@@ -805,7 +805,7 @@ class DrillThroughTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testDrillThroughMeasureExp(Context context) {
-        Result result = executeQuery(context.getConnection(),
+        Result result = executeQuery(context.getConnectionWithDefaultRole(),
             "SELECT {[Measures].[Promotion Sales]} on columns,\n"
             + " {[Product].Children} on rows\n"
             + "from Sales");
@@ -827,7 +827,7 @@ class DrillThroughTest {
             + " and `sales_fact_1997`.`product_id` = `product`.`product_id`"
             + " and `product`.`product_class_id` = `product_class`.`product_class_id`"
             + " and `product_class`.`product_family` = 'Drink' "
-            + (getDialect(context.getConnection()).requiresOrderByAlias()
+            + (getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
                 ? "order by `Year` ASC, `Product Family` ASC"
                 : "order by `time_by_day`.`the_year` ASC, `product_class`.`product_family` ASC");
 
@@ -852,7 +852,7 @@ class DrillThroughTest {
             break;
         }
 
-        assertSqlEquals(context.getConnection(), expectedSql, sql, 7978);
+        assertSqlEquals(context.getConnectionWithDefaultRole(), expectedSql, sql, 7978);
     }
 
     /**
@@ -893,7 +893,7 @@ class DrillThroughTest {
          */
         withSchema(context, SchemaModifiers.DrillThroughTestModifier1::new);
 
-        Result result = executeQuery(context.getConnection(),
+        Result result = executeQuery(context.getConnectionWithDefaultRole(),
             "SELECT {[Store2].[Store Id].Members} on columns,\n"
             + " NON EMPTY([Store3].[Store Id].Members) on rows\n"
             + "from Sales");
@@ -915,17 +915,17 @@ class DrillThroughTest {
             + " and `sales_fact_1997`.`store_id` = `store`.`store_id`"
             + " and `store`.`store_id` = 2 "
             + "order by "
-            + (getDialect(context.getConnection()).requiresOrderByAlias()
+            + (getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
                 ? "`Year` ASC, `Store Id` ASC, `Store Id_0` ASC"
                 : "`time_by_day`.`the_year` ASC, `store_ragged`.`store_id` ASC, `store`.`store_id` ASC");
 
-        assertSqlEquals(context.getConnection(), expectedSql, sql, 0);
+        assertSqlEquals(context.getConnectionWithDefaultRole(), expectedSql, sql, 0);
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void  testDrillThroughDupKeysAndMeasure(Context context) throws Exception {
-        if (!getDatabaseProduct(getDialect(context.getConnection()).getDialectName())
+        if (!getDatabaseProduct(getDialect(context.getConnectionWithDefaultRole()).getDialectName())
             .equals(DatabaseProduct.MYSQL))
         {
             // This test only works on MySQL because we
@@ -933,7 +933,7 @@ class DrillThroughTest {
             return;
         }
         withSchema(context, SchemaModifiers.DrillThroughTestModifier4::new);
-       final Result result = executeQuery(context.getConnection(),
+       final Result result = executeQuery(context.getConnectionWithDefaultRole(),
            "WITH\n"
            + "SET [*NATIVE_CJ_SET] AS 'FILTER([Frozen sqft].[Frozen sqft].MEMBERS, NOT ISEMPTY ([Measures].[Store sqft]))'\n"
            + "SET [*SORTED_ROW_AXIS] AS 'ORDER([*CJ_ROW_AXIS],[Frozen sqft].CURRENTMEMBER.ORDERKEY,BASC)'\n"
@@ -948,7 +948,7 @@ class DrillThroughTest {
        final String sql =
            result.getCell(new int[]{0, 0}).getDrillThroughSQL(true);
 
-       assertSqlEquals(context.getConnection(),
+       assertSqlEquals(context.getConnectionWithDefaultRole(),
            "select store.frozen_sqft as Frozen sqft, store.grocery_sqft as Grocery sqft, store.meat_sqft as Meat sqft, store.store_sqft as Store sqft, store.store_sqft as Store sqft_0 from store as store where store.frozen_sqft = 2452 order by Frozen sqft ASC, Grocery sqft ASC, Meat sqft ASC, Store sqft ASC",
            sql,
            1);
@@ -969,7 +969,7 @@ class DrillThroughTest {
             + " [Measures].[Meat sqft] ON COLUMNS\n"
             + ", [*SORTED_ROW_AXIS]  ON ROWS\n"
             + "FROM [dsad] WHERE ( [Grocery Sqft].[24390] ) RETURN [Store sqft].[Store sqft], [Measures].[Grocery sqft]";
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         ResultSet resultSet = null;
         try {
             resultSet = connection.createStatement()
@@ -994,7 +994,7 @@ class DrillThroughTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void  testDrillThroughVirtualCube(Context context) {
-        Result result = executeQuery(context.getConnection(),
+        Result result = executeQuery(context.getConnectionWithDefaultRole(),
             "select Crossjoin([Customers].[All Customers].[USA].[OR].Children, {[Measures].[Unit Sales]}) ON COLUMNS, "
             + " [Gender].[All Gender].Children ON ROWS"
             + " from [Warehouse and Sales]"
@@ -1022,7 +1022,7 @@ class DrillThroughTest {
             + " `customer`.`city` = 'Albany' and"
             + " `customer`.`gender` = 'F'"
             + " order by "
-            + (getDialect(context.getConnection()).requiresOrderByAlias()
+            + (getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
                 ? "`Year` ASC,"
                 + " `Quarter` ASC,"
                 + " `Month` ASC,"
@@ -1036,7 +1036,7 @@ class DrillThroughTest {
                 + " `customer`.`city` ASC,"
                 + " `customer`.`gender` ASC");
 
-        assertSqlEquals(context.getConnection(), expectedSql, sql, 73);
+        assertSqlEquals(context.getConnectionWithDefaultRole(), expectedSql, sql, 73);
     }
 
     /**
@@ -1046,7 +1046,7 @@ class DrillThroughTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void  testBug1438285(Context context) {
-        final Dialect dialect = getDialect(context.getConnection());
+        final Dialect dialect = getDialect(context.getConnectionWithDefaultRole());
         if (getDatabaseProduct(dialect.getDialectName()) == DatabaseProduct.TERADATA) {
             // On default Teradata express instance there isn't enough spool
             // space to run this query.
@@ -1070,7 +1070,7 @@ class DrillThroughTest {
          */
         withSchema(context, SchemaModifiers.DrillThroughTestModifier2::new);
 
-        Result result = executeQuery(context.getConnection(),
+        Result result = executeQuery(context.getConnectionWithDefaultRole(),
             "SELECT {[Measures].[Unit Sales]} on columns, "
             + "{[Store2].members} on rows FROM [Sales]");
 
@@ -1127,7 +1127,7 @@ class DrillThroughTest {
             + " and `sales_fact_1997`.`promotion_id` = `promotion`.`promotion_id`"
             + " and `sales_fact_1997`.`customer_id` = `customer`.`customer_id`"
             + " order by"
-            + (getDialect(context.getConnection()).requiresOrderByAlias()
+            + (getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
                 ? " `Store Country` ASC,"
                 + " `Store State` ASC,"
                 + " `Store City` ASC,"
@@ -1187,7 +1187,7 @@ class DrillThroughTest {
                 + " `customer`.`education` ASC,"
                 + " `customer`.`yearly_income` ASC");
 
-        assertSqlEquals(context.getConnection(), expectedSql, sql, 86837);
+        assertSqlEquals(context.getConnectionWithDefaultRole(), expectedSql, sql, 86837);
     }
 
     /**
@@ -1217,7 +1217,7 @@ class DrillThroughTest {
          */
     	withSchema(context, SchemaModifiers.DrillThroughTestModifier3::new);
 
-        Result result = executeQuery(context.getConnection(),
+        Result result = executeQuery(context.getConnectionWithDefaultRole(),
             "SELECT {[Measures].[Unit Sales]} on columns,\n"
             + "{[Education Level2].Children} on rows\n"
             + "FROM [Sales]\n"
@@ -1228,12 +1228,12 @@ class DrillThroughTest {
         // Check that SQL is valid.
         java.sql.Connection connection = null;
         try {
-            DataSource dataSource = context.getConnection().getDataSource();
+            DataSource dataSource = context.getConnectionWithDefaultRole().getDataSource();
             connection = dataSource.getConnection();
             final Statement statement = connection.createStatement();
             final ResultSet resultSet = statement.executeQuery(sql);
             final int columnCount = resultSet.getMetaData().getColumnCount();
-            final Dialect dialect = getDialect(context.getConnection());
+            final Dialect dialect = getDialect(context.getConnectionWithDefaultRole());
             if (getDatabaseProduct(dialect.getDialectName()) == DatabaseProduct.DERBY) {
                 // derby counts ORDER BY columns as columns. insane!
                 assertEquals(11, columnCount);
@@ -1259,7 +1259,7 @@ class DrillThroughTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void  testDrillThroughExprs(Context context) {
     	context.getSchemaCache().clear();
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         assertCanDrillThrough(connection,
             true,
             "Sales",
@@ -1321,7 +1321,7 @@ class DrillThroughTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void  testDrillthroughMaxRows(Context context) throws SQLException {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         assertMaxRows(connection, "", 29);
         assertMaxRows(connection, "maxrows 1000", 29);
         assertMaxRows(connection, "maxrows 0", 29);
@@ -1355,7 +1355,7 @@ class DrillThroughTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void  testDrillthroughNegativeMaxRowsFails(Context context) throws SQLException {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         try {
             final ResultSet resultSet = executeStatement(connection,
                 "DRILLTHROUGH MAXROWS -3\n"
@@ -1372,7 +1372,7 @@ class DrillThroughTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void  testDrillThroughCalculatedMemberMeasure(Context context) throws SQLException {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         try {
             final ResultSet resultSet = executeStatement(connection,
                 "DRILLTHROUGH\n"
@@ -1391,7 +1391,7 @@ class DrillThroughTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testDrillThroughNotDrillableFails(Context context) throws SQLException {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         try {
             final ResultSet resultSet = executeStatement(connection,
                 "DRILLTHROUGH\n"
@@ -1444,7 +1444,7 @@ class DrillThroughTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void  testDrillThroughOneAxis(Context context) {
-        Result result = executeQuery(context.getConnection(),
+        Result result = executeQuery(context.getConnectionWithDefaultRole(),
             "SELECT [Measures].[Unit Sales] on 0\n"
             + "from Sales");
 
@@ -1461,7 +1461,7 @@ class DrillThroughTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void  testDrillThroughCalcMemberInSlicer(Context context) {
-        Result result = executeQuery(context.getConnection(),
+        Result result = executeQuery(context.getConnectionWithDefaultRole(),
             "WITH MEMBER [Product].[Aggregate Food Drink] AS \n"
             + " Aggregate({[Product].[Food], [Product].[Drink]})\n"
             + "SELECT [Measures].[Unit Sales] on 0\n"
@@ -1484,7 +1484,7 @@ class DrillThroughTest {
         ((TestConfig)context.getConfig()).setGenerateFormattedSql(true);
         // A query with a simple multi-position compound slicer
         Result result =
-            executeQuery(context.getConnection(),
+            executeQuery(context.getConnectionWithDefaultRole(),
                 "SELECT {[Measures].[Unit Sales]} ON COLUMNS,\n"
                 + " {[Product].[All Products]} ON ROWS\n"
                 + "FROM [Sales]\n"
@@ -1493,7 +1493,7 @@ class DrillThroughTest {
         assertTrue(cell.canDrillThrough());
         String sql = cell.getDrillThroughSQL(false);
         String expectedSql;
-        switch (getDatabaseProduct(getDialect(context.getConnection()).getDialectName())) {
+        switch (getDatabaseProduct(getDialect(context.getConnectionWithDefaultRole()).getDialectName())) {
         case MARIADB:
         case MYSQL:
             expectedSql =
@@ -1526,11 +1526,11 @@ class DrillThroughTest {
         default:
                 return;
         }
-        assertSqlEquals(context.getConnection(), expectedSql, sql, 41956);
+        assertSqlEquals(context.getConnectionWithDefaultRole(), expectedSql, sql, 41956);
 
         // A query with a slightly more complex multi-position compound slicer
         result =
-            executeQuery(context.getConnection(),
+            executeQuery(context.getConnectionWithDefaultRole(),
                 "SELECT {[Measures].[Unit Sales]} ON COLUMNS,\n"
                 + " {[Product].[All Products]} ON ROWS\n"
                 + "FROM [Sales]\n"
@@ -1542,7 +1542,7 @@ class DrillThroughTest {
 
         // Note that gender and marital status get their own predicates,
         // independent of the time portion of the slicer
-        switch (getDatabaseProduct(getDialect(context.getConnection()).getDialectName())) {
+        switch (getDatabaseProduct(getDialect(context.getConnectionWithDefaultRole()).getDialectName())) {
         case MARIADB:
         case MYSQL:
             expectedSql =
@@ -1567,7 +1567,7 @@ class DrillThroughTest {
                 + "and\n"
                 + "    (((time_by_day.the_year, time_by_day.quarter) in ((1997, 'Q1'), (1997, 'Q2'))))\n"
                 + "order by\n"
-                + (getDialect(context.getConnection()).requiresOrderByAlias()
+                + (getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
                     ? "    Gender ASC,\n"
                     + "    Marital Status ASC"
                     : "    customer.gender ASC,\n"
@@ -1602,12 +1602,12 @@ class DrillThroughTest {
         default:
             return;
         }
-        assertSqlEquals(context.getConnection(), expectedSql, sql, 10430);
+        assertSqlEquals(context.getConnectionWithDefaultRole(), expectedSql, sql, 10430);
 
         // A query with an even more complex multi-position compound slicer
         // (gender must be in the slicer predicate along with time)
         result =
-            executeQuery(context.getConnection(),
+            executeQuery(context.getConnectionWithDefaultRole(),
                 "SELECT {[Measures].[Unit Sales]} ON COLUMNS,\n"
                 + " {[Product].[All Products]} ON ROWS\n"
                 + "FROM [Sales]\n"
@@ -1619,7 +1619,7 @@ class DrillThroughTest {
 
         // Note that gender and marital status get their own predicates,
         // independent of the time portion of the slicer
-        switch (getDatabaseProduct(getDialect(context.getConnection()).getDialectName())) {
+        switch (getDatabaseProduct(getDialect(context.getConnectionWithDefaultRole()).getDialectName())) {
         case MARIADB:
         case MYSQL:
             expectedSql =
@@ -1660,12 +1660,12 @@ class DrillThroughTest {
         default:
             return;
         }
-        assertSqlEquals(context.getConnection(), expectedSql, sql, 20971);
+        assertSqlEquals(context.getConnectionWithDefaultRole(), expectedSql, sql, 20971);
 
         // A query with a simple multi-position compound slicer with
         // different levels (overlapping)
         result =
-            executeQuery(context.getConnection(),
+            executeQuery(context.getConnectionWithDefaultRole(),
                 "SELECT {[Measures].[Unit Sales]} ON COLUMNS,\n"
                 + " {[Product].[All Products]} ON ROWS\n"
                 + "FROM [Sales]\n"
@@ -1676,7 +1676,7 @@ class DrillThroughTest {
 
         // With overlapping slicer members, the first slicer predicate is
         // redundant, but does not affect the query's results
-        switch (getDatabaseProduct(getDialect(context.getConnection()).getDialectName())) {
+        switch (getDatabaseProduct(getDialect(context.getConnectionWithDefaultRole()).getDialectName())) {
         case MARIADB:
         case MYSQL:
             expectedSql =
@@ -1711,12 +1711,12 @@ class DrillThroughTest {
         default:
             return;
         }
-        assertSqlEquals(context.getConnection(), expectedSql, sql, 21588);
+        assertSqlEquals(context.getConnectionWithDefaultRole(), expectedSql, sql, 21588);
 
         // A query with a simple multi-position compound slicer with
         // different levels (non-overlapping)
         result =
-            executeQuery(context.getConnection(),
+            executeQuery(context.getConnectionWithDefaultRole(),
                 "SELECT {[Measures].[Unit Sales]} ON COLUMNS,\n"
                 + " {[Product].[All Products]} ON ROWS\n"
                 + "FROM [Sales]\n"
@@ -1724,7 +1724,7 @@ class DrillThroughTest {
         cell = result.getCell(new int[]{0, 0});
         assertTrue(cell.canDrillThrough());
         sql = cell.getDrillThroughSQL(false);
-        switch (getDatabaseProduct(getDialect(context.getConnection()).getDialectName())) {
+        switch (getDatabaseProduct(getDialect(context.getConnectionWithDefaultRole()).getDialectName())) {
         case MARIADB:
         case MYSQL:
             expectedSql =
@@ -1759,7 +1759,7 @@ class DrillThroughTest {
         default:
             return;
         }
-        assertSqlEquals(context.getConnection(), expectedSql, sql, 27402);
+        assertSqlEquals(context.getConnectionWithDefaultRole(), expectedSql, sql, 27402);
     }
 
     @ParameterizedTest
@@ -1767,7 +1767,7 @@ class DrillThroughTest {
     void  testDrillthroughDisable(Context context) {
         ((TestConfig)context.getConfig()).setEnableDrillThrough(true);
         Result result =
-            executeQuery(context.getConnection(),
+            executeQuery(context.getConnectionWithDefaultRole(),
                 "SELECT {[Measures].[Unit Sales]} ON COLUMNS,\n"
                 + " {[Product].[All Products]} ON ROWS\n"
                 + "FROM [Sales]\n"
@@ -1776,7 +1776,7 @@ class DrillThroughTest {
         assertTrue(cell.canDrillThrough());
         ((TestConfig)context.getConfig()).setEnableDrillThrough(false);
         result =
-            executeQuery(context.getConnection(),
+            executeQuery(context.getConnectionWithDefaultRole(),
                 "SELECT {[Measures].[Unit Sales]} ON COLUMNS,\n"
                 + " {[Product].[All Products]} ON ROWS\n"
                 + "FROM [Sales]\n"
@@ -1800,7 +1800,7 @@ class DrillThroughTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void  testColumnAliasQuotedInOrderBy(Context context) throws Exception {
-        Result result = executeQuery(context.getConnection(),
+        Result result = executeQuery(context.getConnectionWithDefaultRole(),
             "WITH\n"
             + "SET [*NATIVE_CJ_SET] AS 'FILTER([*BASE_MEMBERS__Customers_], NOT ISEMPTY ([Measures].[Unit Sales]))'\n"
             + "SET [*BASE_MEMBERS__Measures_] AS '{[Measures].[*FORMATTED_MEASURE_0]}'\n"
@@ -1818,7 +1818,7 @@ class DrillThroughTest {
         Cell cell = result.getCell(new int[]{0, 0});
         String sql = cell.getDrillThroughSQL(true);
         String expectedSql;
-        switch (getDatabaseProduct(getDialect(context.getConnection()).getDialectName())) {
+        switch (getDatabaseProduct(getDialect(context.getConnectionWithDefaultRole()).getDialectName())) {
         case VECTORWISE:
             expectedSql =
                 "select \"store\".\"store_country\" as \"Store Country\","
@@ -1885,7 +1885,7 @@ class DrillThroughTest {
         default:
             return;
         }
-        assertSqlEquals(context.getConnection(), expectedSql, sql, 11);
+        assertSqlEquals(context.getConnectionWithDefaultRole(), expectedSql, sql, 11);
     }
 
     @ParameterizedTest
@@ -1899,7 +1899,7 @@ class DrillThroughTest {
         // columns.
         ResultSet rs = null;
         try {
-            rs = executeStatement(context.getConnection(),
+            rs = executeStatement(context.getConnectionWithDefaultRole(),
                 "DRILLTHROUGH \n"
                 + "// Request ID: d73ea21c-2a29-11e5-ba1d-d4bed923da37 - RUN_REPORT\n"
                 + "WITH\n"
@@ -1915,7 +1915,7 @@ class DrillThroughTest {
             assertEquals(
                 5, rs.getMetaData().getColumnCount());
             Object expectedYear;
-            switch (getDatabaseProduct(getDialect(context.getConnection()).getDialectName())) {
+            switch (getDatabaseProduct(getDialect(context.getConnectionWithDefaultRole()).getDialectName())) {
             case MARIADB:
             case MYSQL:
                 expectedYear = new Integer(1997);
@@ -1959,7 +1959,7 @@ class DrillThroughTest {
         withSchema(context, SchemaModifiers.DrillThroughTestModifier5::new);
         int rowCount = 0;
         try {
-            rs = executeStatement(context.getConnection(),
+            rs = executeStatement(context.getConnectionWithDefaultRole(),
                 DRILLTHROUGH_QUERY_WITH_CUSTOMER_FULL_NAME);
             assertEquals(
                 5, rs.getMetaData().getColumnCount());
@@ -2013,7 +2013,7 @@ class DrillThroughTest {
         withSchema(context, SchemaModifiers.DrillThroughTestModifier6::new);
         int rowCount = 0;
         try {
-            rs = executeStatement(context.getConnection(),
+            rs = executeStatement(context.getConnectionWithDefaultRole(),
                 DRILLTHROUGH_QUERY_WITH_CUSTOMER_ID);
             assertEquals(
                 3, rs.getMetaData().getColumnCount());
@@ -2058,7 +2058,7 @@ class DrillThroughTest {
         int rowCount = 0;
         ResultSet rs = null;
         try {
-            rs = executeStatement(context.getConnection(),
+            rs = executeStatement(context.getConnectionWithDefaultRole(),
                 "DRILLTHROUGH \n"
                 + "WITH\n"
                 + "SET [*NATIVE_CJ_SET_WITH_SLICER] AS 'FILTER({[Store Type].[All Store Types].[Gourmet Supermarket],[Store Type].[All Store Types].[Small Grocery]}, NOT ISEMPTY ([Measures].[Store Sales]))'\n"

--- a/mondrian/src/test/java/mondrian/test/ExplainPlanTest.java
+++ b/mondrian/src/test/java/mondrian/test/ExplainPlanTest.java
@@ -72,7 +72,7 @@ class ExplainPlanTest {
   void testExplain(Context context) throws SQLException {
 //    Level originalLevel = RolapUtil.PROFILE_LOGGER.getLevel();
     //Util.setLevel( RolapUtil.PROFILE_LOGGER, Level.OFF ); // Must turn off in case test environment has enabled profiling
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     final Statement statement = connection.createStatement();
     final ResultSet resultSet =
         statement.executeQuery( "explain plan for\n" + "select [Measures].[Unit Sales] on 0,\n"
@@ -112,7 +112,7 @@ mondrian.olap.fun.FilterFunDef$ImmutableIterCalc(type=SetType<MemberType<hierarc
 //    Level originalLevel = RolapUtil.PROFILE_LOGGER.getLevel();
 		// Util.setLevel( RolapUtil.PROFILE_LOGGER, Level.OFF );; // Must turn off in
 		// case test environment has enabled profiling
-		Connection connection = context.getConnection();
+		Connection connection = context.getConnectionWithDefaultRole();
 		final Statement statement = connection.createStatement();
 		final String mdx = """
 				with member [Time].[Time].[1997].[H1] as
@@ -228,7 +228,7 @@ mondrian.olap.fun.CrossJoinFunDef$CrossJoinIterCalc(type=SetType<TupleType<Membe
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
   void testExplainInvalid(Context context) throws SQLException {
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     final Statement statement = connection.createStatement();
     try {
       final ResultSet resultSet =
@@ -414,7 +414,7 @@ mondrian.olap.fun.CrossJoinFunDef$CrossJoinIterCalc(type=SetType<TupleType<Membe
 
   private ArrayList<String> executeQuery(Context context, String mdx ) throws SQLException {
 
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     final CacheControl cacheControl = connection.getCacheControl( null );
 
     // Flush the entire cache.

--- a/mondrian/src/test/java/mondrian/test/IgnoreMeasureForNonJoiningDimensionInAggregationTest.java
+++ b/mondrian/src/test/java/mondrian/test/IgnoreMeasureForNonJoiningDimensionInAggregationTest.java
@@ -55,7 +55,7 @@ class IgnoreMeasureForNonJoiningDimensionInAggregationTest
     void testNoTotalsForCompdMeasureWithComponentsHavingNonJoiningDims(Context context)
     {
         ((TestConfig)context.getConfig()).setIgnoreMeasureForNonJoiningDimension(true);
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         connection.getCacheControl(null).flushSchemaCache();
         assertQueryReturns(connection,
             "with member [Measures].[Total Sales] as "
@@ -76,7 +76,7 @@ class IgnoreMeasureForNonJoiningDimensionInAggregationTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testNonJoiningDimsWhenAggFunctionIsUsedOrNotUsed(Context context) {
         ((TestConfig)context.getConfig()).setIgnoreMeasureForNonJoiningDimension(true);
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         connection.getCacheControl(null).flushSchemaCache();
         final String query = "WITH\n"
                              + "MEMBER [Measures].[Total Sales] AS "
@@ -126,7 +126,7 @@ class IgnoreMeasureForNonJoiningDimensionInAggregationTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testNonJoiningDimForAMemberDefinedOnJoiningDim(Context context) {
         ((TestConfig)context.getConfig()).setIgnoreMeasureForNonJoiningDimension(true);
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         connection.getCacheControl(null).flushSchemaCache();
         assertQueryReturns(connection,
             "WITH\n"
@@ -155,7 +155,7 @@ class IgnoreMeasureForNonJoiningDimensionInAggregationTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testNonJoiningDimWithNumericIif(Context context) {
         ((TestConfig)context.getConfig()).setIgnoreMeasureForNonJoiningDimension(true);
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         connection.getCacheControl(null).flushSchemaCache();
         assertQueryReturns(connection,
             "WITH\n"
@@ -190,7 +190,7 @@ class IgnoreMeasureForNonJoiningDimensionInAggregationTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testNonJoiningDimAtMemberValueCalcMultipleScenarios(Context context) {
         ((TestConfig)context.getConfig()).setIgnoreMeasureForNonJoiningDimension(true);
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         connection.getCacheControl(null).flushSchemaCache();
         assertQueryReturns(connection,
             "WITH\n"
@@ -238,7 +238,7 @@ class IgnoreMeasureForNonJoiningDimensionInAggregationTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testNonJoiningDimAtTupleValueCalcMultipleScenarios(Context context) {
         ((TestConfig)context.getConfig()).setIgnoreMeasureForNonJoiningDimension(true);
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         connection.getCacheControl(null).flushSchemaCache();
         assertQueryReturns(connection,
             "WITH\n"
@@ -299,7 +299,7 @@ class IgnoreMeasureForNonJoiningDimensionInAggregationTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testNoTotalsForCompoundMeasureWithNonJoiningDimAtAllLevel(Context context) {
         ((TestConfig)context.getConfig()).setIgnoreMeasureForNonJoiningDimension(true);
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         connection.getCacheControl(null).flushSchemaCache();
         assertQueryReturns(connection,
             "with member [Measures].[Total Sales] as "
@@ -321,7 +321,7 @@ class IgnoreMeasureForNonJoiningDimensionInAggregationTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testNoTotalForMeasureWithCrossJoinOfJoiningAndNonJoiningDims(Context context) {
         ((TestConfig)context.getConfig()).setIgnoreMeasureForNonJoiningDimension(true);
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         connection.getCacheControl(null).flushSchemaCache();
         assertQueryReturns(connection,
             "with member [Product].x as "
@@ -338,7 +338,7 @@ class IgnoreMeasureForNonJoiningDimensionInAggregationTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testShouldTotalAMeasureWithAllJoiningDimensions(Context context) {
         ((TestConfig)context.getConfig()).setIgnoreMeasureForNonJoiningDimension(true);
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         connection.getCacheControl(null).flushSchemaCache();
         assertQueryReturns(connection,
             "with member [Product].x as "
@@ -360,7 +360,7 @@ class IgnoreMeasureForNonJoiningDimensionInAggregationTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testShouldNotTotalAMeasureWithANonJoiningDimension(Context context) {
         ((TestConfig)context.getConfig()).setIgnoreMeasureForNonJoiningDimension(true);
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         connection.getCacheControl(null).flushSchemaCache();
         assertQueryReturns(connection,
             "with member [Gender].x as 'sum({Gender.members})'"
@@ -379,7 +379,7 @@ class IgnoreMeasureForNonJoiningDimensionInAggregationTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testGetMeasureCubeForCalcMeasureDoesNotThrowCastException(Context context) {
         ((TestConfig)context.getConfig()).setIgnoreMeasureForNonJoiningDimension(true);
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         connection.getCacheControl(null).flushSchemaCache();
         assertQueryReturns(connection,
             "WITH MEMBER [Measures].[My Profit] AS "

--- a/mondrian/src/test/java/mondrian/test/IgnoreUnrelatedDimensionsTest.java
+++ b/mondrian/src/test/java/mondrian/test/IgnoreUnrelatedDimensionsTest.java
@@ -138,7 +138,7 @@ class IgnoreUnrelatedDimensionsTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testTotalingOnCrossJoinOfJoiningAndNonJoiningDimensions(Context context) {
     	prepareContext(context);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH MEMBER [Measures].[Unit Sales VM] AS "
             + "'ValidMeasure([Measures].[Unit Sales])', SOLVE_ORDER = 3000 "
             + "MEMBER Gender.G AS 'AGGREGATE(CROSSJOIN({[Gender].[Gender].MEMBERS},"
@@ -160,7 +160,7 @@ class IgnoreUnrelatedDimensionsTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testVMShouldNotPushUpAggMemberDefinedOnNonJoiningDimension(Context context) {
     	prepareContext(context);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH MEMBER [Measures].[Total Sales] AS "
             + "'ValidMeasure(Measures.[Warehouse Sales]) + [Measures].[Unit Sales]',"
             + "SOLVE_ORDER = 3000 "
@@ -191,7 +191,7 @@ class IgnoreUnrelatedDimensionsTest {
         withSchema(context, schema);
          */
     	withSchema(context, SchemaModifiers.IgnoreUnrelatedDimensionsTestModifier1::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH MEMBER [Measures].[Total Sales] AS "
             + "'ValidMeasure(Measures.[Warehouse Sales]) + [Measures].[Unit Sales]',"
             + "SOLVE_ORDER = 3000 "
@@ -225,7 +225,7 @@ class IgnoreUnrelatedDimensionsTest {
         withSchema(context, schema);
          */
         withSchema(context, SchemaModifiers.IgnoreUnrelatedDimensionsTestModifier1::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "SELECT "
             + "{[Measures].[Warehouse Sales]} ON 0"
             + " FROM [WAREHOUSE AND SALES 3] where ([Gender].[M])",
@@ -249,7 +249,7 @@ class IgnoreUnrelatedDimensionsTest {
         withSchema(context, schema);
          */
         withSchema(context, SchemaModifiers.IgnoreUnrelatedDimensionsTestModifier1::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "SELECT "
             + "{[Measures].[Warehouse Sales]} ON 0"
             + " FROM [WAREHOUSE AND SALES 3] where "
@@ -275,7 +275,7 @@ class IgnoreUnrelatedDimensionsTest {
         withSchema(context, schema);
          */
         withSchema(context, SchemaModifiers.IgnoreUnrelatedDimensionsTestModifier1::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "SELECT "
             + "{[Measures].[Warehouse Sales]} ON 0"
             + " FROM [WAREHOUSE AND SALES 3] where "
@@ -307,7 +307,7 @@ class IgnoreUnrelatedDimensionsTest {
         // Should equal the [Unit Sales] of [Graduate Degree] and
         // [High School Degree] (with default Gender.F),
         //  plus the total [warehouse sales].
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with member measures.bothCubes as "
             + "'measures.[unit sales] + measures.[warehouse sales]'"
             + " SELECT "
@@ -324,7 +324,7 @@ class IgnoreUnrelatedDimensionsTest {
         // [Sales] does not ignoreUnrelatedDimensions, so the [Unit Sales]
         // part of the formula below should result in NULL given the
         // [Warehouse] dim in the slicer.
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with member measures.bothCubes as "
             + "'measures.[unit sales] + measures.[warehouse sales]'"
             + " SELECT "
@@ -349,7 +349,7 @@ class IgnoreUnrelatedDimensionsTest {
         // MONDRIAN-2072
         ((TestConfig)context.getConfig()).setIgnoreMeasureForNonJoiningDimension(true);
         prepareContext(context);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             " SELECT "
             + " FROM [WAREHOUSE AND SALES2] where "
             + "crossjoin( measures.[warehouse sales], "
@@ -365,7 +365,7 @@ class IgnoreUnrelatedDimensionsTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testTotalingForValidAndNonValidMeasuresWithJoiningDimensions(Context context) {
     	prepareContext(context);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH MEMBER [Measures].[Unit Sales VM] AS "
             + "'ValidMeasure([Measures].[Unit Sales])',"
             + "SOLVE_ORDER = 3000 "
@@ -389,7 +389,7 @@ class IgnoreUnrelatedDimensionsTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testTotalingWhenIgnoreUnrelatedDimensionsPropertyIsTrue(Context context) {
     	prepareContext(context);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH MEMBER [Measures].[Unit Sales VM] AS "
             + "'ValidMeasure([Measures].[Unit Sales])', SOLVE_ORDER = 3000 "
             + "MEMBER [Gender].[COG_OQP_USR_Aggregate(Gender SET)] AS "
@@ -448,7 +448,7 @@ class IgnoreUnrelatedDimensionsTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testTotalingOnNonJoiningDimension(Context context) {
     	prepareContext(context);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH MEMBER [Measures].[Unit Sales VM] AS "
             + "'ValidMeasure([Measures].[Unit Sales])', SOLVE_ORDER =3000"
             + "MEMBER MEASURES.[VirtualMeasure] AS "
@@ -528,7 +528,7 @@ class IgnoreUnrelatedDimensionsTest {
         ((TestConfig)context.getConfig()).setIgnoreMeasureForNonJoiningDimension(true);
 
         prepareContext(context);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH\n"
             + "MEMBER [Measures].[Total Sales] AS '[Measures].[Store Sales] + "
             + "[Measures].[Warehouse Sales]'\n"

--- a/mondrian/src/test/java/mondrian/test/InlineTableTest.java
+++ b/mondrian/src/test/java/mondrian/test/InlineTableTest.java
@@ -181,7 +181,7 @@ class InlineTableTest {
         withSchema(context, schema);
          */
         withSchema(context, TestInlineTableModifier::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Alternative Promotion].[All Alternative Promotions].children} ON COLUMNS\n"
             + "from [" + cubeName + "] ",
             "Axis #0:\n"
@@ -325,7 +325,7 @@ class InlineTableTest {
         withSchema(context, schema);
         */
         withSchema(context, TestInlineTableInSharedDimModifier::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Shared Alternative Promotion].[All Shared Alternative Promotions].children} ON COLUMNS\n"
             + "from [" + cubeName + "] ",
             "Axis #0:\n"
@@ -340,7 +340,7 @@ class InlineTableTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testInlineTableSnowflake(Context context) {
-        if (getDatabaseProduct(getDialect(context.getConnection()).getDialectName())
+        if (getDatabaseProduct(getDialect(context.getConnectionWithDefaultRole()).getDialectName())
             == DatabaseProduct.INFOBRIGHT)
         {
             // Infobright has a bug joining an inline table. Gives error
@@ -516,7 +516,7 @@ class InlineTableTest {
         withSchema(context, schema);
          */
         withSchema(context, TestInlineTableSnowflakeModifier::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Store].children} ON COLUMNS\n"
             + "from [" + cubeName + "] ",
             "Axis #0:\n"
@@ -696,7 +696,7 @@ class InlineTableTest {
             return;
         }
         withSchema(context, TestInlineTableDateModifier::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Alternative Promotion].Members} ON COLUMNS\n"
             + "from [" + cubeName + "] ",
             "Axis #0:\n"

--- a/mondrian/src/test/java/mondrian/test/MdcUtilTest.java
+++ b/mondrian/src/test/java/mondrian/test/MdcUtilTest.java
@@ -43,7 +43,7 @@ class MdcUtilTest {
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testMdcContext(Context context) throws Exception {
 
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     flushSchemaCache(connection);
 
 //    ThreadContext.put( "sessionName", "hello-world" );
@@ -78,7 +78,7 @@ class MdcUtilTest {
               + "{[Gender].[All Gender]}\n" + "{[Gender].[F]}\n" + "{[Gender].[M]}\n" + "Row #0: 266,773\n"
               + "Row #1: 131,558\n" + "Row #2: 135,215\n";
 
-      assertQueryReturns(context.getConnection(), query, expected );
+      assertQueryReturns(context.getConnectionWithDefaultRole(), query, expected );
       log = writer.toString();
 
     } finally {

--- a/mondrian/src/test/java/mondrian/test/MonitorTest.java
+++ b/mondrian/src/test/java/mondrian/test/MonitorTest.java
@@ -59,7 +59,7 @@ class MonitorTest {
             + "where [Time].[1997].[Q3].[9]";
 
         final Statement statement =
-            context.getConnection().createStatement();
+            context.getConnectionWithDefaultRole().createStatement();
         CellSet cellSet = statement.executeQuery(queryString);
         StringWriter stringWriter = new StringWriter();
         new RectangularCellSetFormatter(true).format(

--- a/mondrian/src/test/java/mondrian/test/MultipleHierarchyTest.java
+++ b/mondrian/src/test/java/mondrian/test/MultipleHierarchyTest.java
@@ -42,7 +42,7 @@ class MultipleHierarchyTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testWeekly(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         if (SystemWideProperties.instance().SsasCompatibleNaming) {
             // [Time.Weekly] has an 'all' member, but [Time] does not.
             assertAxisReturns(connection,
@@ -67,7 +67,7 @@ class MultipleHierarchyTest {
     void testWeekly2(Context context) {
         // When the context is one hierarchy,
         // the current member of other hierarchy must be its default member.
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with\n"
             + "  member [Measures].[Foo] as ' "
             + timeWeekly + ".CurrentMember.UniqueName '\n"
@@ -105,7 +105,7 @@ class MultipleHierarchyTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testMultipleMembersOfSameDimensionInSlicerFails(Context context) {
-        assertQueryThrows(context.getConnection(),
+        assertQueryThrows(context.getConnectionWithDefaultRole(),
             "select {[Measures].[Unit Sales]} on columns,\n"
             + " {[Store].children} on rows\n"
             + "from [Sales]\n"
@@ -116,7 +116,7 @@ class MultipleHierarchyTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testMembersOfHierarchiesInSameDimensionInSlicer(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Measures].[Unit Sales]} on columns,\n"
             + " {[Store].children} on rows\n"
             + "from [Sales]\n"
@@ -139,7 +139,7 @@ class MultipleHierarchyTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCalcMember(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         assertQueryReturns(connection,
             "with member [Measures].[Sales to Date] as \n"
             + " ' Sum(PeriodsToDate([Time].[Year], [Time].[Time].CurrentMember), [Measures].[Unit Sales])'\n"
@@ -225,7 +225,7 @@ class MultipleHierarchyTest {
         withSchema(context, SchemaModifiers.MultipleHierarchyTestModifier1::new);
 
         final String nuStore = hierarchyName("NuStore", "NuStore");
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with member [Measures].[Store level] as '" + nuStore
             + ".CurrentMember.Level.Name'\n"
             + "member [Measures].[Store type] as 'IIf((" + nuStore
@@ -335,7 +335,7 @@ class MultipleHierarchyTest {
             + "  [Time].Children.Count\n"
             + "select [Measures].[Time Child Count] on 0\n"
             + "from [Sales]";
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         if (SystemWideProperties.instance().SsasCompatibleNaming) {
             assertQueryThrows(connection,
                 query,
@@ -381,7 +381,7 @@ class MultipleHierarchyTest {
         withSchema(context, SchemaModifiers.MultipleHierarchyTestModifier2::new);
         final String nuStore = hierarchyName("NuStore", "NuStore");
 
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with set [*NATIVE_CJ_SET] as '[*BASE_MEMBERS_NuStore]' "
             + "set [*SORTED_ROW_AXIS] as 'Order([*CJ_ROW_AXIS], "
             + nuStore + ".CurrentMember.OrderKey, BASC)' "
@@ -419,7 +419,7 @@ class MultipleHierarchyTest {
             + "UPPER('Time.Weekly') group by `store`.`store_country` order by"
             + " ISNULL(`store`.`store_country`) ASC, "
             + "`store`.`store_country` ASC";
-        TestUtil.assertNoQuerySql(context.getConnection(),
+        TestUtil.assertNoQuerySql(context.getConnectionWithDefaultRole(),
             "with member [Time.Weekly].blah as '1' select from sales",
             new SqlPattern[]{
                 new SqlPattern(

--- a/mondrian/src/test/java/mondrian/test/NamedSetTest.java
+++ b/mondrian/src/test/java/mondrian/test/NamedSetTest.java
@@ -72,7 +72,7 @@ class NamedSetTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testNamedSet(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH\n"
             + "    SET [Top Sellers]\n"
             + "AS \n"
@@ -118,14 +118,14 @@ class NamedSetTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testNamedSetOnMember(Context context) {
-        switch (getDatabaseProduct(getDialect(context.getConnection()).getDialectName())) {
+        switch (getDatabaseProduct(getDialect(context.getConnectionWithDefaultRole()).getDialectName())) {
         case INFOBRIGHT:
             // Mondrian generates 'select ... sum(warehouse_sales) -
             // sum(warehouse_cost) as c ... order by c4', correctly, but
             // Infobright gives error "'c4' isn't in GROUP BY".
             return;
         }
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH\n"
             + "    MEMBER [Measures].[Profit]\n"
             + "AS '[Measures].[Warehouse Sales] - [Measures].[Warehouse Cost] '\n"
@@ -163,7 +163,7 @@ class NamedSetTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testNamedSetAsList(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH SET [ChardonnayChablis] AS\n"
             + "   '{[Product].[All Products].[Drink].[Alcoholic Beverages].[Beer and Wine].[Wine].[Good].[Good Chardonnay],\n"
             + "   [Product].[All Products].[Drink].[Alcoholic Beverages].[Beer and Wine].[Wine].[Pearl].[Pearl Chardonnay],\n"
@@ -213,7 +213,7 @@ class NamedSetTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testIntrinsic(Context context) {
     	SystemWideProperties.instance().CaseSensitiveMdxInstr = true;
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH SET [ChardonnayChablis] AS\n"
             + "   'Filter([Product].Members, (InStr(1, [Product].CurrentMember.Name, \"chardonnay\") <> 0) OR (InStr(1, [Product].CurrentMember.Name, \"chablis\") <> 0))'\n"
             + "SELECT\n"
@@ -225,7 +225,7 @@ class NamedSetTest {
             + "Axis #1:\n"
             + "Axis #2:\n"
             + "{[Measures].[Unit Sales]}\n");
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH SET [BeerMilk] AS\n"
             + "   'Filter([Product].Members, (InStr(1, [Product].CurrentMember.Name, \"Beer\") <> 0) OR (InStr(1, LCase([Product].CurrentMember.Name), \"milk\") <> 0))'\n"
             + "SELECT\n"
@@ -331,7 +331,7 @@ class NamedSetTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testNamedSetCrossJoin(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH\n"
             + "    SET [Store Types by Country]\n"
             + "AS\n"
@@ -364,7 +364,7 @@ class NamedSetTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     public void _testXxx(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH MEMBER [Store Type].[All Store Type].[oNormal] AS 'Aggregate(Filter([Customers].[Name].Members, [Customers].CurrentMember.Properties(\"Member Card\") = \"Normal\") * {[Store Type].[All Store Type]})'\n"
             + "MEMBER [Store Type].[All Store Type].[oBronze] AS 'Aggregate(Filter([Customers].[Name].Members, [Customers].CurrentMember.Properties(\"Member Card\") = \"Bronze\") * {[Store Type].[All Store Type]})'\n"
             + "MEMBER [Store Type].[All Store Type].[oGolden] AS 'Aggregate(Filter([Customers].[Name].Members, [Customers].CurrentMember.Properties(\"Member Card\") = \"Golden\") * {[Store Type].[All Store Type]})'\n"
@@ -381,7 +381,7 @@ class NamedSetTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testNamedSetUsedInCrossJoin(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH\n"
             + "  SET [TopMedia] AS 'TopCount([Promotion Media].children, 5, [Measures].[Store Sales])' \n"
             + "SELECT {[Time].[1997].[Q1], [Time].[1997].[Q2]} ON COLUMNS,\n"
@@ -443,7 +443,7 @@ class NamedSetTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testAggOnCalcMember(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH\n"
             + "  SET [TopMedia] AS 'TopCount([Promotion Media].children, 5, [Measures].[Store Sales])' \n"
             + "  MEMBER [Measures].[California sales for Top Media] AS 'Sum([TopMedia], ([Store].[USA].[CA], [Measures].[Store Sales]))'\n"
@@ -472,7 +472,7 @@ class NamedSetTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testContextSensitiveNamedSet(Context context) {
         // For reference.
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "SELECT {[Measures].[Unit Sales]} ON COLUMNS,\n"
             + "Order([Promotion Media].Children, [Measures].[Unit Sales], DESC) ON ROWS\n"
             + "FROM [Sales]\n"
@@ -513,7 +513,7 @@ class NamedSetTest {
             + "Row #13: 2,454\n");
 
         // For reference.
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "SELECT {[Measures].[Unit Sales]} ON COLUMNS,\n"
             + "Order([Promotion Media].Children, [Measures].[Unit Sales], DESC) ON ROWS\n"
             + "FROM [Sales]\n"
@@ -557,7 +557,7 @@ class NamedSetTest {
         // The bottom medium in 1997.Q2 is In-Store Coupon, with $35 in sales,
         //  whereas Radio has $40 in sales in 1997.Q2.
 
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH\n"
             + "  SET [Bottom Media] AS 'BottomCount([Promotion Media].children, 1, [Measures].[Unit Sales])' \n"
             + "  MEMBER [Measures].[Unit Sales for Bottom Media] AS 'Sum([Bottom Media], [Measures].[Unit Sales])'\n"
@@ -577,7 +577,7 @@ class NamedSetTest {
             + "Row #0: 2,454\n"
             + "Row #1: 40\n");
 
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH\n"
             + "  SET [TopMedia] AS 'TopCount([Promotion Media].children, 3, [Measures].[Store Sales])' \n"
             + "  MEMBER [Measures].[California sales for Top Media] AS 'Sum([TopMedia], [Measures].[Store Sales])'\n"
@@ -622,7 +622,7 @@ class NamedSetTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testOrderedNamedSet(Context context) {
         // From http://www.developersdex.com
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH SET [SET1] AS\n"
             + "'ORDER ({[Education Level].[Education Level].Members}, [Gender].[All Gender].[F], ASC)'\n"
             + "MEMBER [Gender].[RANK1] AS 'rank([Education Level].currentmember, [SET1])'\n"
@@ -655,7 +655,7 @@ class NamedSetTest {
             + "Row #4: 82,177.11\n"
             + "Row #4: 5\n");
 
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH SET [SET1] AS\n"
             + "'ORDER ({[Education Level].[Education Level].Members}, [Gender].[All Gender].[F], ASC)'\n"
             + "MEMBER [Gender].[RANK1] AS 'rank([Education Level].currentmember, [SET1])'\n"
@@ -689,7 +689,7 @@ class NamedSetTest {
             + "Row #4: $0.00\n");
 
         // Solve order fixes the problem.
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH SET [SET1] AS\n"
             + "'ORDER ({[Education Level].[Education Level].Members}, [Gender].[F], ASC)'\n"
             + "MEMBER [Gender].[RANK1] AS 'rank([Education Level].currentmember, [SET1])', \n"
@@ -726,7 +726,7 @@ class NamedSetTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testGenerate(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with \n"
             + "  member [Measures].[DateName] as \n"
             + "    'Generate({[Time].[1997].[Q1], [Time].[1997].[Q2]}, [Time].[Time].CurrentMember.Name) '\n"
@@ -743,7 +743,7 @@ class NamedSetTest {
             + "Row #0: Q1Q2\n"
             + "Row #1: Q1Q2\n");
 
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with \n"
             + "  member [Measures].[DateName] as \n"
             + "    'Generate({[Time].[1997].[Q1], [Time].[1997].[Q2]}, [Time].[Time].CurrentMember.Name, \" and \") '\n"
@@ -768,7 +768,7 @@ class NamedSetTest {
         withSchema(context,
                 NamedSetsInCubeModifier::new);
         // Set defined against cube, using 'formula' attribute.
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         assertQueryReturns(connection,
             "SELECT {[Measures].[Unit Sales]} ON COLUMNS,\n"
             + " {[CA Cities]} ON ROWS\n"
@@ -844,7 +844,7 @@ class NamedSetTest {
     	Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
         withSchema(context,
         		NamedSetTest.NamedSetsInCubeAndSchemaModifier::new);
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         assertQueryReturns(connection,
             "SELECT {[Measures].[Store Sales]} on columns,\n"
             + " Intersect([Top CA Cities], [Top USA Stores]) on rows\n"
@@ -908,7 +908,7 @@ class NamedSetTest {
         Result result;
         String queryString;
         String pattern;
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         // Formula for a named set must not be a member.
         queryString =
             "with set [Foo] as ' [Store].CurrentMember  '"
@@ -976,7 +976,7 @@ class NamedSetTest {
 
         withSchema(context,
                 MixedNamedSetSchemaModifier::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {\n"
             + "    [Measures].[Unit Sales],\n"
             + "    [Measures].[CA City Sales]} on columns,\n"
@@ -1032,7 +1032,7 @@ class NamedSetTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testNamedSetAndUnion(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with set [Set Education Level] as\n"
             + "   '{([Education Level].[All Education Levels].[Bachelors Degree]),\n"
             + "     ([Education Level].[All Education Levels].[Graduate Degree])}'\n"
@@ -1072,7 +1072,7 @@ class NamedSetTest {
     void testNamedSetDependencies(Context context) {
         withSchema(context,
                 NamedSetsInCubeModifier::new);
-        assertSetExprDependsOn(context.getConnection(), "[Top CA Cities]", "{}");
+        assertSetExprDependsOn(context.getConnectionWithDefaultRole(), "[Top CA Cities]", "{}");
     }
 
     /**
@@ -1082,7 +1082,7 @@ class NamedSetTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testHierarchizeNamedSetImmutable(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         flushSchemaCache(connection);
         assertQueryReturns(connection,
             "with set necj as\n"
@@ -1111,7 +1111,7 @@ class NamedSetTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCurrentAndCurrentOrdinal(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with set [Gender Marital Status] as\n"
             + " [Gender].members * [Marital Status].members\n"
             + "member [Measures].[GMS Ordinal] as\n"
@@ -1177,7 +1177,7 @@ class NamedSetTest {
             + "'Filter([Customers].[Name].Members, "
             + "measures.[Unit Sales] > 200)' select FilteredNamedSet on 0 from "
             + "sales where {Time.[1997].Q1, TIme.[1997].Q2}";
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             mdx,
             "Axis #0:\n"
             + "{[Time].[1997].[Q1]}\n"
@@ -1199,7 +1199,7 @@ class NamedSetTest {
             + "Row #0: 257\n"
             + "Row #0: 258\n"
             + "Row #0: 227\n");
-        verifySameNativeAndNot(context.getConnection(), mdx, "");
+        verifySameNativeAndNot(context.getConnectionWithDefaultRole(), mdx, "");
     }
 
     /**
@@ -1233,7 +1233,7 @@ class NamedSetTest {
             + "Row #0: 363\n"
             + "Row #0: 344\n"
             + "Row #0: 323\n";
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         assertQueryReturns(connection,
             "SELECT\n"
             + "NON EMPTY TopCount([Customers].[Name].Members, 5, [Measures].[Unit Sales]) * [Measures].[Unit Sales] on 0\n"
@@ -1286,7 +1286,7 @@ class NamedSetTest {
     void testMondrian2424(Context context) {
 
         SystemWideProperties.instance().SsasCompatibleNaming = false;
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "WITH SET Gender as '[Gender].[Gender].members' \n" +
                         "select {Gender} ON 0 from [Sales]",
                 "Axis #0:\n" +

--- a/mondrian/src/test/java/mondrian/test/NativeSetEvaluationTest.java
+++ b/mondrian/src/test/java/mondrian/test/NativeSetEvaluationTest.java
@@ -261,7 +261,7 @@ protected void assertQuerySql(Connection connection,
         + "NON EMPTY {[Measures].[Store Sales], Measures.x1, Measures.x2, Measures.x3} ON 0\n"
         + "FROM [Sales] where [Time.Weekly].x";
 
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     ((TestConfig)context.getConfig()).setGenerateFormattedSql(true);
     SqlPattern mysqlPattern = useAgg
       ? new SqlPattern(
@@ -273,9 +273,9 @@ protected void assertQuerySql(Connection connection,
       NativeTopCountWithAgg.getMysql(connection),
       NativeTopCountWithAgg.getMysql(connection));
     if ( context.getConfig().enableNativeTopCount() ) {
-      assertQuerySql(context.getConnection(), mdx, new SqlPattern[] { mysqlPattern } );
+      assertQuerySql(context.getConnectionWithDefaultRole(), mdx, new SqlPattern[] { mysqlPattern } );
     }
-    assertQueryReturns(context.getConnection(), mdx, NativeTopCountWithAgg.result );
+    assertQueryReturns(context.getConnectionWithDefaultRole(), mdx, NativeTopCountWithAgg.result );
   }
 
   /**
@@ -298,7 +298,7 @@ protected void assertQuerySql(Connection connection,
         + " SELECT NON EMPTY products ON 1,\n"
         + "NON EMPTY {[Measures].[Store Sales], Measures.x1, Measures.x2, Measures.x3} ON 0\n"
         + "FROM [Sales] where [Time.Weekly].x";
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     ((TestConfig)context.getConfig()).setGenerateFormattedSql(true);
     SqlPattern mysqlPattern = useAgg ? new SqlPattern(
       DatabaseProduct.MYSQL,
@@ -310,16 +310,16 @@ protected void assertQuerySql(Connection connection,
       NativeTopCountWithAgg.getMysql(connection));
     if ( context.getConfig().enableNativeTopCount()
       && SystemWideProperties.instance().EnableNativeNonEmpty ) {
-      assertQuerySql(context.getConnection(), mdx, new SqlPattern[] { mysqlPattern } );
+      assertQuerySql(context.getConnectionWithDefaultRole(), mdx, new SqlPattern[] { mysqlPattern } );
     }
-    assertQueryReturns(context.getConnection(), mdx, NativeTopCountWithAgg.result );
+    assertQueryReturns(context.getConnectionWithDefaultRole(), mdx, NativeTopCountWithAgg.result );
   }
 
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testNativeFilterWithAggDescendants(Context context) {
 	  context.getSchemaCache().clear();
-	  context.getConnection().getCacheControl(null).flushSchemaCache();
+	  context.getConnectionWithDefaultRole().getCacheControl(null).flushSchemaCache();
     final boolean useAgg =
       context.getConfig().useAggregates()
         && context.getConfig().readAggregates();
@@ -380,7 +380,7 @@ protected void assertQuerySql(Connection connection,
         + ( useAgg ? "    (sum(`agg_c_14_sales_fact_1997`.`store_sales`) > 700)\n"
         : "    (sum(`sales_fact_1997`.`store_sales`) > 700)\n" )
         + "order by\n"
-        + (getDialect(context.getConnection()).requiresOrderByAlias()
+        + (getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
         ? "    ISNULL(`c0`) ASC, `c0` ASC,\n"
         + "    ISNULL(`c1`) ASC, `c1` ASC,\n"
         + "    ISNULL(`c2`) ASC, `c2` ASC,\n"
@@ -402,9 +402,9 @@ protected void assertQuerySql(Connection connection,
         mysqlQuery );
     if ( context.getConfig().enableNativeFilter()
       && SystemWideProperties.instance().EnableNativeNonEmpty ) {
-      assertQuerySql(context.getConnection(), mdx, new SqlPattern[] { mysqlPattern } );
+      assertQuerySql(context.getConnectionWithDefaultRole(), mdx, new SqlPattern[] { mysqlPattern } );
     }
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       mdx,
       "Axis #0:\n"
         + "{[Time].[x]}\n"
@@ -493,7 +493,7 @@ protected void assertQuerySql(Connection connection,
         + "    `product_class`.`product_department`,\n"
         + "    `product_class`.`product_category`\n"
         + "order by\n"
-        + (getDialect(context.getConnection()).requiresOrderByAlias()
+        + (getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
         ? "    `c3` DESC,\n"
         + "    ISNULL(`c0`) ASC, `c0` ASC,\n"
         + "    ISNULL(`c1`) ASC, `c1` ASC,\n"
@@ -513,9 +513,9 @@ protected void assertQuerySql(Connection connection,
         mysqlQuery,
         mysqlQuery.indexOf( "(" ) );
     if ( context.getConfig().enableNativeTopCount() ) {
-      assertQuerySql(context.getConnection(), mdx, new SqlPattern[] { mysqlPattern } );
+      assertQuerySql(context.getConnectionWithDefaultRole(), mdx, new SqlPattern[] { mysqlPattern } );
     }
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       mdx,
       "Axis #0:\n"
         + "{[Time].[Slicer], [Store Type].[Slicer]}\n"
@@ -598,7 +598,7 @@ protected void assertQuerySql(Connection connection,
         + "    `product_class`.`product_department`,\n"
         + "    `product_class`.`product_category`\n"
         + "order by\n"
-        + (getDialect(context.getConnection()).requiresOrderByAlias()
+        + (getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
         ? "    `c3` DESC,\n"
         + "    ISNULL(`c0`) ASC, `c0` ASC,\n"
         + "    ISNULL(`c1`) ASC, `c1` ASC,\n"
@@ -618,10 +618,10 @@ protected void assertQuerySql(Connection connection,
         mysqlQuery,
         mysqlQuery.indexOf( "(" ) );
     if ( context.getConfig().enableNativeTopCount() ) {
-      context.getConnection().getCacheControl(null).flushSchemaCache();
-      assertQuerySql(context.getConnection(), mdx, new SqlPattern[] { mysqlPattern } );
+      context.getConnectionWithDefaultRole().getCacheControl(null).flushSchemaCache();
+      assertQuerySql(context.getConnectionWithDefaultRole(), mdx, new SqlPattern[] { mysqlPattern } );
     }
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       mdx,
       "Axis #0:\n"
         + "{[Time].[Slicer], [Store Type].[Slicer]}\n"
@@ -704,7 +704,7 @@ protected void assertQuerySql(Connection connection,
         + "    `product_class`.`product_department`,\n"
         + "    `product_class`.`product_category`\n"
         + "order by\n"
-        + ( getDialect(context.getConnection()).requiresOrderByAlias()
+        + ( getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
         ? "    `c3` DESC,\n"
         + "    ISNULL(`c0`) ASC, `c0` ASC,\n"
         + "    ISNULL(`c1`) ASC, `c1` ASC,\n"
@@ -724,9 +724,9 @@ protected void assertQuerySql(Connection connection,
           DatabaseProduct.MYSQL,
           mysqlQuery,
           mysqlQuery.indexOf( "(" ) );
-      assertQuerySql(context.getConnection(), mdx, new SqlPattern[] { mysqlPattern } );
+      assertQuerySql(context.getConnectionWithDefaultRole(), mdx, new SqlPattern[] { mysqlPattern } );
     }
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       mdx,
       "Axis #0:\n"
         + "{[Time].[Slicer], [Store Type].[Slicer]}\n"
@@ -752,7 +752,7 @@ protected void assertQuerySql(Connection connection,
         + "  SELECT NON EMPTY [Measures].[Unit Sales] on 0,\n"
         + "    TC ON 1 \n"
         + "  FROM [Sales] WHERE [Store Type].[Slicer]\n";
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       mdx,
       "Axis #0:\n"
         + "{[Store Type].[Slicer]}\n"
@@ -772,7 +772,7 @@ protected void assertQuerySql(Connection connection,
 
       // native should be used and Canada/Mexico should be returned
     // even though Canada and Mexico have no associated data.
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "select TopCount(Customers.Country.members, 2) "
         + "on 0 from Sales",
       "Axis #0:\n"
@@ -783,7 +783,7 @@ protected void assertQuerySql(Connection connection,
         + "Row #0: \n"
         + "Row #0: \n" );
     // TopCount should return in natural order, not order of measure val
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "select TopCount(Product.Drink.Children, 2) "
         + "on 0 from Sales",
       "Axis #0:\n"
@@ -805,7 +805,7 @@ protected void assertQuerySql(Connection connection,
       ((TestConfig)context.getConfig())
           .setAlertNativeEvaluationUnsupported("ERROR");
 
-      Connection connection = context.getConnection();
+      Connection connection = context.getConnectionWithDefaultRole();
     try {
       executeQuery(
         "select TopCount( CrossJoin(Gender.Gender.members, Product.Drink.Children), 2) "
@@ -827,7 +827,7 @@ protected void assertQuerySql(Connection connection,
       ((TestConfig)context.getConfig())
           .setAlertNativeEvaluationUnsupported("ERROR");
 
-      Connection connection = context.getConnection();
+      Connection connection = context.getConnectionWithDefaultRole();
     try {
       executeQuery(
         "with member Gender.foo as '1'"
@@ -857,7 +857,7 @@ protected void assertQuerySql(Connection connection,
         + "SELECT NON EMPTY [Measures].[Unit Sales] on 0,\n"
         + "  NON EMPTY TOP_COUNTRY ON 1 \n"
         + "FROM [Sales] WHERE [Product].[Top Drinks]";
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       mdx,
       "Axis #0:\n"
         + "{[Product].[Top Drinks]}\n"
@@ -892,7 +892,7 @@ protected void assertQuerySql(Connection connection,
         + "  SELECT NON EMPTY [Measures].[Unit Sales] on 0,\n"
         + "    TC ON 1 \n"
         + "  FROM [Sales] where [Time].[Slicer]\n";
-    assertQueryThrows(context.getConnection(), mdx, "evaluating itself" );
+    assertQueryThrows(context.getConnectionWithDefaultRole(), mdx, "evaluating itself" );
   }
 
   /**
@@ -926,7 +926,7 @@ protected void assertQuerySql(Connection connection,
         + "Row #0: 372.36\n"
         + "Row #1: 365.20\n";
 
-    assertQueryReturns(context.getConnection(), mdx, result );
+    assertQueryReturns(context.getConnectionWithDefaultRole(), mdx, result );
   }
 
   /**
@@ -967,7 +967,7 @@ protected void assertQuerySql(Connection connection,
         + "Row #0: 460.02\n"
         + "Row #1: 420.74\n";
 
-    assertQueryReturns(context.getConnection(), mdx, result );
+    assertQueryReturns(context.getConnectionWithDefaultRole(), mdx, result );
   }
 
   /**
@@ -1017,7 +1017,7 @@ protected void assertQuerySql(Connection connection,
         + "    `product_class`.`product_family`,\n"
         + "    `product_class`.`product_department`\n"
         + "order by\n"
-        + ( getDialect(context.getConnection()).requiresOrderByAlias()
+        + ( getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
         ? "    `c2` DESC,\n"
         + "    ISNULL(`c0`) ASC, `c0` ASC,\n"
         + "    ISNULL(`c1`) ASC, `c1` ASC"
@@ -1032,11 +1032,11 @@ protected void assertQuerySql(Connection connection,
         mysql );
 
     if ( context.getConfig().enableNativeTopCount() ) {
-      context.getConnection().getCacheControl(null).flushSchemaCache();
-      assertQuerySql(context.getConnection(), mdx, new SqlPattern[] { mysqlPattern } );
+      context.getConnectionWithDefaultRole().getCacheControl(null).flushSchemaCache();
+      assertQuerySql(context.getConnectionWithDefaultRole(), mdx, new SqlPattern[] { mysqlPattern } );
     }
 
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       mdx,
       "Axis #0:\n"
         + "{[Time.Weekly].[x]}\n"
@@ -1223,7 +1223,7 @@ protected void assertQuerySql(Connection connection,
     withSchema(context, schema);
      */
       withSchema(context, TestMultipleAllWithInExprModifier::new);
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       mdx,
       result );
   }
@@ -1275,7 +1275,7 @@ protected void assertQuerySql(Connection connection,
         + "    `customer`.`education`,\n"
         + "    `customer`.`yearly_income`\n"
         + "order by\n"
-        + ( getDialect(context.getConnection()).requiresOrderByAlias()
+        + ( getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
         ? "    ISNULL(`c1`) ASC, `c1` ASC"
         :
         "    ISNULL(CONCAT(`customer`.`fname`, ' ', `customer`.`lname`)) ASC, CONCAT(`customer`.`fname`, ' ', "
@@ -1287,10 +1287,10 @@ protected void assertQuerySql(Connection connection,
         mysql );
 
     if ( SystemWideProperties.instance().EnableNativeNonEmpty ) {
-      assertQuerySql(context.getConnection(), mdx, new SqlPattern[] { mysqlPattern } );
+      assertQuerySql(context.getConnectionWithDefaultRole(), mdx, new SqlPattern[] { mysqlPattern } );
     }
 
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       mdx,
       "Axis #0:\n"
         + "{[Time].[1997].[Q1]}\n"
@@ -1367,7 +1367,7 @@ protected void assertQuerySql(Connection connection,
         + "    `customer`.`education`,\n"
         + "    `customer`.`yearly_income`\n"
         + "order by\n"
-        + ( getDialect(context.getConnection()).requiresOrderByAlias()
+        + ( getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
         ? "    `c10` DESC,\n"
         + "    ISNULL(`c0`) ASC, `c0` ASC,\n"
         + "    ISNULL(`c1`) ASC, `c1` ASC,\n"
@@ -1386,10 +1386,10 @@ protected void assertQuerySql(Connection connection,
         mysql );
 
     if ( context.getConfig().enableNativeTopCount() ) {
-      assertQuerySql(context.getConnection(), mdx, new SqlPattern[] { mysqlPattern } );
+      assertQuerySql(context.getConnectionWithDefaultRole(), mdx, new SqlPattern[] { mysqlPattern } );
     }
 
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       mdx,
       "Axis #0:\n"
         + "{[Time].[1997], [Product].[Drink]}\n"
@@ -1458,7 +1458,7 @@ protected void assertQuerySql(Connection connection,
         + "    `customer`.`education`,\n"
         + "    `customer`.`yearly_income`\n"
         + "order by\n"
-        + ( getDialect(context.getConnection()).requiresOrderByAlias()
+        + ( getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
         ? "    `c10` DESC,\n"
         + "    ISNULL(`c0`) ASC, `c0` ASC,\n"
         + "    ISNULL(`c1`) ASC, `c1` ASC,\n"
@@ -1477,10 +1477,10 @@ protected void assertQuerySql(Connection connection,
         mysql );
 
     if ( context.getConfig().enableNativeTopCount() ) {
-      assertQuerySql(context.getConnection(), mdx, new SqlPattern[] { mysqlPattern } );
+      assertQuerySql(context.getConnectionWithDefaultRole(), mdx, new SqlPattern[] { mysqlPattern } );
     }
 
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       mdx,
       "Axis #0:\n"
         + "{[Time.Weekly].[1997].[48].[17]}\n"
@@ -1504,7 +1504,7 @@ protected void assertQuerySql(Connection connection,
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testConstraintCacheIncludesMultiPositionSlicer(Context context) {
     // MONDRIAN-2081
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "select non empty [Customers].[USA].[WA].[Spokane].children  on 0, "
         + "Time.[1997].[Q1].[1] * [Store].[USA].[WA].[Spokane] * Gender.F * [Marital Status].M on 1 from sales where\n"
         + "{[Product].[Food].[Snacks].[Candy].[Gum].[Atomic].[Atomic Bubble Gum],\n"
@@ -1519,7 +1519,7 @@ protected void assertQuerySql(Connection connection,
         + "{[Time].[1997].[Q1].[1], [Store].[USA].[WA].[Spokane], [Gender].[F], [Marital Status].[M]}\n"
         + "Row #0: 4\n"
         + "Row #0: 3\n" );
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "select non empty [Customers].[USA].[WA].[Spokane].children on 0, "
         + "Time.[1997].[Q1].[1] * [Store].[USA].[WA].[Spokane] * Gender.F *"
         + "[Marital Status].M on 1 from sales where "
@@ -1811,7 +1811,7 @@ protected void assertQuerySql(Connection connection,
         + "> 1000))'\n"
         + "SELECT [Measures].[TotalVal] ON 0, [Product].[All Products].Children on 1 \n"
         + "FROM [Sales] WHERE {[Time].[1997].[Q1],[Time].[1997].[Q2]}";
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       mdx,
       "Axis #0:\n"
         + "{[Time].[1997].[Q1]}\n"
@@ -1825,7 +1825,7 @@ protected void assertQuerySql(Connection connection,
         + "Row #0: 10,152\n"
         + "Row #1: 90,413\n"
         + "Row #2: 23,813\n" );
-    context.getConnection().getCacheControl(null).flushSchemaCache();
+    context.getConnectionWithDefaultRole().getCacheControl(null).flushSchemaCache();
     if ( !context.getConfig().enableNativeFilter() ) {
       return;
     }
@@ -1862,7 +1862,7 @@ protected void assertQuerySql(Connection connection,
       + "having\n"
       + "    (sum(`sales_fact_1997`.`unit_sales`) > 1000)\n"
       + "order by\n"
-      + ( getDialect(context.getConnection()).requiresOrderByAlias()
+      + ( getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
       ? "    ISNULL(`c0`) ASC, `c0` ASC,\n"
       + "    ISNULL(`c1`) ASC, `c1` ASC,\n"
       + "    ISNULL(`c2`) ASC, `c2` ASC"
@@ -1897,7 +1897,7 @@ protected void assertQuerySql(Connection connection,
       + "having\n"
       + "    (sum(`agg_c_14_sales_fact_1997`.`unit_sales`) > 1000)\n"
       + "order by\n"
-      + ( getDialect(context.getConnection()).requiresOrderByAlias()
+      + ( getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
       ? "    ISNULL(`c0`) ASC, `c0` ASC,\n"
       + "    ISNULL(`c1`) ASC, `c1` ASC,\n"
       + "    ISNULL(`c2`) ASC, `c2` ASC"
@@ -1906,7 +1906,7 @@ protected void assertQuerySql(Connection connection,
       + "    ISNULL(`store`.`store_city`) ASC, `store`.`store_city` ASC" );
     SqlPattern mysqlPattern =
       new SqlPattern( DatabaseProduct.MYSQL, mysql, null );
-    assertQuerySql(context.getConnection(), mdx, new SqlPattern[] { mysqlPattern } );
+    assertQuerySql(context.getConnectionWithDefaultRole(), mdx, new SqlPattern[] { mysqlPattern } );
   }
 
   /**
@@ -1924,7 +1924,7 @@ protected void assertQuerySql(Connection connection,
         + "WHERE {([Product].[Non-Consumable], [Time].[1997].[Q1]),([Product].[Drink], [Time].[1997].[Q2])}";
 
     //TestContext context = getTestContext().withFreshConnection();
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       mdx,
       "Axis #0:\n"
         + "{[Product].[Non-Consumable], [Time].[1997].[Q1]}\n"
@@ -1948,7 +1948,7 @@ protected void assertQuerySql(Connection connection,
         + "Gender].[SomeSlicer]} on 1 from [Sales]\n"
         + "WHERE {([Product].[Non-Consumable], [Time].[1997].[Q1]),([Product].[Drink], [Time].[1997].[Q2])}";
 
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       mdx,
       "Axis #0:\n"
         + "{[Product].[Non-Consumable], [Time].[1997].[Q1]}\n"
@@ -1974,7 +1974,7 @@ protected void assertQuerySql(Connection connection,
         + "SELECT [Measures].[TotalVal] ON 0, [Gender].[All Gender].Children on 1 \n"
         + "FROM [Sales]\n"
         + "WHERE CrossJoin({ [Product].[Non-Consumable], [Product].[Drink] }, {[Time].[1997].[Q1],[Time].[1997].[Q2]})";
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       mdx,
       "Axis #0:\n"
         + "{[Product].[Non-Consumable], [Time].[1997].[Q1]}\n"
@@ -1999,7 +1999,7 @@ protected void assertQuerySql(Connection connection,
       "SELECT [Measures].[Unit Sales] ON 0,\n"
         + " Filter({[Store].[Store City].members},[Measures].[Unit Sales] > 10000) on 1 \n"
         + "FROM [Sales] WHERE {[Time].[1997].[Q1], [Time].[1997].[Q2].[4]}";
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       mdx,
       "Axis #0:\n"
         + "{[Time].[1997].[Q1]}\n"
@@ -2016,7 +2016,7 @@ protected void assertQuerySql(Connection connection,
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testNativeFilterWithCompoundSlicer2049(Context context) {
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "with member measures.avgQtrs as 'avg( filter( time.quarter.members, measures.[unit sales] < 200))' "
         + "select measures.avgQtrs * gender.members on 0 from sales where head( product.[product name].members, 3)",
       "Axis #0:\n"
@@ -2039,7 +2039,7 @@ protected void assertQuerySql(Connection connection,
     // tuples where not all combinations of their members are present to
     // fail when nativized.
     // MondrianProperties.instance().EnableNativeFilter.set(true);
-    assertQueryReturns(context.getConnection(),
+    assertQueryReturns(context.getConnectionWithDefaultRole(),
       "select [Measures].[Unit Sales] on columns, Filter([Time].[1997].Children, [Measures].[Unit Sales] < 12335) on "
         + "rows from [Sales] where {([Product].[Drink],[Store].[USA].[CA]),([Product].[Food],[Store].[USA].[OR])}",
       "Axis #0:\n"
@@ -2084,7 +2084,7 @@ protected void assertQuerySql(Connection connection,
       + "having\n"
       + "    (sum(`sales_fact_1997`.`unit_sales`) > 0)\n"
       + "order by\n"
-      + ( getDialect(context.getConnection()).requiresOrderByAlias()
+      + ( getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
       ? "    ISNULL(`c0`) ASC, `c0` ASC"
       : "    ISNULL(`customer`.`gender`) ASC, `customer`.`gender` ASC" );
 
@@ -2094,7 +2094,7 @@ protected void assertQuerySql(Connection connection,
         DatabaseProduct.MYSQL,
         query,
         null );
-    Result rest = executeQuery( mdx, context.getConnection());
+    Result rest = executeQuery( mdx, context.getConnectionWithDefaultRole());
     RolapCube cube = (RolapCube) rest.getQuery().getCube();
     RolapConnection con = (RolapConnection) rest.getQuery().getConnection();
     CacheControl cacheControl = con.getCacheControl( null );
@@ -2107,7 +2107,7 @@ protected void assertQuerySql(Connection connection,
     }
     SqlPattern[] patterns = new SqlPattern[] { mysqlPattern };
     if ( context.getConfig().enableNativeFilter() ) {
-      assertQuerySqlOrNot(context.getConnection(),
+      assertQuerySqlOrNot(context.getConnectionWithDefaultRole(),
         mdx, patterns, false, false, false );
     }
   }
@@ -2123,7 +2123,7 @@ protected void assertQuerySql(Connection connection,
       + " where customers.agg";
     final String message =
       "The results of native and non-native evaluations should be equal";
-    verifySameNativeAndNot(context.getConnection(), query, message);
+    verifySameNativeAndNot(context.getConnectionWithDefaultRole(), query, message);
   }
 
   @ParameterizedTest
@@ -2140,7 +2140,7 @@ protected void assertQuerySql(Connection connection,
 
     final String message =
       "The results of native and non-native evaluations should be equal";
-    verifySameNativeAndNot(context.getConnection(), query, message);
+    verifySameNativeAndNot(context.getConnectionWithDefaultRole(), query, message);
   }
 
   @ParameterizedTest
@@ -2155,7 +2155,7 @@ protected void assertQuerySql(Connection connection,
 
     final String message =
       "The results of native and non-native evaluations should be equal";
-    verifySameNativeAndNot(context.getConnection(), query, message);
+    verifySameNativeAndNot(context.getConnectionWithDefaultRole(), query, message);
   }
 
   @ParameterizedTest
@@ -2172,7 +2172,7 @@ protected void assertQuerySql(Connection connection,
       + "with member Measures.q1Sales as '([PurchaseDate].[1997].[Q1], Measures.[Unit Sales])'\n"
       + "select NonEmptyCrossjoin([PurchaseDate].[1997].[Q1], Gender.Gender.members) on 0 \n"
       + "from Sales where Measures.q1Sales";
-    Result result = executeQuery(mdx, context.getConnection());
+    Result result = executeQuery(mdx, context.getConnectionWithDefaultRole());
 
     checkNative(context, mdx, result);
     context.getSchemaCache().clear();
@@ -2185,7 +2185,7 @@ protected void assertQuerySql(Connection connection,
       + "with member Measures.q1Sales as '([Time].[1997].[Q1], Measures.[Unit Sales])'\n"
       + "select NonEmptyCrossjoin( [Time].[1997].[Q1], Gender.Gender.members) on 0 \n"
       + "from Sales where Measures.q1Sales";
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     Result result = executeQuery(mdx, connection);
 
     checkNative(context, mdx, result );
@@ -2194,7 +2194,7 @@ protected void assertQuerySql(Connection connection,
   @ParameterizedTest
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testMondrian2575(Context context) {
-    assertQueriesReturnSimilarResults(context.getConnection(),
+    assertQueriesReturnSimilarResults(context.getConnectionWithDefaultRole(),
       String.format(
         "WITH member [Customers].[AggregatePageMembers] AS \n'Aggregate({[Customers].[USA].[CA].[Altadena].[Amy "
           + "Petranoff], [Customers].[USA].[CA].[Altadena].[Arvid Duran]})'\nmember [Measures].[test set] AS "
@@ -2213,7 +2213,7 @@ protected void assertQuerySql(Connection connection,
   @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
   void testResultLimitInNativeCJ(Context context) {
     SystemWideProperties.instance().ResultLimit = 400;
-    assertAxisThrows(context.getConnection(), "NonEmptyCrossjoin({[Product].[All Products].Children}, "
+    assertAxisThrows(context.getConnectionWithDefaultRole(), "NonEmptyCrossjoin({[Product].[All Products].Children}, "
         + "{ [Customers].[Name].members})",
       "exceeded limit (400)" );
   }

--- a/mondrian/src/test/java/mondrian/test/OrderByAliasTest.java
+++ b/mondrian/src/test/java/mondrian/test/OrderByAliasTest.java
@@ -61,13 +61,13 @@ class OrderByAliasTest extends BatchTestCase {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testSqlInKeyExpression(Context context) {
     ((TestConfig)context.getConfig()).setGenerateFormattedSql(true);
-    if (getDatabaseProduct(getDialect(context.getConnection()).getDialectName())
+    if (getDatabaseProduct(getDialect(context.getConnectionWithDefaultRole()).getDialectName())
         != DatabaseProduct.MYSQL
-        || !getDialect(context.getConnection()).requiresOrderByAlias())
+        || !getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias())
     {
       return; // For MySQL 5.7+ only!
     }
-    final StringBuilder colName = getDialect(context.getConnection())
+    final StringBuilder colName = getDialect(context.getConnectionWithDefaultRole())
         .quoteIdentifier("promotion_name");
     /*
     ((BaseTestContext)context).update(SchemaUpdater.createSubstitutingCube(
@@ -86,7 +86,7 @@ class OrderByAliasTest extends BatchTestCase {
       CatalogMapping catalog = ((RolapContext) context).getCatalogMapping();
       ((TestContext)context).setCatalogMappingSupplier(new SchemaModifiers.OrderByAliasTestModifier1KE(catalog, colName));
 
-      assertQuerySql(context.getConnection(),
+      assertQuerySql(context.getConnectionWithDefaultRole(),
         "select non empty{[Promotions].[All Promotions].Children} ON rows, "
         + "non empty {[Store].[All Stores]} ON columns "
         + "from [Sales] "
@@ -109,13 +109,13 @@ class OrderByAliasTest extends BatchTestCase {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testSqlInNameExpression(Context context) {
     ((TestConfig)context.getConfig()).setGenerateFormattedSql(true);
-    if (getDatabaseProduct(getDialect(context.getConnection()).getDialectName())
+    if (getDatabaseProduct(getDialect(context.getConnectionWithDefaultRole()).getDialectName())
         != DatabaseProduct.MYSQL
-        || !getDialect(context.getConnection()).requiresOrderByAlias())
+        || !getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias())
     {
       return; // For MySQL 5.7+ only!
     }
-    final StringBuilder colName = getDialect(context.getConnection())
+    final StringBuilder colName = getDialect(context.getConnectionWithDefaultRole())
         .quoteIdentifier("promotion_name");
     /*
     ((BaseTestContext)context).update(SchemaUpdater.createSubstitutingCube(
@@ -134,7 +134,7 @@ class OrderByAliasTest extends BatchTestCase {
          CatalogMapping catalog = ((RolapContext) context).getCatalogMapping();
          ((TestContext)context).setCatalogMappingSupplier(new SchemaModifiers.OrderByAliasTestModifier1NE(catalog, colName));
          assertQuerySql(
-        context.getConnection(),
+        context.getConnectionWithDefaultRole(),
         "select non empty{[Promotions].[All Promotions].Children} ON rows, "
         + "non empty {[Store].[All Stores]} ON columns "
         + "from [Sales] "
@@ -159,13 +159,13 @@ class OrderByAliasTest extends BatchTestCase {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testSqlInCaptionExpression(Context context) {
     ((TestConfig)context.getConfig()).setGenerateFormattedSql(true);
-    if (getDatabaseProduct(getDialect(context.getConnection()).getDialectName())
+    if (getDatabaseProduct(getDialect(context.getConnectionWithDefaultRole()).getDialectName())
         != DatabaseProduct.MYSQL
-        || !getDialect(context.getConnection()).requiresOrderByAlias())
+        || !getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias())
     {
       return; // For MySQL 5.7+ only!
     }
-    final StringBuilder colName = getDialect(context.getConnection())
+    final StringBuilder colName = getDialect(context.getConnectionWithDefaultRole())
         .quoteIdentifier("promotion_name");
     /*
     ((BaseTestContext)context).update(SchemaUpdater.createSubstitutingCube(
@@ -184,7 +184,7 @@ class OrderByAliasTest extends BatchTestCase {
          CatalogMapping catalog = ((RolapContext) context).getCatalogMapping();
          ((TestContext)context).setCatalogMappingSupplier(new SchemaModifiers.OrderByAliasTestModifier1CE(catalog, colName));
          assertQuerySql(
-        context.getConnection(),
+        context.getConnectionWithDefaultRole(),
         "select non empty{[Promotions].[All Promotions].Children} ON rows, "
         + "non empty {[Store].[All Stores]} ON columns "
         + "from [Sales] "
@@ -209,13 +209,13 @@ class OrderByAliasTest extends BatchTestCase {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testSqlInOrdinalExpression(Context context) {
     ((TestConfig)context.getConfig()).setGenerateFormattedSql(true);
-    if (getDatabaseProduct(getDialect(context.getConnection()).getDialectName())
+    if (getDatabaseProduct(getDialect(context.getConnectionWithDefaultRole()).getDialectName())
         != DatabaseProduct.MYSQL
-        || !getDialect(context.getConnection()).requiresOrderByAlias())
+        || !getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias())
     {
       return; // For MySQL 5.7+ only!
     }
-    final StringBuilder colName = getDialect(context.getConnection())
+    final StringBuilder colName = getDialect(context.getConnectionWithDefaultRole())
         .quoteIdentifier("promotion_name");
     /*
     ((BaseTestContext)context).update(SchemaUpdater.createSubstitutingCube(
@@ -234,7 +234,7 @@ class OrderByAliasTest extends BatchTestCase {
          CatalogMapping catalog = ((RolapContext) context).getCatalogMapping();
          ((TestContext)context).setCatalogMappingSupplier(new SchemaModifiers.OrderByAliasTestModifier1OE(catalog, colName));         
          assertQuerySql(
-        context.getConnection(),
+        context.getConnectionWithDefaultRole(),
         "select non empty{[Promotions].[All Promotions].Children} ON rows, "
         + "non empty {[Store].[All Stores]} ON columns "
         + "from [Sales] "
@@ -259,13 +259,13 @@ class OrderByAliasTest extends BatchTestCase {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testSqlInParentExpression(Context context) {
     ((TestConfig)context.getConfig()).setGenerateFormattedSql(true);
-    if (getDatabaseProduct(getDialect(context.getConnection()).getDialectName())
+    if (getDatabaseProduct(getDialect(context.getConnectionWithDefaultRole()).getDialectName())
         != DatabaseProduct.MYSQL
-        || !getDialect(context.getConnection()).requiresOrderByAlias())
+        || !getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias())
     {
       return; // For MySQL 5.7+ only!
     }
-    final StringBuilder colName = getDialect(context.getConnection())
+    final StringBuilder colName = getDialect(context.getConnectionWithDefaultRole())
         .quoteIdentifier("supervisor_id");
     /*
     ((BaseTestContext)context).update(SchemaUpdater.createSubstitutingCube(
@@ -296,7 +296,7 @@ class OrderByAliasTest extends BatchTestCase {
          CatalogMapping catalog = ((RolapContext) context).getCatalogMapping();
          ((TestContext)context).setCatalogMappingSupplier(new SchemaModifiers.OrderByAliasTestModifier2(catalog, colName));         
          assertQuerySql(
-        context.getConnection(),
+        context.getConnectionWithDefaultRole(),
         "select non empty{[Employees].[All Employees].Children} ON rows, "
         + "non empty {[Store].[All Stores]} ON columns "
         + "from [HR] "
@@ -333,13 +333,13 @@ class OrderByAliasTest extends BatchTestCase {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testSqlInPropertyExpression(Context context) {
     ((TestConfig)context.getConfig()).setGenerateFormattedSql(true);
-    if (getDatabaseProduct(getDialect(context.getConnection()).getDialectName())
+    if (getDatabaseProduct(getDialect(context.getConnectionWithDefaultRole()).getDialectName())
         != DatabaseProduct.MYSQL
-        || !getDialect(context.getConnection()).requiresOrderByAlias())
+        || !getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias())
     {
       return; // For MySQL 5.7+ only!
     }
-    final StringBuilder colName = getDialect(context.getConnection())
+    final StringBuilder colName = getDialect(context.getConnectionWithDefaultRole())
         .quoteIdentifier("promotion_name");
     /*
     ((BaseTestContext)context).update(SchemaUpdater.createSubstitutingCube(
@@ -358,7 +358,7 @@ class OrderByAliasTest extends BatchTestCase {
          CatalogMapping catalog = ((RolapContext) context).getCatalogMapping();
          ((TestContext)context).setCatalogMappingSupplier(new SchemaModifiers.OrderByAliasTestModifier3(catalog, colName));
          assertQuerySql(
-        context.getConnection(),
+        context.getConnectionWithDefaultRole(),
         "select non empty{[Promotions].[All Promotions].Children} ON rows, "
         + "non empty {[Store].[All Stores]} ON columns "
         + "from [Sales] "
@@ -381,14 +381,14 @@ class OrderByAliasTest extends BatchTestCase {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testSqlInMeasureExpression(Context context) {
     ((TestConfig)context.getConfig()).setGenerateFormattedSql(true);
-    if (getDatabaseProduct(getDialect(context.getConnection()).getDialectName())
+    if (getDatabaseProduct(getDialect(context.getConnectionWithDefaultRole()).getDialectName())
         != DatabaseProduct.MYSQL
-        || !getDialect(context.getConnection()).requiresOrderByAlias())
+        || !getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias())
     {
       return; // For MySQL 5.7+ only!
     }
-    flushSchemaCache(context.getConnection());
-    final StringBuilder colName = getDialect(context.getConnection())
+    flushSchemaCache(context.getConnectionWithDefaultRole());
+    final StringBuilder colName = getDialect(context.getConnectionWithDefaultRole())
         .quoteIdentifier("promotion_name");
     /*
     ((BaseTestContext)context).update(SchemaUpdater.createSubstitutingCube(
@@ -408,7 +408,7 @@ class OrderByAliasTest extends BatchTestCase {
         ((TestContext)context).setCatalogMappingSupplier(new SchemaModifiers.OrderByAliasTestModifier1ME(catalog, colName));
 
         assertQuerySql(
-        context.getConnection(),
+        context.getConnectionWithDefaultRole(),
         "select non empty{[Promotions].[All Promotions].Children} ON rows, "
         + "non empty {[Store].[All Stores]} ON columns "
         + "from [Sales] "
@@ -431,14 +431,14 @@ class OrderByAliasTest extends BatchTestCase {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testNonEmptyCrossJoin(Context context) {
     ((TestConfig)context.getConfig()).setGenerateFormattedSql(true);
-    if (getDatabaseProduct(getDialect(context.getConnection()).getDialectName())
+    if (getDatabaseProduct(getDialect(context.getConnectionWithDefaultRole()).getDialectName())
         != DatabaseProduct.MYSQL
-        || !getDialect(context.getConnection()).requiresOrderByAlias())
+        || !getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias())
     {
       return; // For MySQL 5.7+ only!
     }
     assertQuerySql(
-        context.getConnection(),
+        context.getConnectionWithDefaultRole(),
         "with set necj as\n"
         + "NonEmptyCrossJoin([Customers].[Name].members,[Store].[Store Name].members)\n"
         + "select\n"
@@ -514,15 +514,15 @@ class OrderByAliasTest extends BatchTestCase {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testVirtualCube(Context context) {
     ((TestConfig)context.getConfig()).setGenerateFormattedSql(true);
-    if (getDatabaseProduct(getDialect(context.getConnection()).getDialectName())
+    if (getDatabaseProduct(getDialect(context.getConnectionWithDefaultRole()).getDialectName())
         != DatabaseProduct.MYSQL
-        || !getDialect(context.getConnection()).requiresOrderByAlias())
+        || !getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias())
     {
       return; // For MySQL 5.7+ only!
     }
     withSchema(context, SchemaModifiers.OrderByAliasTestModifier4::new);
     assertQuerySql(
-        context.getConnection(),
+        context.getConnectionWithDefaultRole(),
         "select non empty crossjoin( product.[product family].members, time.quarter.members) on 0 "
         + "from [warehouse and sales]",
         mysqlPattern(

--- a/mondrian/src/test/java/mondrian/test/ParallelTest.java
+++ b/mondrian/src/test/java/mondrian/test/ParallelTest.java
@@ -39,7 +39,7 @@ class ParallelTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testParallelSchemaFlush(Context context) {
         // 5 threads, 8 cycles each, flush cache 1/10 of the time
-        checkSchemaFlush(context.getConnection(), 5, 8, 10);
+        checkSchemaFlush(context.getConnectionWithDefaultRole(), 5, 8, 10);
     }
 
     /**

--- a/mondrian/src/test/java/mondrian/test/ParameterTest.java
+++ b/mondrian/src/test/java/mondrian/test/ParameterTest.java
@@ -98,7 +98,7 @@ class ParameterTest {
         String mdx =
             "select {Parameter(\"Foo\",[Time],[Time].[1997],\"Foo\")} "
             + "ON COLUMNS from [Sales]";
-        Query query = context.getConnection().parseQuery(mdx);
+        Query query = context.getConnectionWithDefaultRole().parseQuery(mdx);
         SchemaReader sr = query.getSchemaReader(false).withLocus();
         Member m =
             sr.getMemberByUniqueName(
@@ -119,7 +119,7 @@ class ParameterTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testParameterInFormatString(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with member [Measures].[X] as '[Measures].[Store Sales]',\n"
             + "format_string = Parameter(\"fmtstrpara\", STRING, \"#\")\n"
             + "select {[Measures].[X]} ON COLUMNS\n"
@@ -142,7 +142,7 @@ class ParameterTest {
             + "from [Sales]";
 
         // this used to crash
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         Query query = connection.parseQuery(queryString);
         query.toString();
     }
@@ -150,7 +150,7 @@ class ParameterTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testParameterOnAxis(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Measures].[Unit Sales]} on rows,\n"
             + " {Parameter(\"GenderParam\",[Gender],[Gender].[M],\"Which gender?\")} on columns\n"
             + "from Sales",
@@ -168,7 +168,7 @@ class ParameterTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testNumericParameter(Context context) {
         String s =
-            executeExpr(context.getConnection(),"Parameter(\"N\",NUMERIC,2+3,\"A numeric parameter\")");
+            executeExpr(context.getConnectionWithDefaultRole(),"Parameter(\"N\",NUMERIC,2+3,\"A numeric parameter\")");
         assertEquals("5", s);
     }
 
@@ -176,7 +176,7 @@ class ParameterTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testStringParameter(Context context) {
         String s =
-            executeExpr(context.getConnection(),
+            executeExpr(context.getConnectionWithDefaultRole(),
                 "Parameter(\"S\",STRING,\"x\" || \"y\","
                 + "\"A string parameter\")");
         assertEquals("xy", s);
@@ -185,7 +185,7 @@ class ParameterTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testStringParameterNull(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         assertParameterizedExprReturns(connection,
             "Parameter('foo', STRING, 'default')",
             "xxx",
@@ -212,7 +212,7 @@ class ParameterTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testNumericParameterNull(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         assertParameterizedExprReturns(connection,
             "Parameter('foo', NUMERIC, 12.3)",
             "234",
@@ -231,7 +231,7 @@ class ParameterTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testMemberParameterNull(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         assertParameterizedExprReturns(connection,
             "Parameter('foo', [Gender], [Gender].[F]).Name",
             "M",
@@ -270,7 +270,7 @@ class ParameterTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testNullStrToMember(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         Query query = connection.parseQuery(
             "select NON EMPTY {[Time].[1997]} ON COLUMNS, "
             + "NON EMPTY {StrToMember(Parameter(\"sProduct\", STRING, \"[Gender].[Gender].[F]\"))} ON ROWS "
@@ -328,7 +328,7 @@ class ParameterTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testSetUnsetParameter(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         Query query = connection.parseQuery(
             "with member [Measures].[Foo] as\n"
             + " len(Parameter(\"sProduct\", STRING, \"foobar\"))\n"
@@ -388,7 +388,7 @@ class ParameterTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testNumericParameterStringValueFails(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         assertExprThrows(connection,
             "Parameter(\"S\",NUMERIC,\"x\" || \"y\",\"A string parameter\")",
             "java.lang.NumberFormatException: For input string: \"xy\"");
@@ -397,7 +397,7 @@ class ParameterTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testParameterDimensionWithTwoHierarchies(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         assertExprReturns(connection,
             "Parameter(\"Foo\",[Time],[Time].[1997],\"Foo\").Name", "1997");
         assertExprReturns(connection,
@@ -416,7 +416,7 @@ class ParameterTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testParameterDimensionWithOneHierarchy(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
       assertExprReturns(connection,
           "Parameter(\"Foo\",[Store],[Store].[USA],\"Foo\").Name", "USA");
       assertExprReturns(connection,
@@ -435,7 +435,7 @@ class ParameterTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testParameterHierarchy(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         assertExprReturns(connection,
             "Parameter(\"Foo\", [Time.Weekly], [Time.Weekly].[1997].[40],\"Foo\").Name",
             "40");
@@ -464,7 +464,7 @@ class ParameterTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testParameterLevel(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         assertExprReturns(connection,
             "Parameter(\"Foo\",[Time].[Quarter], [Time].[1997].[Q3], \"Foo\").Name",
             "Q3");
@@ -477,7 +477,7 @@ class ParameterTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testParameterMemberFails(Context context) {
         // type of a param can be dimension, hierarchy, level but not member
-        assertExprThrows(context.getConnection(),
+        assertExprThrows(context.getConnectionWithDefaultRole(),
             "Parameter(\"Foo\",[Time].[1997].[Q2],[Time].[1997],\"Foo\")",
             "Invalid type for parameter 'Foo'; expecting NUMERIC, STRING or a hierarchy");
     }
@@ -489,7 +489,7 @@ class ParameterTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testParameterMemberFailsBadLevel(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         assertExprThrows(connection,
             "Parameter(\"Foo\", [Customers].[State], [Customers].[USA].[CA], \"\")",
             "MDX object '[Customers].[State]' not found in cube 'Sales'");
@@ -507,7 +507,7 @@ class ParameterTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testParameterMemberDefaultValue(Context context) {
         // "[Time]" is shorthand for "[Time].CurrentMember"
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         assertExprReturns(connection,
             "Parameter(\"Foo\", [Time], [Time].[Time], \"Description\").UniqueName",
             "[Time].[1997]");
@@ -526,7 +526,7 @@ class ParameterTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testParameterMemberDefaultValue2(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         assertQueryReturns(connection,
             "select [Measures].[Unit Sales] on 0,\n"
             + " [Product].Children on 1\n"
@@ -560,7 +560,7 @@ class ParameterTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testParameterWithExpressionForHierarchyFails(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         assertExprThrows(connection,
             "Parameter(\"Foo\",[Gender].DefaultMember.Hierarchy,[Gender].[M],\"Foo\")",
             "Invalid parameter 'Foo'. Type must be a NUMERIC, STRING, or a dimension, hierarchy or level");
@@ -573,7 +573,7 @@ class ParameterTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDerivedParameter(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         assertExprReturns(connection,
             "Parameter(\"X\", NUMERIC, Parameter(\"Y\", NUMERIC, 1) + 2)",
             "3");
@@ -582,7 +582,7 @@ class ParameterTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testParameterInSlicer(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         assertQueryReturns(connection,
             "select {[Measures].[Unit Sales]} on rows,\n"
             + " {[Marital Status].children} on columns\n"
@@ -616,7 +616,7 @@ class ParameterTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     public void dontTestParamRef(Context context) {
-        String s = executeExpr(context.getConnection(),
+        String s = executeExpr(context.getConnectionWithDefaultRole(),
             "Parameter(\"X\",STRING,\"x\",\"A string\") || "
             + "ParamRef(\"Y\") || "
             + "\".\" ||"
@@ -628,13 +628,13 @@ class ParameterTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testParamRefWithoutParamFails(Context context) {
-        assertExprThrows(context.getConnection(), "ParamRef(\"Y\")", "Unknown parameter 'Y'");
+        assertExprThrows(context.getConnectionWithDefaultRole(), "ParamRef(\"Y\")", "Unknown parameter 'Y'");
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testParamDefinedTwiceFails(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         assertQueryThrows(connection,
             "select {[Measures].[Unit Sales]} on rows,\n"
             + " {Parameter(\"P\",[Gender],[Gender].[M],\"Which gender?\"),\n"
@@ -645,7 +645,7 @@ class ParameterTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testParamBadTypeFails(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         assertExprThrows(connection,
             "Parameter(\"P\", 5)",
             "No function matches signature 'Parameter(<String>, <Numeric Expression>)'");
@@ -654,7 +654,7 @@ class ParameterTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testParamCyclicOk(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         assertExprReturns(connection,
             "Parameter(\"P\", NUMERIC, ParamRef(\"Q\") + 1) + "
             + "Parameter(\"Q\", NUMERIC, Iif(1 = 0, ParamRef(\"P\"), 2))",
@@ -664,7 +664,7 @@ class ParameterTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testParamCyclicFails(Context context) {
-        assertExprThrows(context.getConnection(),
+        assertExprThrows(context.getConnectionWithDefaultRole(),
             "Parameter(\"P\", NUMERIC, ParamRef(\"Q\") + 1) + "
             + "Parameter(\"Q\", NUMERIC, Iif(1 = 1, ParamRef(\"P\"), 2))",
             "Cycle occurred while evaluating parameter 'P'");
@@ -673,7 +673,7 @@ class ParameterTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testParameterMetadata(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         Query query = connection.parseQuery(
             "with member [Measures].[A string] as \n"
             + "   Parameter(\"S\",STRING,\"x\" || \"y\",\"A string parameter\")\n"
@@ -705,7 +705,7 @@ class ParameterTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testTwoParametersBug1425153(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         Query query = connection.parseQuery(
             "select \n"
             + "{[Measures].[Unit Sales]} on columns, \n"
@@ -795,7 +795,7 @@ class ParameterTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testAssignNumericParameter(Context context) {
         final String para = "Parameter(\"x\", NUMERIC, 1)";
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         assertAssignParameter(connection, para, false, "8", null);
         assertAssignParameter(connection, para, false, "8.24", null);
         assertAssignParameter(connection, para, false, 8, null);
@@ -824,7 +824,7 @@ class ParameterTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testAssignStringParameter(Context context) {
         final String para = "Parameter(\"x\", STRING, 'xxx')";
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         assertAssignParameter(connection, para, false, "8", null);
         assertAssignParameter(connection, para, false, "8.24", null);
         assertAssignParameter(connection, para, false, 8, null);
@@ -847,7 +847,7 @@ class ParameterTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testAssignMemberParameter(Context context) {
         final String para = "Parameter(\"x\", [Customers], [Customers].[USA])";
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         assertAssignParameter(connection,
                 para, false, "8", "MDX object '8' not found in cube 'Sales'");
         assertAssignParameter(connection,
@@ -944,7 +944,7 @@ class ParameterTest {
     void testAssignSetParameter(Context context) {
         final String para =
             "Parameter(\"x\", [Customers], {[Customers].[USA], [Customers].[USA].[CA]})";
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         assertAssignParameter(connection,
             para, true, "8",
             "MDX object '8' not found in cube 'Sales'");
@@ -1134,7 +1134,7 @@ class ParameterTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testParamSet(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         try {
             String mdx =
                 "select [Measures].[Unit Sales] on 0,\n"
@@ -1188,7 +1188,7 @@ class ParameterTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testConnectionPropsWhichShouldBeNull(Context context) {
         // properties which must always return null
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         assertExprThrows(connection, "ParamRef(\"JdbcPassword\")", "Unknown parameter 'JdbcPassword'"); // was deleted
         assertExprThrows(connection, "ParamRef(\"CatalogContent\")", "Unknown parameter 'CatalogContent'");
     }
@@ -1205,7 +1205,7 @@ class ParameterTest {
         final List<SystemProperty> propertyList =
             SystemWideProperties.instance().getPropertyList();
         for (SystemProperty property : propertyList) {
-            assertExprReturns(context.getConnection(),
+            assertExprReturns(context.getConnectionWithDefaultRole(),
                 "ParamRef("
                 + Util.singleQuoteString(property.getPath())
                 + ")",
@@ -1219,7 +1219,7 @@ class ParameterTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testSystemPropsNotAvailable(Context context) {
-        assertExprThrows(context.getConnection(),
+        assertExprThrows(context.getConnectionWithDefaultRole(),
             "ParamRef(\"java.version\")",
             "Unknown parameter 'java.version'");
     }
@@ -1235,7 +1235,7 @@ class ParameterTest {
             SystemWideProperties.instance().getPropertyList();
         for (SystemProperty property : propertyList) {
             final String propName = property.getPath();
-            assertSetPropertyFails(context.getConnection(), propName, "System");
+            assertSetPropertyFails(context.getConnectionWithDefaultRole(), propName, "System");
         }
     }
 
@@ -1276,7 +1276,7 @@ class ParameterTest {
         withSchema(context, schema);
          */
         withSchema(context, TestSchemaPropModifier::new);
-        assertExprReturns(context.getConnection(), "ParamRef(\"prop\")", "foo bar");
+        assertExprReturns(context.getConnectionWithDefaultRole(), "ParamRef(\"prop\")", "foo bar");
     }
 
     /**
@@ -1408,7 +1408,7 @@ class ParameterTest {
         withSchema(context,schema);
          */
         withSchema(context, TestSchemaPropInvalidDefaultExpFailsModifier::new);
-        assertExprThrows(context.getConnection(),
+        assertExprThrows(context.getConnectionWithDefaultRole(),
             "ParamRef(\"Product Current Member\")",
             "No function matches signature '<Member>.Children(<Numeric Expression>)'");
     }
@@ -1450,7 +1450,7 @@ class ParameterTest {
         withSchema(context,schema);
          */
         withSchema(context, TestSchemaPropContextModifier::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with member [Measures].[Foo] as ' ParamRef(\"Customer Current Member\").Name '\n"
             + "select {[Measures].[Foo]} on columns\n"
             + "from [Sales]",
@@ -1460,7 +1460,7 @@ class ParameterTest {
             + "{[Measures].[Foo]}\n"
             + "Row #0: USA\n");
 
-        assertQueryThrows(context.getConnection(),
+        assertQueryThrows(context.getConnectionWithDefaultRole(),
             "with member [Measures].[Foo] as ' ParamRef(\"Customer Current Member\").Name '\n"
             + "select {[Measures].[Foo]} on columns\n"
             + "from [Warehouse]",

--- a/mondrian/src/test/java/mondrian/test/ParentChildHierarchyTest.java
+++ b/mondrian/src/test/java/mondrian/test/ParentChildHierarchyTest.java
@@ -243,7 +243,7 @@ class ParentChildHierarchyTest {
                 + "</Dimension>\n"));
         */
         withSchema(context, SchemaModifiers.ParentChildHierarchyTestModifier5::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH\n"
             + "SET [*NATIVE_CJ_SET] AS 'Head(FILTER([*BASE_MEMBERS__EmployeesNoClosure_], NOT ISEMPTY ([Measures].[Count])), 5)'\n"
             + "SET [*BASE_MEMBERS__EmployeesNoClosure_] AS '[EmployeesNoClosure].[Employee Id].MEMBERS'\n"
@@ -283,7 +283,7 @@ class ParentChildHierarchyTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testSnowflakeClosure(Context context) {
         getEmpSnowFlakeClosureTestContext(context);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Measures].[Count], [Measures].[Org Salary], \n"
             + "[Measures].[Number Of Employees], [Measures].[Avg Salary]} on columns,\n"
             + "{[EmployeeSnowFlake]} on rows\n"
@@ -307,7 +307,7 @@ class ParentChildHierarchyTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testSharedClosureParentChildHierarchy(Context context) {
         getEmpSharedClosureTestContext(context);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "Select "
             + "{[SharedEmployee].[All SharedEmployees].[Sheri Nowmer].[Derrick Whelply].children} on columns "
             // + [SharedEmployee].[Sheri Nowmer].children
@@ -331,13 +331,13 @@ class ParentChildHierarchyTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testNonClosureParentChildHierarchy(Context context) {
-        Result result = executeQuery(context.getConnection(),
+        Result result = executeQuery(context.getConnectionWithDefaultRole(),
             "Select {[Employees].members} on columns from HR");
         String expected = upgradeActual(
             TestUtil.toString(result))
           .replace("[Employees]", "[EmployeesNonClosure]");
         getEmpNonClosureTestContext(context);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "Select {[EmployeesNonClosure].members} on columns from HR",
           expected, 120000l);
     }
@@ -345,7 +345,7 @@ class ParentChildHierarchyTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testAll(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Measures].[Org Salary], [Measures].[Count]} on columns,\n"
             + " {[Employees]} on rows\n"
             + "from [HR]",
@@ -363,7 +363,7 @@ class ParentChildHierarchyTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testChildrenOfAll(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Measures].[Org Salary], [Measures].[Count]} on columns,\n"
             + " {[Employees].children} on rows\n"
             + "from [HR]",
@@ -385,7 +385,7 @@ class ParentChildHierarchyTest {
      */
     void testDistinctAll(Context context) {
         // parent/child dimension not expanded, and the query works
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Measures].[Count], [Measures].[Org Salary], \n"
             + "[Measures].[Number Of Employees], [Measures].[Avg Salary]} on columns,\n"
             + "{[Employees]} on rows\n"
@@ -411,7 +411,7 @@ class ParentChildHierarchyTest {
         // parent/child dimension expanded: fails with
         // java.lang.UnsupportedOperationException at
         // mondrian.rolap.RolapAggregator$6.aggregate(RolapAggregator.java:72)
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Measures].[Count], [Measures].[Org Salary], \n"
             + "[Measures].[Number Of Employees], [Measures].[Avg Salary]} on columns,\n"
             + "{[Employees].children} on rows\n"
@@ -436,7 +436,7 @@ class ParentChildHierarchyTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDistinctSubtree(Context context) {
         // also fails with UnsupportedOperationException
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Measures].[Count], [Measures].[Org Salary], \n"
             + "[Measures].[Number Of Employees], [Measures].[Avg Salary]} on columns,\n"
             + "{[Employees].[All Employees].[Sheri Nowmer].[Rebecca Kanagaki]} on rows\n"
@@ -465,7 +465,7 @@ class ParentChildHierarchyTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDistinctAllExplicitClosure(Context context) {
         getEmpClosureTestContext(context);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Measures].[Count], [Measures].[Org Salary], \n"
             + "[Measures].[Number Of Employees], [Measures].[Avg Salary]} on columns,\n"
             + "{[EmployeesClosure]} on rows\n"
@@ -491,7 +491,7 @@ class ParentChildHierarchyTest {
         // the children of the closed relation are all the descendants, so limit
         // results
         getEmpClosureTestContext(context);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Measures].[Count], [Measures].[Org Salary], \n"
             + "[Measures].[Number Of Employees], [Measures].[Avg Salary]} on columns,\n"
             + "{[EmployeesClosure].FirstChild} on rows\n"
@@ -515,7 +515,7 @@ class ParentChildHierarchyTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDistinctSubtreeExplicitClosure(Context context) {
         getEmpClosureTestContext(context);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Measures].[Count], [Measures].[Org Salary], \n"
             + "[Measures].[Number Of Employees], [Measures].[Avg Salary]} on columns,\n"
             + "{[EmployeesClosure].[All Employees].[7]} on rows\n"
@@ -539,7 +539,7 @@ class ParentChildHierarchyTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testLeaf(Context context) {
         // Juanita Sharp has no reports
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Measures].[Org Salary], [Measures].[Count]} on columns,\n"
             + " {[Employees].[All Employees].[Sheri Nowmer].[Rebecca Kanagaki].[Juanita Sharp]} on rows\n"
             + "from [HR]",
@@ -558,7 +558,7 @@ class ParentChildHierarchyTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testOneAboveLeaf(Context context) {
         // Rebecca Kanagaki has 2 direct reports, and they have no reports
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Measures].[Org Salary], [Measures].[Count]} on columns,\n"
             + " {[Employees].[All Employees].[Sheri Nowmer].[Rebecca Kanagaki]} on rows\n"
             + "from [HR]",
@@ -580,7 +580,7 @@ class ParentChildHierarchyTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testParentChildDescendantsLeavesBottom(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH SET [NonEmptyEmployees] AS 'FILTER(DESCENDANTS([Employees].[All Employees], 10, LEAVES),\n"
             + "  NOT ISEMPTY([Measures].[Employee Salary]))'\n"
             + "SELECT { [Measures].[Employee Salary], [Measures].[Number of Employees] } ON COLUMNS,\n"
@@ -631,10 +631,10 @@ class ParentChildHierarchyTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testParentChildDescendantsLeavesTop(Context context) {
-        if (Bug.avoidSlowTestOnLucidDB(getDialect(context.getConnection()))) {
+        if (Bug.avoidSlowTestOnLucidDB(getDialect(context.getConnectionWithDefaultRole()))) {
             return;
         }
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with set [Leaves] as 'Descendants([Employees].[All Employees], 15, LEAVES)'\n"
             + " set [Parents] as 'Generate([Leaves], {[Employees].CurrentMember.Parent})'\n"
             + " set [FirstParents] as 'Filter([Parents], \n"
@@ -711,7 +711,7 @@ class ParentChildHierarchyTest {
 
         // Query contains 'Head' just to keep the number of rows reasonable. We
         // assume that it does not affect the behavior of <Hierarchy>.Members.
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with member [Measures].[Parent] as '[Employees].CurrentMember.Parent.Name'\n"
             + "select {[Measures].[Parent]}\n"
             + "ON COLUMNS,\n"
@@ -721,7 +721,7 @@ class ParentChildHierarchyTest {
 
         // Similar query, using <Hierarchy>.AllMembers rather than
         // <Hierarchy>.Members, returns the same result.
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with member [Measures].[Parent] as '[Employees].CurrentMember.Parent.Name'\n"
             + "select {[Measures].[Parent]}\n"
             + "ON COLUMNS,\n"
@@ -730,7 +730,7 @@ class ParentChildHierarchyTest {
             expected);
 
         // Similar query use <Level>.Members, same result expected.
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with member [Measures].[Parent] as '[Employees].CurrentMember.Parent.Name'\n"
             + "select {[Measures].[Parent]}\n"
             + "ON COLUMNS,\n"
@@ -750,11 +750,11 @@ class ParentChildHierarchyTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testHierarchyFalseCycle(Context context) {
-        if (Bug.avoidSlowTestOnLucidDB(getDialect(context.getConnection()))) {
+        if (Bug.avoidSlowTestOnLucidDB(getDialect(context.getConnectionWithDefaultRole()))) {
             return;
         }
         // On the regular HR cube, this has always worked.
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "SELECT {[Employees].[All Employees].Children} on columns,\n"
             + " {[Measures].[Org Salary]} on rows\n"
             + "FROM [HR]",
@@ -804,7 +804,7 @@ class ParentChildHierarchyTest {
         // On a cube with fewer dimensions, this gave a false failure.
         withSchema(context, SchemaModifiers.ParentChildHierarchyTestModifier6::new);
 
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "SELECT {[Employees].[All Employees].Children} on columns,\n"
             + " {[Measures].[Org Salary]} on rows\n"
             + "FROM [HR-fewer-dims]",
@@ -820,7 +820,7 @@ class ParentChildHierarchyTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testGenuineCycle(Context context) {
-        Result result = executeQuery(context.getConnection(),
+        Result result = executeQuery(context.getConnectionWithDefaultRole(),
             "with member [Measures].[Foo] as \n"
             + "  '([Measures].[Foo], OpeningPeriod([Time].[Month]))'\n"
             + "select\n"
@@ -889,7 +889,7 @@ class ParentChildHierarchyTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testParentChildDrillThrough(Context context) {
-        Result result = executeQuery(context.getConnection(),
+        Result result = executeQuery(context.getConnectionWithDefaultRole(),
             "select {[Measures].Members} ON columns,\n"
             + "  {[Employees].Members} ON rows\n"
             + "from [HR]");
@@ -898,7 +898,7 @@ class ParentChildHierarchyTest {
         // Note that the SQL does not contain the employees or employee_closure
         // tables.
         final boolean extendedContext = false;
-        checkDrillThroughSql(context.getConnection(),
+        checkDrillThroughSql(context.getConnectionWithDefaultRole(),
             result,
             0,
             extendedContext,
@@ -911,7 +911,7 @@ class ParentChildHierarchyTest {
             + " `time_by_day` =as= `time_by_day` "
             + "where `salary`.`pay_date` = `time_by_day`.`the_date`"
             + " and `time_by_day`.`the_year` = 1997 "
-            + (getDialect(context.getConnection()).requiresOrderByAlias()
+            + (getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
                 ? "order by `Year` ASC"
                 : "order by `time_by_day`.`the_year` ASC"),
             7392);
@@ -920,7 +920,7 @@ class ParentChildHierarchyTest {
         // Note that the SQL does not contain the employee_closure table.
         // That's because when we drill through, we don't want to roll up
         // measures along the hierarchy.
-        checkDrillThroughSql(context.getConnection(),
+        checkDrillThroughSql(context.getConnectionWithDefaultRole(),
             result,
             1,
             extendedContext,
@@ -936,14 +936,14 @@ class ParentChildHierarchyTest {
             + " and `time_by_day`.`the_year` = 1997"
             + " and `salary`.`employee_id` = `employee`.`employee_id`"
             + " and `employee`.`employee_id` = 1 "
-            + (getDialect(context.getConnection()).requiresOrderByAlias()
+            + (getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
                 ? "order by `Year` ASC, `Employee Id (Key) ASC"
                 : "order by `time_by_day`.`the_year` ASC, `employee`.`employee_id` ASC"),
             12);
 
         // Drill-through for row #2, [Employees].[All].[Sheri Nowmer].
         // Note that the SQL does not contain the employee_closure table.
-        checkDrillThroughSql(context.getConnection(),
+        checkDrillThroughSql(context.getConnectionWithDefaultRole(),
             result,
             2,
             extendedContext,
@@ -959,7 +959,7 @@ class ParentChildHierarchyTest {
             + " and `time_by_day`.`the_year` = 1997"
             + " and `salary`.`employee_id` = `employee`.`employee_id`"
             + " and `employee`.`employee_id` = 2 "
-                + (getDialect(context.getConnection()).requiresOrderByAlias()
+                + (getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
                 ? "order by `Year` ASC, `Employee Id (Key) ASC"
                 : "order by `time_by_day`.`the_year` ASC, `employee`.`employee_id` ASC"),
             12);
@@ -968,14 +968,14 @@ class ParentChildHierarchyTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testParentChildDrillThroughWithContext(Context context) {
-        Result result = executeQuery(context.getConnection(),
+        Result result = executeQuery(context.getConnectionWithDefaultRole(),
             "select {[Measures].Members} ON columns,\n"
             + "  {[Employees].Members} ON rows\n"
             + "from [HR]");
 
         // Now with full context.
         final boolean extendedContext = true;
-        checkDrillThroughSql(context.getConnection(),
+        checkDrillThroughSql(context.getConnectionWithDefaultRole(),
             result,
             2,
             extendedContext,
@@ -1014,7 +1014,7 @@ class ParentChildHierarchyTest {
             + " and `salary`.`department_id` = `department`.`department_id`"
             + " and `employee`.`employee_id` = 2 "
             + "order by"
-            + (getDialect(context.getConnection()).requiresOrderByAlias()
+            + (getDialect(context.getConnectionWithDefaultRole()).requiresOrderByAlias()
                 ? " `Year` ASC,"
                 + " `Quarter` ASC,"
                 + " `Month` ASC,"
@@ -1076,7 +1076,7 @@ class ParentChildHierarchyTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testBugMondrian168(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select \n"
             + "     {[Employee Salary]} on columns, \n"
             + "     {[Employees]} on rows \n"
@@ -1089,7 +1089,7 @@ class ParentChildHierarchyTest {
             + "{[Employees].[All Employees]}\n"
             + "Row #0: \n");
 
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select \n"
             + "     {[Position]} on columns,\n"
             + "     {[Employee Salary]} on rows\n"
@@ -1113,7 +1113,7 @@ class ParentChildHierarchyTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testParentChildOrdinal(Context context) {
-        if (Bug.avoidSlowTestOnLucidDB(getDialect(context.getConnection()))) {
+        if (Bug.avoidSlowTestOnLucidDB(getDialect(context.getConnectionWithDefaultRole()))) {
             return;
         }
         /*
@@ -1153,7 +1153,7 @@ class ParentChildHierarchyTest {
         withSchema(context, SchemaModifiers.ParentChildHierarchyTestModifier7::new);
 
         // Make sure <Member>.CHILDREN is sorted.
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Employees].[All Employees].[Sheri Nowmer].[Rebecca Kanagaki].Children} on columns from [HR-ordered]",
 
             "Axis #0:\n"
@@ -1165,7 +1165,7 @@ class ParentChildHierarchyTest {
             + "Row #0: $152.76\n");
 
         // Make sure <Member>.DESCENDANTS is sorted.
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {HEAD(DESCENDANTS([Employees].[Sheri Nowmer], [Employees].[Employee Id], LEAVES), 6)} on columns from [HR-ordered]",
             "Axis #0:\n"
             + "{}\n"
@@ -1188,7 +1188,7 @@ class ParentChildHierarchyTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testLevelMembers(Context context) {
         //use  "HR" cube name
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         // <Dimension>.MEMBERS
         assertExprReturns(connection, "HR","[Employees].Members.Count", "1,156");
         // <Level>.MEMBERS
@@ -1201,7 +1201,7 @@ class ParentChildHierarchyTest {
         // Make sure that members of the [Employee] hierarachy don't
         // as calculated (even though they are calculated, internally)
         // but that real calculated members are counted as calculated.
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with member [Employees].[Foo] as ' Sum([Employees].[All Employees].[Sheri Nowmer].[Donna Arnold].Children) '\n"
             + "member [Measures].[Count1] AS [Employees].MEMBERS.Count\n"
             + "member [Measures].[Count2] AS [Employees].ALLMEMBERS.COUNT\n"
@@ -1265,7 +1265,7 @@ class ParentChildHierarchyTest {
         withSchema(context, schema);
         */
         withSchema(context, SchemaModifiers.ParentChildHierarchyTestModifier8::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select "
             + "[Employees].[All Employees].[Sheri Nowmer].[Rebecca Kanagaki].Children"
             + " ON COLUMNS, "
@@ -1289,7 +1289,7 @@ class ParentChildHierarchyTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testClosureVsNoClosure(Context context) {
-        if (Bug.avoidSlowTestOnLucidDB(getDialect(context.getConnection()))) {
+        if (Bug.avoidSlowTestOnLucidDB(getDialect(context.getConnectionWithDefaultRole()))) {
             return;
         }
         /*
@@ -1331,7 +1331,7 @@ class ParentChildHierarchyTest {
                         + " NON EMPTY {[Employees].AllMembers} ON ROWS\n"
                         + "from [HR4C]";
         expected =
-                TestUtil.toString(executeQuery(context.getConnection(), mdx));
+                TestUtil.toString(executeQuery(context.getConnectionWithDefaultRole(), mdx));
         assertTrue(unfold(expected).contains("Row #0: 21,252\n"), expected);
 
         // 2. Run a small query with known results on both contexts.
@@ -1365,7 +1365,7 @@ class ParentChildHierarchyTest {
                         + "Row #6: 60\n"
                         + "Row #7: 168\n"
                         + "Row #8: 60\n";
-        assertQueryReturns(context.getConnection(), mdx, expected);
+        assertQueryReturns(context.getConnectionWithDefaultRole(), mdx, expected);
         /*
         schema = SchemaUtil.getSchema(baseSchema,
                 null, cubestart + cubeend, null, null, null, null);
@@ -1375,10 +1375,10 @@ class ParentChildHierarchyTest {
 
         // Need to unfold because 'expect' has platform-specific line-endings,
         // yet assertQueryReturns assumes that it contains linefeeds.
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
                 mdx, unfold(expected));
 
-        assertQueryReturns(context.getConnection(), mdx, expected);
+        assertQueryReturns(context.getConnectionWithDefaultRole(), mdx, expected);
     }
 
     @ParameterizedTest
@@ -1386,7 +1386,7 @@ class ParentChildHierarchyTest {
     void testSchemaReaderLevelMembers(Context context)
     {
         final SchemaReader schemaReader =
-                context.getConnection()
+                context.getConnectionWithDefaultRole()
             .getSchemaReader().withLocus();
         int found = 0;
         for (Cube cube : schemaReader.getCubes()) {
@@ -1491,7 +1491,7 @@ class ParentChildHierarchyTest {
             + "</Schema>");
         */
         withSchema(context, SchemaModifiers.ParentChildHierarchyTestModifier11::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select\n"
             + " NON EMPTY {[Measures].[Store Sales]} ON COLUMNS,\n"
             + " {[Employee].[Sheri Nowmer]} on ROWS\n"
@@ -1544,7 +1544,7 @@ class ParentChildHierarchyTest {
             + "[*BASE_MEMBERS_Measures] on columns,\n"
             + "[*SORTED_ROW_AXIS] on rows\n"
             + "From [HR]\n";
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             mdx,
             "Axis #0:\n"
             + "{}\n"
@@ -1592,7 +1592,7 @@ class ParentChildHierarchyTest {
             + "Row #18: 444\n"
             + "Row #19: 432\n");
         assertNotNull(
-            executeQuery(context.getConnection(), mdx)
+            executeQuery(context.getConnectionWithDefaultRole(), mdx)
                 .getAxes()[1].getPositions().get(2).iterator().next()
                     .getParentMember());
     }

--- a/mondrian/src/test/java/mondrian/test/PerformanceTest.java
+++ b/mondrian/src/test/java/mondrian/test/PerformanceTest.java
@@ -86,7 +86,7 @@ public class PerformanceTest {
     final Statistician statistician =
       new Statistician( "testBugMondrian550" );
     for ( int i = 0; i < 10; i++ ) {
-      checkBugMondrian550(context.getConnection(), statistician );
+      checkBugMondrian550(context.getConnectionWithDefaultRole(), statistician );
     }
     statistician.printDurations();
   }
@@ -125,7 +125,7 @@ public class PerformanceTest {
     final Statistician statistician =
       new Statistician( "testBugMondrian550Tuple" );
     int n = LOGGER.isDebugEnabled() ? 10 : 2;
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     for ( int i = 0; i < n; i++ ) {
       checkBugMondrian550Tuple(connection, statistician );
     }
@@ -198,7 +198,7 @@ public class PerformanceTest {
     }
     long start = System.currentTimeMillis();
     Result result =
-      executeQuery(context.getConnection(),
+      executeQuery(context.getConnectionWithDefaultRole(),
         "select  non empty  {  crossjoin( customers.[city].members, "
           + "crossjoin( [store type].[store type].members,  "
           + "product.[product name].members)) }"
@@ -266,7 +266,7 @@ public class PerformanceTest {
       new Statistician( "testVeryLargeExplicitSet: Param query" ),
     };
     for ( int i = 0; i < 10; i++ ) {
-      checkVeryLargeExplicitSet(context.getConnection(), statisticians);
+      checkVeryLargeExplicitSet(context.getConnectionWithDefaultRole(), statisticians);
     }
     for ( Statistician statistician : statisticians ) {
       statistician.printDurations();
@@ -359,7 +359,7 @@ public class PerformanceTest {
     final Statistician statistician =
       new Statistician( "testBugMondrian639" );
     for ( int i = 0; i < 20; i++ ) {
-      checkBugMondrian639(context.getConnection(), statistician);
+      checkBugMondrian639(context.getConnectionWithDefaultRole(), statistician);
     }
     statistician.printDurations();
   }
@@ -422,7 +422,7 @@ public class PerformanceTest {
         + "Crossjoin([Customers].[name].members,[Store].[Store Name].members)"
         + " on 1 from sales";
     long start = System.currentTimeMillis();
-    executeQuery(context.getConnection(), mdx);
+    executeQuery(context.getConnectionWithDefaultRole(), mdx);
 
     // jdk1.6 marmalade 3.2 14036  23,588 23,426 ms
     // jdk1.6 marmalade main 14036 26,430 27,045 25,497 ms
@@ -526,7 +526,7 @@ public class PerformanceTest {
         + "from [Sales]\n"
         + "where [Time].[1997].[Q3]";
     final long start = System.currentTimeMillis();
-    assertQueryReturns(context.getConnection(), mdx, result );
+    assertQueryReturns(context.getConnectionWithDefaultRole(), mdx, result );
     printDuration( "in-memory calc", start );
   }
 
@@ -548,7 +548,7 @@ public class PerformanceTest {
     // jdk1.7 marmite   main 14771    266 ms (as part of suite)
     // jdk1.7 marmite   main 14773    181 ms
     long start = System.currentTimeMillis();
-    executeQuery(context.getConnection(),
+    executeQuery(context.getConnectionWithDefaultRole(),
       "WITH SET [filtered] AS "
         + "FILTER({customers.members, customers.members, customers.members, customers.members, customers.members}, "
         + "[Measures].[Unit Sales] > 100) "
@@ -611,7 +611,7 @@ public class PerformanceTest {
     SystemWideProperties.instance().SsasCompatibleNaming = false;
     withSchema(context, SchemaModifiers.PerformanceTestModifier4::new);
     // original test case for MONDRIAN-1242; ensures correct result
-    Connection connection = context.getConnection();
+    Connection connection = context.getConnectionWithDefaultRole();
     assertQueryReturns(connection,
       "select {[Measures].[Unit Sales]} on COLUMNS,\n"
         + "[Store].[USA].[CA].Children on ROWS\n"

--- a/mondrian/src/test/java/mondrian/test/PropertiesTest.java
+++ b/mondrian/src/test/java/mondrian/test/PropertiesTest.java
@@ -53,7 +53,7 @@ class PropertiesTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testMandatoryMemberProperties(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         Cube salesCube = connection.getSchema().lookupCube("Sales", true);
         SchemaReader scr = salesCube.getSchemaReader(null).withLocus();
         Member member =
@@ -194,7 +194,7 @@ class PropertiesTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testGetChildCardinalityPropertyValue(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         Cube salesCube = connection.getSchema().lookupCube("Sales", true);
         SchemaReader scr = salesCube.getSchemaReader(null);
         Member memberForCardinalityTest =
@@ -214,7 +214,7 @@ class PropertiesTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testPropertiesMDX(Context context) {
-        Result result = executeQuery(context.getConnection(),
+        Result result = executeQuery(context.getConnectionWithDefaultRole(),
             "SELECT {[Customers].[All Customers].[USA].[CA]} DIMENSION PROPERTIES \n"
             + " CATALOG_NAME, SCHEMA_NAME, CUBE_NAME, DIMENSION_UNIQUE_NAME, \n"
             + " HIERARCHY_UNIQUE_NAME, LEVEL_UNIQUE_NAME, LEVEL_NUMBER, MEMBER_UNIQUE_NAME, \n"
@@ -257,7 +257,7 @@ class PropertiesTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testMemberProperties(Context context) {
-        Result result = executeQuery(context.getConnection(),
+        Result result = executeQuery(context.getConnectionWithDefaultRole(),
             "SELECT {[Store].Children} DIMENSION PROPERTIES\n"
             + " CATALOG_NAME, PARENT_UNIQUE_NAME, [Store Type], FORMAT_EXP\n"
             + " ON COLUMNS\n"
@@ -274,7 +274,7 @@ class PropertiesTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testMemberPropertiesBad(Context context) {
-        Result result = executeQuery(context.getConnection(),
+        Result result = executeQuery(context.getConnectionWithDefaultRole(),
             "SELECT {[Store].Children} DIMENSION PROPERTIES\n"
             + " CATALOG_NAME, PARENT_UNIQUE_NAME, [Store Type], BAD\n"
             + " ON COLUMNS\n"
@@ -288,7 +288,7 @@ class PropertiesTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testMandatoryCellProperties(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         Query salesCube = connection.parseQuery(
             "select \n"
             + " {[Measures].[Store Sales], [Measures].[Unit Sales]} on columns, \n"
@@ -344,7 +344,7 @@ class PropertiesTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testPropertyDescription(Context context) throws Exception {
         withSchema(context, SchemaModifiers.PropertiesTestModifier::new);
-        Cube[] cubes = context.getConnection().getSchema()
+        Cube[] cubes = context.getConnectionWithDefaultRole().getSchema()
             .getCubes();
         Optional<Cube> optionalCube = Arrays.stream(cubes).filter(c -> c.getName().equals("Foo")).findFirst();
         Cube cube = optionalCube.orElseThrow(() -> new RuntimeException("Cube with name Foo absent"));

--- a/mondrian/src/test/java/mondrian/test/RaggedHierarchyTest.java
+++ b/mondrian/src/test/java/mondrian/test/RaggedHierarchyTest.java
@@ -60,7 +60,7 @@ class RaggedHierarchyTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testChildrenOfRoot(Context context) {
-        assertRaggedReturns(context.getConnection(),
+        assertRaggedReturns(context.getConnectionWithDefaultRole(),
             "[Store].children",
             "[Store].[Canada]\n"
             + "[Store].[Israel]\n"
@@ -72,7 +72,7 @@ class RaggedHierarchyTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testChildrenOfUSA(Context context) {
-        assertRaggedReturns(context.getConnection(),
+        assertRaggedReturns(context.getConnectionWithDefaultRole(),
             "[Store].[USA].children",
             "[Store].[USA].[CA]\n"
             + "[Store].[USA].[OR]\n"
@@ -85,7 +85,7 @@ class RaggedHierarchyTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testChildrenOfIsrael(Context context) {
-        assertRaggedReturns(context.getConnection(),
+        assertRaggedReturns(context.getConnectionWithDefaultRole(),
             "[Store].[Israel].children",
             "[Store].[Israel].[Israel].[Haifa]\n"
             + "[Store].[Israel].[Israel].[Tel Aviv]");
@@ -98,7 +98,7 @@ class RaggedHierarchyTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     public void dont_testChildrenOfVatican(Context context) {
 	    SystemWideProperties.instance().NullMemberRepresentation = "null";
-        assertRaggedReturns(context.getConnection(),
+        assertRaggedReturns(context.getConnectionWithDefaultRole(),
             "[Store].[Vatican].children",
             "[Store].[Vatican].[Vatican].[null].[Store 17]");
     }
@@ -106,14 +106,14 @@ class RaggedHierarchyTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testParentOfHaifa(Context context) {
-        assertRaggedReturns(context.getConnection(),
+        assertRaggedReturns(context.getConnectionWithDefaultRole(),
             "[Store].[Israel].[Haifa].Parent", "[Store].[Israel]");
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testParentOfVatican(Context context) {
-        assertRaggedReturns(context.getConnection(),
+        assertRaggedReturns(context.getConnectionWithDefaultRole(),
             "[Store].[Vatican].Parent", "[Store].[All Stores]");
     }
 
@@ -121,7 +121,7 @@ class RaggedHierarchyTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testPrevMemberOfHaifa(Context context) {
-        assertRaggedReturns(context.getConnection(),
+        assertRaggedReturns(context.getConnectionWithDefaultRole(),
             "[Store].[Israel].[Haifa].PrevMember",
             "[Store].[Canada].[BC].[Victoria]");
     }
@@ -130,7 +130,7 @@ class RaggedHierarchyTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testNextMemberOfTelAviv(Context context) {
-        assertRaggedReturns(context.getConnection(),
+        assertRaggedReturns(context.getConnectionWithDefaultRole(),
             "[Store].[Israel].[Tel Aviv].NextMember",
             "[Store].[Mexico].[DF].[Mexico City]");
     }
@@ -139,7 +139,7 @@ class RaggedHierarchyTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testNextMemberOfBC(Context context) {
         // The next state after BC is Israel, but it's hidden
-        assertRaggedReturns(context.getConnection(),
+        assertRaggedReturns(context.getConnectionWithDefaultRole(),
             "[Store].[Canada].[BC].NextMember",
             "[Store].[Mexico].[DF]");
     }
@@ -147,7 +147,7 @@ class RaggedHierarchyTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testLead(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         assertRaggedReturns(connection,
             "[Store].[Mexico].[DF].Lead(1)",
             "[Store].[Mexico].[Guerrero]");
@@ -173,7 +173,7 @@ class RaggedHierarchyTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     public void dont_testDescendantsOfVatican(Context context) {
-        assertRaggedReturns(context.getConnection(),
+        assertRaggedReturns(context.getConnectionWithDefaultRole(),
             "Descendants([Store].[Vatican])",
             "[Store].[Vatican]\n"
             + "[Store].[Vatican].[Vatican].[null].[Store 17]");
@@ -183,7 +183,7 @@ class RaggedHierarchyTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDescendantsOfVaticanAtStateLevel(Context context) {
-        assertRaggedReturns(context.getConnection(),
+        assertRaggedReturns(context.getConnectionWithDefaultRole(),
             "Descendants([Store].[Vatican], [Store].[Store State])",
             "");
     }
@@ -191,7 +191,7 @@ class RaggedHierarchyTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDescendantsOfRootAtCity(Context context) {
-        assertRaggedReturns(context.getConnection(),
+        assertRaggedReturns(context.getConnectionWithDefaultRole(),
             "Descendants([Store], [Store City])",
             "[Store].[Canada].[BC].[Vancouver]\n"
             + "[Store].[Canada].[BC].[Victoria]\n"
@@ -222,7 +222,7 @@ class RaggedHierarchyTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testAncestorOfHaifa(Context context) {
-        assertRaggedReturns(context.getConnection(),
+        assertRaggedReturns(context.getConnectionWithDefaultRole(),
             "Ancestor([Store].[Israel].[Haifa], [Store].[Store State])",
             "");
     }
@@ -233,7 +233,7 @@ class RaggedHierarchyTest {
         // Haifa and Tel Aviv should appear directly after Israel
         // Vatican should have no children
         // Washington should appear after WA
-        assertRaggedReturns(context.getConnection(),
+        assertRaggedReturns(context.getConnectionWithDefaultRole(),
             "Hierarchize(Descendants([Store], [Store].[Store City], SELF_AND_BEFORE))",
             "[Store].[All Stores]\n"
             + "[Store].[Canada]\n"
@@ -288,7 +288,7 @@ class RaggedHierarchyTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     public void dont_testMeasuresVatican(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "SELECT {[Measures].[Unit Sales]} ON COLUMNS,\n"
             + " {Descendants([Store].[Vatican])} ON ROWS\n"
             + "FROM [Sales Ragged]",
@@ -311,7 +311,7 @@ class RaggedHierarchyTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     public void dont_testMeasures(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "SELECT {[Measures].[Unit Sales]} ON COLUMNS,\n"
             + " NON EMPTY {Descendants([Store])} ON ROWS\n"
             + "FROM [Sales Ragged]",
@@ -397,7 +397,7 @@ class RaggedHierarchyTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testNullMember(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "With \n"
             + " Set [*NATIVE_CJ_SET] as '[*BASE_MEMBERS_Geography]' \n"
             + " Set [*SORTED_ROW_AXIS] as 'Order([*CJ_ROW_AXIS],Ancestor([Geography].CurrentMember, [Geography].[Country]).OrderKey,BASC,Ancestor([Geography].CurrentMember, [Geography].[State]).OrderKey,BASC,[Geography].CurrentMember.OrderKey,BASC)' \n"
@@ -467,7 +467,7 @@ class RaggedHierarchyTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testHideIfBlankHidesWhitespace(Context context) {
-        if (getDatabaseProduct(getDialect(context.getConnection()).getDialectName())
+        if (getDatabaseProduct(getDialect(context.getConnectionWithDefaultRole()).getDialectName())
             != DatabaseProduct.ORACLE)
         {
             return;
@@ -493,7 +493,7 @@ class RaggedHierarchyTest {
          */
         withSchema(context, SchemaModifiers.RaggedHierarchyTestModifier1::new);
 
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             " select {[Gender4].[Gender].members} "
             + "on COLUMNS "
             + "from sales",
@@ -523,7 +523,7 @@ class RaggedHierarchyTest {
             + "  </Dimension>"));
          */
         withSchema(context, SchemaModifiers.RaggedHierarchyTestModifier2::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "SELECT\n"
             + "[Measures].[Unit Sales] ON COLUMNS\n"
             + ",FILTER([Store].[Store City].MEMBERS, NOT ISEMPTY ([Measures].[Unit Sales])) ON ROWS\n"
@@ -579,7 +579,7 @@ class RaggedHierarchyTest {
          */
         withSchema(context,  SchemaModifiers.RaggedHierarchyTestModifier2::new);
 
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "SELECT\n"
             + "[Measures].[Unit Sales] ON COLUMNS\n"
             + ",non empty Crossjoin([Gender].[Gender].members, [Store].[Store City].MEMBERS) ON ROWS\n"

--- a/mondrian/src/test/java/mondrian/test/ScenarioTest.java
+++ b/mondrian/src/test/java/mondrian/test/ScenarioTest.java
@@ -54,7 +54,7 @@ class ScenarioTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCreateScenario(Context context) throws SQLException {
         final Connection connection =
-            context.getConnection();
+            context.getConnectionWithDefaultRole();
         try {
             assertNull(connection.getScenario());
             final Scenario scenario = connection.createScenario();
@@ -78,7 +78,7 @@ class ScenarioTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testSetCell(Context context) throws SQLException {
         final Connection connection =
-            context.getConnection();
+            context.getConnectionWithDefaultRole();
         try {
             assertNull(connection.getScenario());
             final Scenario scenario = connection.createScenario();
@@ -100,7 +100,7 @@ class ScenarioTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testSetCellWithoutScenarioFails(Context context) throws SQLException {
         final Connection connection =
-            context.getConnection();
+            context.getConnectionWithDefaultRole();
         try {
             assertNull(connection.getScenario());
             final Statement pstmt = connection.createStatement();
@@ -127,7 +127,7 @@ class ScenarioTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testSetCellCalcError(Context context) throws SQLException {
-        final Connection connection = context.getConnection();
+        final Connection connection = context.getConnectionWithDefaultRole();
         connection.setScenario(connection.createScenario());
         Statement pstmt = connection.createStatement();
         CellSet cellSet = pstmt.executeQuery(
@@ -177,7 +177,7 @@ class ScenarioTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testUnsupportedAllocationPolicyFails(Context context) throws SQLException {
-        final Connection connection = context.getConnection();
+        final Connection connection = context.getConnectionWithDefaultRole();
         connection.setScenario(connection.createScenario());
         final Statement pstmt = connection.createStatement();
         final CellSet cellSet = pstmt.executeQuery(
@@ -254,7 +254,7 @@ class ScenarioTest {
         */
         withSchema(context,  SchemaModifiers.ScenarioTestModifier1::new);
 
-        final Connection connection = context.getConnection();
+        final Connection connection = context.getConnectionWithDefaultRole();
         connection.setScenario(connection.createScenario());
         final Scenario scenario = connection.getScenario();
         String id = scenario.getId();
@@ -272,7 +272,7 @@ class ScenarioTest {
         final Cell cell = cellSet.getCell(Arrays.asList(0, 0));
         cell.setValue(connection.getScenario(),23597, allocationPolicy);
 
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Measures].[Unit Sales]} on 0,\n"
             + "{[Product].[Drink]} on 1\n"
             + "from [Sales]"
@@ -285,7 +285,7 @@ class ScenarioTest {
             + "{[Product].[Drink]}\n"
             + "Row #0: 23,597\n");
 
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Measures].[Unit Sales]} on 0,\n"
             + "{[Product].Children,\n"
             + " [Product].[Drink].Children,\n"
@@ -441,7 +441,7 @@ class ScenarioTest {
          */
         withSchema(context,  SchemaModifiers.ScenarioTestModifier1::new);
 
-        final Connection connection = context.getConnection();
+        final Connection connection = context.getConnectionWithDefaultRole();
         connection.setScenario(connection.createScenario());
         final Scenario scenario = connection.createScenario();
         connection.setScenario(scenario);
@@ -514,7 +514,7 @@ class ScenarioTest {
         // looking up the $scenario property for a non ScenarioCalc member
         // causes class cast exception
         // http://jira.pentaho.com/browse/MONDRIAN-1496
-        Result result = executeQuery(context.getConnection(),
+        Result result = executeQuery(context.getConnectionWithDefaultRole(),
             "select {[Gender].[Gender].members} on columns from Sales");
 
         // non calc member, should return null
@@ -522,7 +522,7 @@ class ScenarioTest {
             .getPropertyValue("$scenario");
         assertEquals(null, o);
 
-        result = executeQuery(context.getConnection(),
+        result = executeQuery(context.getConnectionWithDefaultRole(),
             "with member gender.cal as '1' "
             + "select {[Gender].cal} on 0 from Sales");
         // calc member, should return null

--- a/mondrian/src/test/java/mondrian/test/SchemaTest.java
+++ b/mondrian/src/test/java/mondrian/test/SchemaTest.java
@@ -272,7 +272,7 @@ class SchemaTest {
 
         }
         withSchema(context, TestSolveOrderInCalculatedMemberModifier::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Measures].[QuantumProfit]} on 0, {(Gender.foo)} on 1 from sales",
             "Axis #0:\n"
             + "{}\n"
@@ -337,7 +337,7 @@ class SchemaTest {
             + "  </Dimension>"));
         */
         withSchema(context, TestHierarchyDefaultMemberModifier::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Gender with default]} on columns from [Sales]",
             "Axis #0:\n"
             + "{}\n"
@@ -434,7 +434,7 @@ class SchemaTest {
         */
         // note that default member name has no 'all' and has a name not an id
         withSchema(context, TestDefaultMemberNameModifier::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Product with no all]} on columns from [Sales]",
             "Axis #0:\n"
             + "{}\n"
@@ -497,7 +497,7 @@ class SchemaTest {
             + "  </Dimension>"));
         */
         withSchema(context, TestHierarchyAbbreviatedDefaultMemberModifier::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Gender with default]} on columns from [Sales]",
             "Axis #0:\n"
             + "{}\n"
@@ -655,7 +655,7 @@ class SchemaTest {
             "<Measure name=\"Fact Count\" aggregator=\"count\"/>\n"));
         */
         withSchema(context, TestCountMeasureModifier::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Measures].[Fact Count], [Measures].[Unit Sales]} on 0,\n"
             + "[Gender].members on 1\n"
             + "from [Sales]",
@@ -737,7 +737,7 @@ class SchemaTest {
         */
         // FIXME: This should validate the schema, and fail.
         withSchema(context, TestHierarchyTableNotFoundModifier::new);
-        assertSimpleQuery(context.getConnection());
+        assertSimpleQuery(context.getConnectionWithDefaultRole());
         // FIXME: Should give better error.
         assertQueryThrows(context,
             "select [Yearly Income3].Children on 0 from [Sales]",
@@ -985,7 +985,7 @@ class SchemaTest {
             + "</Dimension>"));
         */
         withSchema(context, TestDuplicateTableAliasModifier::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Yearly Income2]} on columns, {[Measures].[Unit Sales]} on rows from [Sales]",
             "Axis #0:\n"
             + "{}\n"
@@ -1051,7 +1051,7 @@ class SchemaTest {
             + "  </Hierarchy>\n"
             + "</Dimension>")); */
         withSchema(context, TestDuplicateTableAliasSameForeignKeyModifier::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select from [Sales]",
             "Axis #0:\n"
             + "{}\n"
@@ -1059,7 +1059,7 @@ class SchemaTest {
 
         // NonEmptyCrossJoin Fails
         if (false) {
-            assertQueryReturns(context.getConnection(),
+            assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "select NonEmptyCrossJoin({[Yearly Income2].[All Yearly Income2s]},{[Customers].[All Customers]}) on rows,"
                 + "NON EMPTY {[Measures].[Unit Sales]} on columns"
                 + " from [Sales]",
@@ -1125,7 +1125,7 @@ class SchemaTest {
         */
 
         withSchema(context, TestDimensionsShareTableModifier::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Yearly Income].[$10K - $30K]} on columns,"
             + "{[Yearly Income2].[$150K +]} on rows from [Sales]",
             "Axis #0:\n"
@@ -1136,7 +1136,7 @@ class SchemaTest {
             + "{[Yearly Income2].[$150K +]}\n"
             + "Row #0: 918\n");
 
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select NON EMPTY {[Measures].[Unit Sales]} ON COLUMNS,\n"
             + "NON EMPTY Crossjoin({[Yearly Income].[All Yearly Incomes].Children},\n"
             + "                     [Yearly Income2].[All Yearly Income2s].Children) ON ROWS\n"
@@ -1331,7 +1331,7 @@ class SchemaTest {
             + "</Dimension>"));
         */
         withSchema(context, TestDimensionsShareTableNativeNonEmptyCrossJoinModifier::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select NonEmptyCrossJoin({[Yearly Income2].[All Yearly Income2s]},{[Customers].[All Customers]}) on rows,"
             + "NON EMPTY {[Measures].[Unit Sales]} on columns"
             + " from [Sales]",
@@ -1399,7 +1399,7 @@ class SchemaTest {
             + "</Dimension>"));
         */
         withSchema(context, TestDimensionsShareTableSameForeignKeysModifier::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Yearly Income].[$10K - $30K]} on columns,"
             + "{[Yearly Income2].[$150K +]} on rows from [Sales]",
             "Axis #0:\n"
@@ -1410,7 +1410,7 @@ class SchemaTest {
             + "{[Yearly Income2].[$150K +]}\n"
             + "Row #0: \n");
 
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select NON EMPTY {[Measures].[Unit Sales]} ON COLUMNS,\n"
             + "NON EMPTY Crossjoin({[Yearly Income].[All Yearly Incomes].Children},\n"
             + "                     [Yearly Income2].[All Yearly Income2s].Children) ON ROWS\n"
@@ -1703,7 +1703,7 @@ class SchemaTest {
         withSchema(context, schema);
          */
         withSchema(context, TestSnowflakeHierarchyValidationNotNeededModifier::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select  {[Store.MyHierarchy].[Mexico]} on rows,"
             + "{[Customers].[USA].[South West]} on columns"
             + " from "
@@ -1996,7 +1996,7 @@ class SchemaTest {
         withSchema(context, schema);
          */
         withSchema(context, TestSnowflakeHierarchyValidationNotNeeded2Modifier::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select  {[Store.MyHierarchy].[USA].[South West]} on rows,"
             + "{[Customers].[USA].[South West]} on columns"
             + " from "
@@ -2213,7 +2213,7 @@ class SchemaTest {
         withSchema(context, schema);
          */
         withSchema(context, TestDimensionsShareJoinTableModifier::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select  {[Store].[USA].[South West]} on rows,"
             + "{[Customers].[USA].[South West]} on columns"
             + " from "
@@ -2432,7 +2432,7 @@ class SchemaTest {
         withSchema(context, schema);
          */
         withSchema(context, TestDimensionsShareJoinTableOneAliasModifier::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select  {[Store].[USA].[South West]} on rows,"
             + "{[Customers].[USA].[South West]} on columns"
             + " from "
@@ -2650,7 +2650,7 @@ class SchemaTest {
         withSchema(context, schema);
          */
         withSchema(context, TestDimensionsShareJoinTableTwoAliasesModifier::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select  {[Store].[USA].[South West]} on rows,"
             + "{[Customers].[USA].[South West]} on columns"
             + " from "
@@ -2825,7 +2825,7 @@ class SchemaTest {
         withSchema(context, schema);
          */
         withSchema(context, TestTwoAliasesDimensionsShareTableModifier::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[StoreA].[USA]} on rows,"
             + "{[StoreB].[USA]} on columns"
             + " from "
@@ -2986,7 +2986,7 @@ class SchemaTest {
         withSchema(context, schema);
          */
         withSchema(context, TestTwoAliasesDimensionsShareTableSameForeignKeysModifier::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[StoreA].[USA]} on rows,"
             + "{[StoreB].[USA]} on columns"
             + " from "
@@ -3089,7 +3089,7 @@ class SchemaTest {
         withSchema(context, schema);
          */
         withSchema(context, TestMultipleDimensionUsagesModifier::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select\n"
             + " {[Time2].[1997]} on columns,\n"
             + " {[Time].[1997].[Q3]} on rows\n"
@@ -3202,7 +3202,7 @@ class SchemaTest {
             + " {[Time].[1997].[Q3]} on rows\n"
             + "From [Sales Two Dimensions]";
 
-        Result result = executeQuery(context.getConnection(), query);
+        Result result = executeQuery(context.getConnectionWithDefaultRole(), query);
 
         // Time2.1997 Member
         Member member1 =
@@ -3281,7 +3281,7 @@ class SchemaTest {
         }
         withSchema(context, TestDimensionCreationModifier::new);
 
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select\n"
             + "NON EMPTY {[Store].[All Stores].children} on columns \n"
             + "From [Sales Create Dimension]",
@@ -3291,7 +3291,7 @@ class SchemaTest {
             + "{[Store].[USA]}\n"
             + "Row #0: 266,773\n");
 
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select\n"
             + "NON EMPTY {[Store].[All Stores].children} on columns, \n"
             + "{[Time].[1997].[Q1]} on rows \n"
@@ -3370,7 +3370,7 @@ class SchemaTest {
         withSchema(context, schema);
          */
         withSchema(context, TestDimensionUsageLevelModifier::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select\n"
             + " {[Store].[Store State].members} on columns \n"
             + "From [Customer Usage Level]",
@@ -3401,7 +3401,7 @@ class SchemaTest {
         // BC.children should return an empty list, considering that we've
         // joined Store at the State level.
         if (false) {
-            assertQueryReturns(context.getConnection(),
+            assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "select\n"
                 + " {[Store].[All Stores].[Canada].[BC].children} on columns \n"
                 + "From [Customer Usage Level]",
@@ -3522,7 +3522,7 @@ class SchemaTest {
                 ? "[Store2].[All Stores]"
                 : "[Store2].[All Store2s]";
         withSchema(context, TestAllMemberMultipleDimensionUsagesModifier::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select\n"
             + " {[Store].[Store].[All Stores]} on columns,\n"
             + " {" + store2AllMember + "} on rows\n"
@@ -3535,7 +3535,7 @@ class SchemaTest {
             + "{[Store2].[Store].[All Stores]}\n"
             + "Row #0: 266,773\n");
 
-        final Result result = executeQuery(context.getConnection(),
+        final Result result = executeQuery(context.getConnectionWithDefaultRole(),
             "select ([Store].[All Stores], " + store2AllMember + ") on 0\n"
             + "from [Sales Two Sales Dimensions]");
         final Axis axis = result.getAxes()[0];
@@ -3632,7 +3632,7 @@ class SchemaTest {
         } else {
             // In new behavior, resolves to the hierarchy name [Time] even if
             // not qualified by dimension name [Time2].
-            assertQueryReturns(context.getConnection(),
+            assertQueryReturns(context.getConnectionWithDefaultRole(),
                 query,
                 "Axis #0:\n"
                 + "{}\n"
@@ -3815,7 +3815,7 @@ class SchemaTest {
         withSchema(context, schema);
          */
         withSchema(context, TestViewDegenerateDimsModifier::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select\n"
             + " NON EMPTY {[Time].[1997], [Time].[1997].[Q3]} on columns,\n"
             + " NON EMPTY {[Store].[USA].Children} on rows\n"
@@ -3988,7 +3988,7 @@ class SchemaTest {
         withSchema(context, schema);
          */
         withSchema(context, TestViewFactTableModifier::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select\n"
             + " {[Time].[1997], [Time].[1997].[Q3]} on columns,\n"
             + " {[Store].[USA].Children} on rows\n"
@@ -4130,7 +4130,7 @@ class SchemaTest {
         withSchema(context, schema);
          */
         withSchema(context, TestViewFactTable2Modifier::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Store Type].Children} on columns from [Store2]",
             "Axis #0:\n"
             + "{}\n"
@@ -4199,7 +4199,7 @@ class SchemaTest {
             }
         }
         withSchema(context, TestDeprecatedDistinctCountAggregatorModifier::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Measures].[Unit Sales],"
             + "    [Measures].[Customer Count], "
             + "    [Measures].[Customer Count2], "
@@ -4491,7 +4491,7 @@ class SchemaTest {
                 + "</Schema>");
          */
             withSchema(context, TestUnknownUsagesModifier::new);
-            assertQueryReturns(context.getConnection(),
+            assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "select from [Sales Degen]",
                 "Axis #0:\n"
                 + "{}\n"
@@ -4749,7 +4749,7 @@ class SchemaTest {
                 + "</Schema>");
              */
             withSchema(context, TestUnknownUsages1Modifier::new);
-            assertQueryReturns(context.getConnection(),
+            assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "select from [Denormalized Sales]",
                 "Axis #0:\n"
                 + "{}\n"
@@ -4836,7 +4836,7 @@ class SchemaTest {
          */
         try {
             withSchema(context, TestPropertyFormatterModifier::new);
-            assertSimpleQuery(context.getConnection());
+            assertSimpleQuery(context.getConnectionWithDefaultRole());
             fail("expected exception");
         } catch (RuntimeException e) {
             checkThrowable(
@@ -4925,10 +4925,10 @@ class SchemaTest {
             + "Axis #1:\n"
             + "{[Measures].[Unit Sales]}\n"
             + "Row #0: 266,773\n";
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Measures]} on 0 from [Sales2]",
             expected);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Measures]} on 0 from [Sales]",
             expected);
     }
@@ -5013,7 +5013,7 @@ class SchemaTest {
         withSchema(context, TestBugMondrian303Modifier::new);
         // In the query below Mondrian (prior to the fix) would
         // return the store name instead of the store type.
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH\n"
             + "   MEMBER [Measures].[StoreType] AS \n"
             + "   '[Store2].CurrentMember.Properties(\"Store Type\")'\n"
@@ -5149,7 +5149,7 @@ class SchemaTest {
         withSchema(context, schema);
          */
         withSchema(context, TestCubeWithOneDimensionOneMeasureModifier::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Promotion Media]} on columns from [OneDim]",
             "Axis #0:\n"
             + "{}\n"
@@ -5216,7 +5216,7 @@ class SchemaTest {
         withSchema(context, schema);
         */
         withSchema(context, TestCubeWithOneDimensionUsageOneMeasureModifier::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Product].Children} on columns from [OneDimUsage]",
             "Axis #0:\n"
             + "{}\n"
@@ -5261,7 +5261,7 @@ class SchemaTest {
         withSchema(context, TestCubeHasFactModifier::new);
         Throwable throwable = null;
         try {
-            assertSimpleQuery(context.getConnection());
+            assertSimpleQuery(context.getConnectionWithDefaultRole());
         } catch (Throwable e) {
             throwable = e;
         }
@@ -5324,7 +5324,7 @@ class SchemaTest {
          */
         withSchema(context, TestCubeCaptionModifier::new);
         final Cube[] cubes =
-            context.getConnection().getSchema().getCubes();
+            context.getConnectionWithDefaultRole().getSchema().getCubes();
         Optional<Cube> optionalCube1 = Arrays.stream(cubes).filter(c -> "Cube with caption".equals(c.getName())).findFirst();
         final Cube cube = optionalCube1.orElseThrow(() -> new RuntimeException("Cube with name \"Cube with caption\" is absent"));
         assertEquals("Cube with caption", cube.getCaption());
@@ -5367,7 +5367,7 @@ class SchemaTest {
             }
         }
         withSchema(context, TestCubeWithNoDimensionsModifier::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Measures].[Unit Sales]} on columns from [NoDim]",
             "Axis #0:\n"
             + "{}\n"
@@ -5454,7 +5454,7 @@ class SchemaTest {
         // Does not fail with
         //    "Hierarchy '[Measures]' is invalid (has no members)"
         // because of the implicit [Fact Count] measure.
-        assertSimpleQuery(context.getConnection());
+        assertSimpleQuery(context.getConnectionWithDefaultRole());
     }
 
     @ParameterizedTest
@@ -5536,7 +5536,7 @@ class SchemaTest {
         // Because there are no explicit stored measures, the default measure is
         // the implicit stored measure, [Fact Count]. Stored measures, even
         // non-visible ones, come before calculated measures.
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Measures]} on columns from [OneCalcMeasure]\n"
             + "where [Promotion Media].[TV]",
             "Axis #0:\n"
@@ -5597,7 +5597,7 @@ class SchemaTest {
         // Because there are no explicit stored measures, the default measure is
         // the implicit stored measure, [Fact Count]. Stored measures, even
         // non-visible ones, come before calculated measures.
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Store].[USA].[CA].[SF and LA]} on columns from [Sales]",
             "Axis #0:\n"
             + "{}\n"
@@ -5608,7 +5608,7 @@ class SchemaTest {
         // Now access the same member using a path that is not its unique name.
         // Only works with new name resolver (if ssas = true).
         if (SystemWideProperties.instance().SsasCompatibleNaming) {
-            assertQueryReturns(context.getConnection(),
+            assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "select {[Store].[All Stores].[USA].[CA].[SF and LA]} on columns from [Sales]",
                 "Axis #0:\n"
                 + "{}\n"
@@ -5661,7 +5661,7 @@ class SchemaTest {
              */
             ((TestContext)context).setCatalogMappingSupplier(new FoodmartMappingSupplier());
             withSchema(context, TestCalcMemberInCubeModifier2::new);
-            assertQueryReturns(context.getConnection(),
+            assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "select {[Store].[All Stores].[USA].[CA].[SF and LA]} on columns from [Sales]",
                 "Axis #0:\n"
                 + "{}\n"
@@ -5719,7 +5719,7 @@ class SchemaTest {
              */
             ((TestContext)context).setCatalogMappingSupplier(new FoodmartMappingSupplier());
             withSchema(context, TestCalcMemberInCubeModifier3::new);
-            assertQueryReturns(context.getConnection(),
+            assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "select {[Store].[All Stores].[USA].[CA].[SF and LA]} on columns from [Sales]",
                 "Axis #0:\n"
                 + "{}\n"
@@ -5774,7 +5774,7 @@ class SchemaTest {
              */
             ((TestContext)context).setCatalogMappingSupplier(new FoodmartMappingSupplier());
             withSchema(context, TestCalcMemberInCubeModifier4::new);
-            assertQueryReturns(context.getConnection(),
+            assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "select {[Store].[All Stores].[USA].[CA].[SF and LA]} on columns from [Sales]",
                 "Axis #0:\n"
                 + "{}\n"
@@ -5830,7 +5830,7 @@ class SchemaTest {
              */
             ((TestContext)context).setCatalogMappingSupplier(new FoodmartMappingSupplier());
             withSchema(context, TestCalcMemberInCubeModifier5::new);
-            assertQueryReturns(context.getConnection(),
+            assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "select {[Store].[All Stores].[USA].[CA].[SF and LA]} on columns from [Sales]",
                 "Axis #0:\n"
                 + "{}\n"
@@ -5889,7 +5889,7 @@ class SchemaTest {
              */
             ((TestContext)context).setCatalogMappingSupplier(new FoodmartMappingSupplier());
             withSchema(context, TestCalcMemberInCubeModifier6::new);
-            assertQueryReturns(context.getConnection(),
+            assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "select {[Store].[All Stores].[USA].[CA].[SF and LA]} on columns from [Sales]",
                 "Axis #0:\n"
                 + "{}\n"
@@ -5947,7 +5947,7 @@ class SchemaTest {
              */
             ((TestContext)context).setCatalogMappingSupplier(new FoodmartMappingSupplier());
             withSchema(context, TestCalcMemberInCubeModifier7::new);
-            assertQueryReturns(context.getConnection(),
+            assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "select {[Store].[All Stores].[USA].[CA].[SF and LA]} on columns from [Sales]",
                 "Axis #0:\n"
                 + "{}\n"
@@ -6041,7 +6041,7 @@ class SchemaTest {
             withSchema(context, schema);
              */
             withSchema(context, TestAggTableSupportOfSharedDimsModifier::new);
-            assertQueryReturns(context.getConnection(),
+            assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "select\n"
                 + " {[Time2].[1997]} on columns,\n"
                 + " {[Time].[1997].[Q3]} on rows\n"
@@ -6200,11 +6200,11 @@ class SchemaTest {
          */
 
         withSchema(context, TestLevelTableAttributeAsViewModifier::new);
-        if (!getDialect(context.getConnection()).allowsFromQuery()) {
+        if (!getDialect(context.getConnectionWithDefaultRole()).allowsFromQuery()) {
             return;
         }
 
-        Result result = executeQuery(context.getConnection(),
+        Result result = executeQuery(context.getConnectionWithDefaultRole(),
             "select {[Gender2].members} on columns from [GenderCube]");
 
         assertEqualsVerbose(
@@ -6315,7 +6315,7 @@ class SchemaTest {
         }
 
         withSchema(context, TestAllMemberNoStringReplaceModifier::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select [TIME.CALENDAR].[All TIME(CALENDAR)] on columns\n"
             + "from [Sales Special Time]",
             "Axis #0:\n"
@@ -6516,7 +6516,7 @@ class SchemaTest {
             + "formula=\"EXCEPT({[Store].[Store Country].[USA].children},{[Store].[Store Country].[USA].[CA]})\"/>"));
          */
         withSchema(context, TestVirtualCubeNamedSetSupportInSchemaModifier::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH "
             + "SET [Non CA State Stores] AS 'EXCEPT({[Store].[Store Country].[USA].children},"
             + "{[Store].[Store Country].[USA].[CA]})'\n"
@@ -6534,7 +6534,7 @@ class SchemaTest {
             + "{[Measures].[Unit Sales]}\n"
             + "Row #0: 266,773\n"
             + "Row #0: 192,025\n");
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH "
             + "MEMBER "
             + "[Store].[Total Non CA State] AS \n"
@@ -6581,7 +6581,7 @@ class SchemaTest {
 
         try {
             withSchema(context, TestVirtualCubeNamedSetSupportInSchemaErrorModifier::new);
-            assertQueryReturns(context.getConnection(),
+            assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "WITH "
                 + "SET [Non CA State Stores] AS 'EXCEPT({[Store].[Store Country].[USA].children},"
                 + "{[Store].[Store Country].[USA].[CA]})'\n"
@@ -6704,7 +6704,7 @@ class SchemaTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testBinaryLevelKey(Context context) {
-        switch (getDatabaseProduct(getDialect(context.getConnection()).getDialectName())) {
+        switch (getDatabaseProduct(getDialect(context.getConnectionWithDefaultRole()).getDialectName())) {
         case DERBY:
         case MARIADB:
         case MYSQL:
@@ -6817,7 +6817,7 @@ class SchemaTest {
          */
 
         withSchema(context, TestBinaryLevelKeyModifier::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Binary].members} on 0 from [Sales]",
             "Axis #0:\n"
             + "{}\n"
@@ -6832,7 +6832,7 @@ class SchemaTest {
             + "Row #0: \n"
             + "Row #0: \n"
             + "Row #0: \n");
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select hierarchize({[Binary].members}) on 0 from [Sales]",
             "Axis #0:\n"
             + "{}\n"
@@ -6952,7 +6952,7 @@ class SchemaTest {
             + "  </Dimension>\n"));
          */
         withSchema(context, TestLevelInternalTypeModifier::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Big numbers].members} on 0 from [Sales]",
             "Axis #0:\n"
             + "{}\n"
@@ -7071,7 +7071,7 @@ class SchemaTest {
     void _testAttributeHierarchy(Context context) {
         // from email from peter tran dated 2008/9/8
         // TODO: schema syntax to create attribute hierarchy
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH \n"
             + " MEMBER\n"
             + "  Measures.SalesPerWorkingDay AS \n"
@@ -7166,7 +7166,7 @@ class SchemaTest {
                 }
         }
         withSchema(context, TestScdJoinModifier::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select non empty {[Measures].[Unit Sales]} on 0,\n"
             + " non empty Filter({[Product truncated].Members}, [Measures].[Unit Sales] > 10000) on 1\n"
             + "from [Sales]",
@@ -7258,7 +7258,7 @@ class SchemaTest {
         withSchema(context, TestNonUniqueAliasModifier::new);
         Throwable throwable = null;
         try {
-            assertSimpleQuery(context.getConnection());
+            assertSimpleQuery(context.getConnectionWithDefaultRole());
         } catch (Throwable e) {
             throwable = e;
         }
@@ -7278,7 +7278,7 @@ class SchemaTest {
         // until bug MONDRIAN-495, "Table filter concept does not support
         // dialects." is fixed, this test case only works on MySQL
         if (!Bug.BugMondrian495Fixed
-            && getDatabaseProduct(getDialect(context.getConnection()).getDialectName())
+            && getDatabaseProduct(getDialect(context.getConnectionWithDefaultRole()).getDialectName())
             != MYSQL)
         {
             return;
@@ -7378,7 +7378,7 @@ class SchemaTest {
             + "SELECT {[Measures].[Unit Sales]} on columns, "
             + "NON EMPTY Hierarchize({[#DataSet#]}) on rows FROM [Sales2]";
 
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             query1,
             "Axis #0:\n"
             + "{}\n"
@@ -7396,7 +7396,7 @@ class SchemaTest {
             + "SELECT {[Measures].[Unit Sales]} on columns, "
             + "NON EMPTY Hierarchize({[#DataSet#]}) on rows FROM [Sales2]";
 
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             query2,
             "Axis #0:\n"
             + "{}\n"
@@ -7534,7 +7534,7 @@ class SchemaTest {
             "Sales", xml, false));
          */
         withSchema(context, CheckBugMondrian355Modifier1::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select Head([Time2].[Quarter hours].Members, 3) on columns\n"
             + "from [Sales]",
             "Axis #0:\n"
@@ -7548,7 +7548,7 @@ class SchemaTest {
             + "Row #0: 589\n");
 
         // Check that can apply ParallelPeriod to a TimeUndefined level.
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         assertAxisReturns(connection,
             "PeriodsToDate([Time2].[Quarter hours], [Time2].[1997].[Q1].[1].[368])",
             "[Time2].[1997].[Q1].[1].[368]");
@@ -7565,7 +7565,7 @@ class SchemaTest {
                 xml.replace("TimeUndefined", "TimeUnspecified"), false));
             */
         	withSchema(context, CheckBugMondrian355Modifier2::new);
-            assertSimpleQuery(context.getConnection());
+            assertSimpleQuery(context.getConnectionWithDefaultRole());
             fail("expected error");
         } catch (Throwable e) {
             //((TestContext)context).setDatabaseMappingSchemaProviders(
@@ -8040,7 +8040,7 @@ class SchemaTest {
          */
         withSchema(context, TestCaptionDescriptionAndAnnotationModifier::new);
         final Result result =
-            executeQuery(context.getConnection(), "select from [" + salesCubeName + "]");
+            executeQuery(context.getConnectionWithDefaultRole(), "select from [" + salesCubeName + "]");
         final Cube cube = result.getQuery().getCube();
         assertEquals("Cube description", cube.getDescription());
         checkAnnotations(cube.getMetaData(), "a", "Cube");
@@ -8208,7 +8208,7 @@ class SchemaTest {
         checkAnnotations(namedSet.getMetaData(), "a", "Named set");
 
         final Result result2 =
-            executeQuery(context.getConnection(), "select from [" + virtualCubeName + "]");
+            executeQuery(context.getConnectionWithDefaultRole(), "select from [" + virtualCubeName + "]");
         final Cube cube2 = result2.getQuery().getCube();
         assertEquals("Virtual cube description", cube2.getDescription());
         checkAnnotations(cube2.getMetaData(), "a", "Virtual cube");
@@ -8310,7 +8310,7 @@ class SchemaTest {
         withSchema(context, TestCaptionModifier::new);
 
 
-        switch (getDatabaseProduct(getDialect(context.getConnection()).getDialectName())) {
+        switch (getDatabaseProduct(getDialect(context.getConnectionWithDefaultRole()).getDialectName())) {
         case POSTGRES:
             // Postgres fails with:
             //   Internal error: while building member cache; sql=[select
@@ -8325,7 +8325,7 @@ class SchemaTest {
             // shouldn't be so picky, and people shouldn't be so daft.
             return;
         }
-        Result result = executeQuery(context.getConnection(),
+        Result result = executeQuery(context.getConnectionWithDefaultRole(),
             "select {[Gender2].Children} on columns from [Sales]");
         assertEquals(
             "foobar",
@@ -8360,7 +8360,7 @@ class SchemaTest {
         // Test case requires a pecular inline view, and it works on dialects
         // that scalar subqery, viz oracle. I believe that the mondrian code
         // being works in all dialects.
-        switch (getDatabaseProduct(getDialect(context.getConnection()).getDialectName())) {
+        switch (getDatabaseProduct(getDialect(context.getConnectionWithDefaultRole()).getDialectName())) {
         case ORACLE:
             break;
         default:
@@ -8620,7 +8620,7 @@ class SchemaTest {
         final String x = !Bug.BugMondrian747Fixed
             ? "1,379,620"
             : "266,773";
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select non empty {[Measures].[unitsales2]} on 0,\n"
             + " non empty [Store].members on 1\n"
             + "from [cube2]",
@@ -8640,7 +8640,7 @@ class SchemaTest {
             + "Row #3: 135,318\n"
             + "Row #4: 870,562\n");
 
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select non empty {[Measures].[unitsales1]} on 0,\n"
             + " non empty [Store].members on 1\n"
             + "from [cube1]",
@@ -8686,7 +8686,7 @@ class SchemaTest {
             + "Row #16: 2,203\n"
             + "Row #17: 11,491\n");
 
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select non empty {[Measures].[unitsales2], [Measures].[unitsales1]} on 0,\n"
             + " non empty [Store].members on 1\n"
             + "from [virtual_cube]",
@@ -9086,7 +9086,7 @@ class SchemaTest {
     }
 
     private void checkBugMondrian463(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select [Measures] on 0,\n"
             + " head([Product3].members, 10) on 1\n"
             + "from [Sales]",
@@ -9238,7 +9238,7 @@ class SchemaTest {
          */
         try {
             withSchema(context, TestLeftDeepJoinFailsModifier::new);
-            assertSimpleQuery(context.getConnection());
+            assertSimpleQuery(context.getConnectionWithDefaultRole());
             fail("expected error");
         } catch (OlapRuntimeException e) {
             assertEquals(
@@ -9314,7 +9314,7 @@ class SchemaTest {
             "WITH SET [#DataSet#] as '{Descendants([Position].[All Position], 2)}' "
             + "SELECT {[Measures].[Org Salary]} on columns, "
             + "NON EMPTY Hierarchize({[#DataSet#]}) on rows FROM [HR]";
-        Result result = executeQuery(context.getConnection(), mdxQuery);
+        Result result = executeQuery(context.getConnectionWithDefaultRole(), mdxQuery);
         Axis[] axes = result.getAxes();
         List<Position> positions = axes[1].getPositions();
         Member mall = positions.get(0).get(0);
@@ -9403,13 +9403,13 @@ class SchemaTest {
          */
         withSchema(context, TestBugMondrian923Modifier::new);
         for (Cube cube
-                : context.getConnection().getSchemaReader().getCubes())
+                : context.getConnectionWithDefaultRole().getSchemaReader().getCubes())
         {
             if (cube.getName().equals("Warehouse and Sales")) {
                 for (Dimension dim : cube.getDimensions()) {
                     if (dim.isMeasures()) {
                         List<Member> members =
-                            context.getConnection()
+                            context.getConnectionWithDefaultRole()
                                 .getSchemaReader().getLevelMembers(
                                     dim.getHierarchy().getLevels()[0],
                                     true);
@@ -9508,7 +9508,7 @@ class SchemaTest {
              */
             withSchema(context, TestCubesVisibilityModifier::new);
             final Cube cube =
-                context.getConnection().getSchema()
+                context.getConnectionWithDefaultRole().getSchema()
                     .lookupCube("Foo", true);
             assertTrue(testValue.equals(cube.isVisible()));
         }
@@ -9562,7 +9562,7 @@ class SchemaTest {
             ((TestContext)context).setCatalogMappingSupplier(new FoodmartMappingSupplier());
             withSchema(context, TestVirtualCubesVisibilityModifier::new);
             final Cube cube =
-                context.getConnection().getSchema()
+                context.getConnectionWithDefaultRole().getSchema()
                     .lookupCube("Foo", true);
             assertTrue(testValue.equals(cube.isVisible()));
         }
@@ -9642,7 +9642,7 @@ class SchemaTest {
              */
             withSchema(context, TestDimensionVisibilityModifier::new);
             final Cube cube =
-                context.getConnection().getSchema()
+                context.getConnectionWithDefaultRole().getSchema()
                     .lookupCube("Foo", true);
             Dimension dim = null;
             for (Dimension dimCheck : cube.getDimensions()) {
@@ -9702,7 +9702,7 @@ class SchemaTest {
             ((TestContext)context).setCatalogMappingSupplier(new FoodmartMappingSupplier());
             withSchema(context, TestVirtualDimensionVisibilityModifier::new);
             final Cube cube =
-                context.getConnection().getSchema()
+                context.getConnectionWithDefaultRole().getSchema()
                     .lookupCube("Foo", true);
             Dimension dim = null;
             for (Dimension dimCheck : cube.getDimensions()) {
@@ -9799,7 +9799,7 @@ class SchemaTest {
             ((TestContext)context).setCatalogMappingSupplier(testDimensionUsageVisibilityModifier);
 
             final Cube cube =
-                context.getConnection().getSchema()
+                context.getConnectionWithDefaultRole().getSchema()
                     .lookupCube("Foo", true);
 
             Dimension dim = null;
@@ -9891,7 +9891,7 @@ class SchemaTest {
              */
             withSchema(context, TestHierarchyVisibilityModifier::new);
             final Cube cube =
-                context.getConnection().getSchema()
+                context.getConnectionWithDefaultRole().getSchema()
                     .lookupCube("Foo", true);
             Dimension dim = null;
             for (Dimension dimCheck : cube.getDimensions()) {
@@ -9983,7 +9983,7 @@ class SchemaTest {
              */
             withSchema(context, TestLevelVisibilityModifier::new);
             final Cube cube =
-                context.getConnection().getSchema()
+                context.getConnectionWithDefaultRole().getSchema()
                     .lookupCube("Foo", true);
             Dimension dim = null;
             for (Dimension dimCheck : cube.getDimensions()) {
@@ -10194,7 +10194,7 @@ class SchemaTest {
         withSchema(context, schema);
          */
         withSchema(context, TestNonCollapsedAggregateModifier::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Product].[Product Family].Members} on rows, {[Measures].[Unit Sales]} on columns from [Foo]",
             "Axis #0:\n"
             + "{}\n"
@@ -10659,7 +10659,7 @@ class SchemaTest {
         withSchema(context, schema);
          */
         withSchema(context, TestTwoNonCollapsedAggregateModifier::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {Crossjoin([Product].[Product Family].Members, [Store].[Store Id].Members)} on rows, {[Measures].[Unit Sales]} on columns from [Foo]",
             "Axis #0:\n"
             + "{}\n"
@@ -11023,7 +11023,7 @@ class SchemaTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testBugMondrian1047(Context context) {
         // Test case only works under MySQL, due to how columns are quoted.
-        switch (getDatabaseProduct(getDialect(context.getConnection()).getDialectName())) {
+        switch (getDatabaseProduct(getDialect(context.getConnectionWithDefaultRole()).getDialectName())) {
         case MARIADB:
         case MYSQL:
             break;
@@ -11096,7 +11096,7 @@ class SchemaTest {
                     + "</Dimension>"),
                 null, false));
          */
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select from [HR]",
             "Axis #0:\n"
             + "{}\n"
@@ -11113,7 +11113,7 @@ class SchemaTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testBugMondrian1065(Context context) {
         // Test case only works under Oracle
-        switch (getDatabaseProduct(getDialect(context.getConnection()).getDialectName())) {
+        switch (getDatabaseProduct(getDialect(context.getConnectionWithDefaultRole()).getDialectName())) {
         case ORACLE:
             break;
         default:
@@ -11236,7 +11236,7 @@ class SchemaTest {
          */
 
         withSchema(context, TestBugMondrian1065Modifier::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select non empty crossjoin({[PandaSteak].[Level3].[level 3 - 1], [PandaSteak].[Level3].[level 3 - 2]}, {[Measures].[Unit Sales], [Measures].[Store Cost]}) on columns, {[Product].[Product Family].Members} on rows from [Sales]",
             "Axis #0:\n"
             + "{}\n"
@@ -11274,7 +11274,7 @@ class SchemaTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testMondrian1390(Context context) throws Exception {
-        Schema schema = context.getConnection().getSchema();
+        Schema schema = context.getConnectionWithDefaultRole().getSchema();
         Cube salesCube = schema.lookupCube("Sales", true);
         SchemaReader sr = salesCube.getSchemaReader(null).withLocus();
         List<Member> members = sr.getLevelMembers(
@@ -11695,7 +11695,7 @@ class SchemaTest {
                 + "</Schema>");
          */
         withSchema(context, TestMondrian1499Modifier::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Measures].[Org Salary]} on columns,\n"
             + "{[Store].[Store Country].Members} on rows from [HR]",
             "Axis #0:\n"
@@ -11817,7 +11817,7 @@ class SchemaTest {
         withSchema(context, schema);
         */
         withSchema(context, TestMondrian1073Modifier::new);
-        assertQueryReturns(context.getConnection(), "CubeB",
+        assertQueryReturns(context.getConnectionWithDefaultRole(), "CubeB",
             "SELECT [Measures].[Fantastic Count for Different Types of Promotion] ON COLUMNS\n"
             + "FROM [CubeB]",
             "Axis #0:\n"
@@ -11866,7 +11866,7 @@ class SchemaTest {
                 schemaFile.getAbsolutePath());
          */
         withSchema(context, TestMultiByteSchemaReadFromFile::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select [Gender].members on 0 from sales",
             "Axis #0:\n"
             + "{}\n"
@@ -12096,7 +12096,7 @@ class SchemaTest {
                                         + "</Schema>\n");
         */
         withSchema(context, TestMondrian1275Modifier::new);
-        final RolapConnection rolapConn = (RolapConnection) context.getConnection();
+        final RolapConnection rolapConn = (RolapConnection) context.getConnectionWithDefaultRole();
         final SchemaReader schemaReader = rolapConn.getSchemaReader();
         final RolapSchema schema = schemaReader.getSchema();
         for (RolapCube cube : schema.getCubeList()) {

--- a/mondrian/src/test/java/mondrian/test/SolveOrderScopeIsolationTest.java
+++ b/mondrian/src/test/java/mondrian/test/SolveOrderScopeIsolationTest.java
@@ -158,7 +158,7 @@ class SolveOrderScopeIsolationTest {
             + "from sales";
 
         setSolveOrderMode(context, SolveOrderMode.ABSOLUTE);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             mdx,
             "Axis #0:\n"
             + "{}\n"
@@ -191,7 +191,7 @@ class SolveOrderScopeIsolationTest {
             + "from sales";
 
         setSolveOrderMode(context, SolveOrderMode.SCOPED);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             mdx,
             "Axis #0:\n"
             + "{}\n"
@@ -220,7 +220,7 @@ class SolveOrderScopeIsolationTest {
     public void _future_testOverrideCubeMemberHappensWithScopeIsolation(Context context) {
     	prepareContext(context);
         setSolveOrderMode(context, SCOPED);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with\n"
             + "member gender.maleMinusFemale as 'Gender.M - gender.f', "
             + "SOLVE_ORDER=3000, FORMAT_STRING='#.##'\n"
@@ -262,7 +262,7 @@ class SolveOrderScopeIsolationTest {
             + " {[Measures].[Store Sales], [Measures].[Store Cost], [Measures].[ProfitSolveOrder3000]} ON 1 "
             + "FROM SALES\n";
         setSolveOrderMode(context, ABSOLUTE);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             mdx,
             "Axis #0:\n"
             + "{}\n"
@@ -297,7 +297,7 @@ class SolveOrderScopeIsolationTest {
             + "FROM SALES\n"
             + "WHERE ProfitSolveOrder3000";
         setSolveOrderMode(context, SCOPED);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             mdx,
             "Axis #0:\n"
             + "{[Measures].[ProfitSolveOrder3000]}\n"
@@ -324,7 +324,7 @@ class SolveOrderScopeIsolationTest {
             + "{gender.override, gender.maleMinusFemale} on 1\n"
             + "from sales";
         setSolveOrderMode(context, ABSOLUTE);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             mdx,
             "Axis #0:\n"
             + "{}\n"
@@ -357,7 +357,7 @@ class SolveOrderScopeIsolationTest {
             + "{gender.override, gender.maleMinusFemale} on 1\n"
             + "from sales";
         setSolveOrderMode(context, SCOPED);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             mdx,
             "Axis #0:\n"
             + "{}\n"
@@ -391,7 +391,7 @@ class SolveOrderScopeIsolationTest {
             + "{[Gender].[override], gender.maleMinusFemale} on 1\n"
             + "from sales";
         setSolveOrderMode(context, ABSOLUTE);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             mdx,
             "Axis #0:\n"
             + "{}\n"
@@ -425,7 +425,7 @@ class SolveOrderScopeIsolationTest {
             + "{[Gender].[override], gender.maleMinusFemale} on 1\n"
             + "from sales";
         setSolveOrderMode(context, SCOPED);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             mdx,
             "Axis #0:\n"
             + "{}\n"
@@ -459,7 +459,7 @@ class SolveOrderScopeIsolationTest {
             + "{[Gender].[override], gender.maleMinusFemale} on 1\n"
             + "from sales";
         setSolveOrderMode(context, ABSOLUTE);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             mdx,
             "Axis #0:\n"
             + "{}\n"
@@ -493,7 +493,7 @@ class SolveOrderScopeIsolationTest {
             + "{[Gender].[override], gender.maleMinusFemale} on 1\n"
             + "from sales";
         setSolveOrderMode(context, SCOPED);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             mdx,
             "Axis #0:\n"
             + "{}\n"
@@ -537,7 +537,7 @@ class SolveOrderScopeIsolationTest {
             + "{Time.Total, Time.Total1, [Time].[1997].[Q1], [Time].[1997].[Q2]} on 1\n"
             + "from sales";
         setSolveOrderMode(context, ABSOLUTE);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             mdx,
             "Axis #0:\n"
             + "{}\n"
@@ -582,7 +582,7 @@ class SolveOrderScopeIsolationTest {
             + "{Time.Total, Time.Total1, [Time].[1997].[Q1], [Time].[1997].[Q2]} on 1\n"
             + "from sales";
         setSolveOrderMode(context, SCOPED);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             mdx,
             "Axis #0:\n"
             + "{}\n"
@@ -633,7 +633,7 @@ class SolveOrderScopeIsolationTest {
             + "{Time.Total, Time.Total1, [Time].[1997].[Q1], [Time].[1997].[Q2]} on 1\n"
             + "from sales";
         setSolveOrderMode(context, ABSOLUTE);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             mdx,
             "Axis #0:\n"
             + "{}\n"
@@ -677,7 +677,7 @@ class SolveOrderScopeIsolationTest {
             + "{Time.Total, Time.Total1, [Time].[1997].[Q1], [Time].[1997].[Q2]} on 1\n"
             + "from sales";
         setSolveOrderMode(context, SCOPED);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             mdx,
             "Axis #0:\n"
             + "{}\n"
@@ -729,7 +729,7 @@ class SolveOrderScopeIsolationTest {
             + "{Time.Total, [Time].[1997].[Q1], [Time].[1997].[Q2]} on 1\n"
             + "from sales";
         setSolveOrderMode(context, ABSOLUTE);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             mdx,
             "Axis #0:\n"
             + "{}\n"
@@ -770,7 +770,7 @@ class SolveOrderScopeIsolationTest {
             + "{Time.Total, [Time].[1997].[Q1], [Time].[1997].[Q2]} on 1\n"
             + "from sales";
         setSolveOrderMode(context, SCOPED);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             mdx,
             "Axis #0:\n"
             + "{}\n"
@@ -809,7 +809,7 @@ class SolveOrderScopeIsolationTest {
             + "{gender.override1, gender.override2, gender.maleMinusFemale} on 1\n"
             + "from sales";
         setSolveOrderMode(context, ABSOLUTE);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             mdx,
             "Axis #0:\n"
             + "{}\n"
@@ -852,7 +852,7 @@ class SolveOrderScopeIsolationTest {
             + "{gender.override1, gender.override2, gender.maleMinusFemale} on 1\n"
             + "from sales";
         setSolveOrderMode(context, SCOPED);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             mdx,
             "Axis #0:\n"
             + "{}\n"

--- a/mondrian/src/test/java/mondrian/test/SteelWheelsPerformanceTest.java
+++ b/mondrian/src/test/java/mondrian/test/SteelWheelsPerformanceTest.java
@@ -88,7 +88,7 @@ class SteelWheelsPerformanceTest {
             + "from [SteelWheelsSales]\n"
             + "where ([Time].[*SLICER_MEMBER], [Order Status].[*SLICER_MEMBER])\n";
         long start = System.currentTimeMillis();
-        executeQuery(context.getConnection(), query);
+        executeQuery(context.getConnectionWithDefaultRole(), query);
         printDuration("Complex filters query performance", start);
     }
 

--- a/mondrian/src/test/java/mondrian/test/SteelWheelsSchemaTest.java
+++ b/mondrian/src/test/java/mondrian/test/SteelWheelsSchemaTest.java
@@ -62,10 +62,10 @@ class SteelWheelsSchemaTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandSteelWheelsCatalog.class, dataloader = SteelWheelsDataLoader.class )
     void testMeasures(Context context) {
-        if (!TestUtil.databaseIsValid(context.getConnection())) {
+        if (!TestUtil.databaseIsValid(context.getConnectionWithDefaultRole())) {
             return;
         }
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Measures.Members",
             "[Measures].[Quantity]\n"
             + "[Measures].[Sales]\n"
@@ -80,7 +80,7 @@ class SteelWheelsSchemaTest {
         if (!databaseIsValid(((TestContext)context).getConnection(List.of("dev")))) {
             return;
         }
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with set [*NATIVE_CJ_SET] as 'Filter([*BASE_MEMBERS_Markets], (NOT IsEmpty([Measures].[Sales])))'\n"
             + "  set [*SORTED_ROW_AXIS] as 'Order([*CJ_ROW_AXIS], [Markets].CurrentMember.OrderKey, BASC)'\n"
             + "  set [*BASE_MEMBERS_Markets] as '[Markets].[Territory].Members'\n"
@@ -111,7 +111,7 @@ class SteelWheelsSchemaTest {
         //if (!databaseIsValid(context.getConnection())) {
         //    return;
         //}
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select [Markets].[All Markets].[Japan] on 0 from [SteelWheelsSales]",
             "Axis #0:\n"
             + "{}\n"
@@ -119,7 +119,7 @@ class SteelWheelsSchemaTest {
             + "{[Markets].[Japan]}\n"
             + "Row #0: 4,923\n");
 
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select [Markets].Children on 0 from [SteelWheelsSales]",
             "Axis #0:\n"
             + "{}\n"
@@ -135,7 +135,7 @@ class SteelWheelsSchemaTest {
             + "Row #0: 4,923\n"
             + "Row #0: 37,952\n");
 
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select Subset([Markets].Members, 130, 8) on 0 from [SteelWheelsSales]",
             "Axis #0:\n"
             + "{}\n"
@@ -157,7 +157,7 @@ class SteelWheelsSchemaTest {
             + "Row #0: 692\n"
             + "Row #0: 692\n");
 
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select [Markets].[Territory].Members on 0 from "
             + "[SteelWheelsSales]",
             "Axis #0:\n"
@@ -243,7 +243,7 @@ class SteelWheelsSchemaTest {
     }
 
     private void checkCellZero(Context context, String mdx) {
-        final Result result = executeQuery(context.getConnection(), mdx);
+        final Result result = executeQuery(context.getConnectionWithDefaultRole(), mdx);
         final Cell cell = result.getCell(new int[result.getAxes().length]);
         assertTrue(cell.canDrillThrough());
         assertEquals(2996, cell.getDrillThroughCount());
@@ -263,7 +263,7 @@ class SteelWheelsSchemaTest {
         //    return;
         //}
         withSchema(context, SchemaModifiers.SteelWheelsSchemaTestModifier2::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select NON EMPTY {[Measures].[Quantity]} ON COLUMNS,\n"
             + "NON EMPTY {[Markets].[APAC]} ON ROWS\n"
             + "from [SteelWheelsSales]\n"
@@ -290,7 +290,7 @@ class SteelWheelsSchemaTest {
         //    return;
         //}
         withSchema(context, SchemaModifiers.SteelWheelsSchemaTestModifier2::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select NON EMPTY {[Measures].[Quantity]} ON COLUMNS,\n"
             + "NON EMPTY {[Markets].[APAC]} ON ROWS\n"
             + "from [SteelWheelsSales]\n"
@@ -313,7 +313,7 @@ class SteelWheelsSchemaTest {
         //    return;
         //}
         withSchema(context, SchemaModifiers.SteelWheelsSchemaTestModifier3::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select NON EMPTY {[Measures].[Quantity]} ON COLUMNS, \n"
             + "  NON EMPTY {([Markets].[APAC], [Customers].[All Customers], "
             + "[Product].[All Products], [Time].[All Years])} ON ROWS \n"
@@ -328,7 +328,7 @@ class SteelWheelsSchemaTest {
             + "Row #0: 596\n");
 
         // same query, pivoted
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select NON EMPTY {[Measures].[Quantity]} ON COLUMNS, \n"
             + "  NON EMPTY {([Customers].[All Customers], "
             + "[Product].[All Products], "
@@ -360,7 +360,7 @@ class SteelWheelsSchemaTest {
             + "select [*BASE_MEMBERS_Measures] ON COLUMNS,\n"
             + "  [*SORTED_ROW_AXIS] ON ROWS\n"
             + "from [SteelWheelsSales2]\n";
-       assertQueryReturns(context.getConnection(),
+       assertQueryReturns(context.getConnectionWithDefaultRole(),
             mdxQuery,
             "Axis #0:\n"
             + "{}\n"
@@ -395,7 +395,7 @@ class SteelWheelsSchemaTest {
         //if (!databaseIsValid(context.getConnection())) {
         //    return;
         //}
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with set [*NATIVE_CJ_SET] as '[*BASE_MEMBERS_Product]' \n"
             + "  set [*SORTED_ROW_AXIS] as 'Order([*CJ_ROW_AXIS], "
             + "[Product].CurrentMember.OrderKey, BASC)' \n"
@@ -449,7 +449,7 @@ class SteelWheelsSchemaTest {
 
         withSchema(context, SchemaModifiers.SteelWheelsSchemaTestModifier5::new);
 
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with member [Measures].[Date] as 'Format([Orders].CurrentMember.Properties(\"OrderDate\"), \"yyyy-mm-dd\")'\n"
             + "select {[Orders].[Order].[10421]} on rows,\n"
             + "{[Measures].[Date]} on columns from [Foo]",
@@ -473,7 +473,7 @@ class SteelWheelsSchemaTest {
         //if (!databaseIsValid(context.getConnection())) {
         //    return;
         //}
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with set [*NATIVE_CJ_SET] as '[*BASE_MEMBERS_Time]'\n"
             + "  set [*SORTED_COL_AXIS] as 'Order([*CJ_COL_AXIS], [Time].CurrentMember.OrderKey, BASC)'\n"
             + "  set [*BASE_MEMBERS_Measures] as '{[Measures].[*ZERO]}'\n"
@@ -495,7 +495,7 @@ class SteelWheelsSchemaTest {
         //if (!databaseIsValid(context.getConnection())) {
         //    return;
         //}
-        executeQuery(context.getConnection(),
+        executeQuery(context.getConnectionWithDefaultRole(),
             "With\n"
             + "Set [*NATIVE_CJ_SET] as 'Filter([*BASE_MEMBERS_Markets], Not IsEmpty ([Measures].[Sales]))'\n"
             + "Set [*SORTED_ROW_AXIS] as 'Order([*CJ_ROW_AXIS],[Markets].CurrentMember.OrderKey,BASC,Ancestor([Markets].CurrentMember,[Markets].[Territory]).OrderKey,BASC)'\n"
@@ -947,7 +947,7 @@ class SteelWheelsSchemaTest {
                 + "[*BASE_MEMBERS_Measures] on columns,\n"
                 + "[*SORTED_ROW_AXIS] on rows\n"
                 + "From [SteelWheelsSales]\n";
-            assertQueryReturns(context.getConnection(),
+            assertQueryReturns(context.getConnectionWithDefaultRole(),
                 mdx,
                 results[i]);
         }
@@ -976,7 +976,7 @@ class SteelWheelsSchemaTest {
             + "{[Measures].[*ZERO]} on columns,\n"
             + "{[Markets].[#null].[Germany].[#null] : [Markets].[EMEA].[France].[#null]} on rows\n"
             + "From [SteelWheelsSales]\n";
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             mdx,
             "Axis #0:\n"
             + "{}\n"
@@ -1044,7 +1044,7 @@ class SteelWheelsSchemaTest {
         //if (!databaseIsValid(context.getConnection())) {
         //    return;
         //}
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with set [*NATIVE_CJ_SET] as 'Filter(NonEmptyCrossJoin([*BASE_MEMBERS_Time], [*BASE_MEMBERS_Product]), (NOT IsEmpty([Measures].[Quantity])))'\n"
             + "  set [*SORTED_ROW_AXIS] as 'Order([*CJ_ROW_AXIS], [Product].CurrentMember.OrderKey, BASC)'\n"
             + "  set [*SORTED_COL_AXIS] as 'Order([*CJ_COL_AXIS], [Time].CurrentMember.OrderKey, BASC)'\n"
@@ -1134,7 +1134,7 @@ class SteelWheelsSchemaTest {
         //if (!databaseIsValid(context.getConnection())) {
         //    return;
         //}
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with \n"
             + "  member [Product].[agg] as \n"
             + "    'Aggregate({[Product].[Line].[Motorcycles]})'\n"
@@ -1146,7 +1146,7 @@ class SteelWheelsSchemaTest {
             + "Axis #1:\n"
             + "{[Measures].[rank]}\n"
             + "Row #0: 3\n");
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with \n"
             + "  member [Product].[agg] as \n"
             + "    'Aggregate({[Product].[Line].[Motorcycles]})'\n"
@@ -1174,7 +1174,7 @@ class SteelWheelsSchemaTest {
     void testMondrian1360(Context context) {
         withSchema(context, SchemaModifiers.SteelWheelsSchemaTestModifier6::new);
 
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH \n"
             + "SET [*NATIVE_CJ_SET] AS 'FILTER([*BASE_MEMBERS_MyProduct], NOT ISEMPTY ([Measures].[Sales]))' \n"
             + "SET [*SORTED_ROW_AXIS] AS "
@@ -1219,7 +1219,7 @@ class SteelWheelsSchemaTest {
         //}
         ((TestConfig)context.getConfig()).setIgnoreInvalidMembers(true);
         ((TestConfig)context.getConfig()).setIgnoreInvalidMembersDuringQuery(true);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH \n"
             + "SET [*NATIVE_CJ_SET] AS '[*BASE_MEMBERS_Time]' \n"
             + "SET [*BASE_MEMBERS_Measures] AS '{[Measures].[*ZERO]}' \n"
@@ -1253,7 +1253,7 @@ class SteelWheelsSchemaTest {
         //}
 
         withSchema(context, SchemaModifiers.SteelWheelsSchemaTestModifier7::new);
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         Schema schema = connection.getSchema();
 
         
@@ -1330,7 +1330,7 @@ class SteelWheelsSchemaTest {
         //if (!databaseIsValid(context.getConnection())) {
         //    return;
         //}
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with member [Measures].[CYQ] as\n"
             + "'Aggregate(CurrentDateMember([Time],\"[Ti\\me]\\.[Year\\s]\\.[yyyy]\", BEFORE), [Quantity])'\n"
             + "select\n"

--- a/mondrian/src/test/java/mondrian/test/TestExcel.java
+++ b/mondrian/src/test/java/mondrian/test/TestExcel.java
@@ -38,11 +38,11 @@ public class TestExcel {
                 SELECT NON EMPTY CrossJoin(Hierarchize(AddCalculatedMembers({DrilldownLevel({[Store].[All Stores]})})),Hierarchize(AddCalculatedMembers({DrilldownLevel({[Position].[All Position]})}))) DIMENSION PROPERTIES PARENT_UNIQUE_NAME ON COLUMNS  FROM [HR] WHERE ([Measures].[Count]) CELL PROPERTIES VALUE, FORMAT_STRING, LANGUAGE, BACK_COLOR, FORE_COLOR, FONT_FLAGS
                 """;
 
-        QueryComponent queryComponent = context.getConnection().parseStatement(mdxQueryString);
+        QueryComponent queryComponent = context.getConnectionWithDefaultRole().parseStatement(mdxQueryString);
 
         assertThat(queryComponent).isInstanceOf(Query.class);
         if (queryComponent instanceof Query query) {
-            Statement statement = context.getConnection().createStatement();
+            Statement statement = context.getConnectionWithDefaultRole().createStatement();
             CellSet cellSet = statement.executeQuery(query);
 
             System.out.println(cellSet);

--- a/mondrian/src/test/java/mondrian/test/TupleListTest.java
+++ b/mondrian/src/test/java/mondrian/test/TupleListTest.java
@@ -69,7 +69,7 @@ class TupleListTest {
 
         TupleList list1 = new UnaryTupleList();
         assertEquals(list0, list1);
-        final Member storeUsaMember = xxx(context.getConnection(),"[Store].[USA]");
+        final Member storeUsaMember = xxx(context.getConnectionWithDefaultRole(),"[Store].[USA]");
         list1.add(Collections.singletonList(storeUsaMember));
         assertFalse(list1.isEmpty());
         assertEquals(1, list1.size());
@@ -99,7 +99,7 @@ class TupleListTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testArrayTupleList(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         final Member genderFMember = xxx(connection, "[Gender].[F]");
         final Member genderMMember = xxx(connection,"[Gender].[M]");
 
@@ -182,7 +182,7 @@ class TupleListTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDelegatingTupleList(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         final Member genderFMember = xxx(connection, "[Gender].[F]");
         final Member genderMMember = xxx(connection, "[Gender].[M]");
         final Member storeUsaMember = xxx(connection, "[Store].[USA]");
@@ -210,7 +210,7 @@ class TupleListTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDelegatingTupleListSlice(Context context) {
         // Functional test.
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         assertQueryReturns(connection,
             "select {[Measures].[Store Sales]} ON COLUMNS, Hierarchize(Except({[Customers].[All Customers], [Customers].[All Customers].Children}, {[Customers].[All Customers]})) ON ROWS from [Sales] ",
             "Axis #0:\n"

--- a/mondrian/src/test/java/mondrian/test/UdfTest.java
+++ b/mondrian/src/test/java/mondrian/test/UdfTest.java
@@ -135,7 +135,7 @@ public class UdfTest {
     void testSanity(Context context) {
         // sanity check, make sure the schema is loading correctly
         prepareContext(context);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "SELECT {[Measures].[Store Sqft]} ON COLUMNS, {[Store Type]} ON ROWS FROM [Store]",
             "Axis #0:\n"
             + "{}\n"
@@ -151,7 +151,7 @@ public class UdfTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testFun(Context context) {
         prepareContext(context);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH MEMBER [Measures].[Sqft Plus One] AS 'PlusOne([Measures].[Store Sqft])'\n"
             + "SELECT {[Measures].[Sqft Plus One]} ON COLUMNS, \n"
             + "  {[Store Type].children} ON ROWS \n"
@@ -194,7 +194,7 @@ public class UdfTest {
         Statement statement = null;
         CellSet x = null;
         try {
-            connection = context.getConnection();
+            connection = context.getConnectionWithDefaultRole();
             statement = connection.createStatement();
             x = statement.executeQuery(
                 "SELECT { CurrentDateMember([Time].[Time], "
@@ -210,7 +210,7 @@ public class UdfTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testLastNonEmpty(Context context) {
         prepareContext(context);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH MEMBER [Measures].[Last Unit Sales] AS \n"
             + " '([Measures].[Unit Sales], \n"
             + "   LastNonEmpty(Descendants([Time].[Time]), [Measures].[Unit Sales]))'\n"
@@ -288,7 +288,7 @@ public class UdfTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testLastNonEmptyBig(Context context) {
         prepareContext(context);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with\n"
             + "     member\n"
             + "     [Measures].[Last Sale] as ([Measures].[Unit Sales],\n"
@@ -318,7 +318,7 @@ public class UdfTest {
             + "\"/>\n");
          */
         try {
-            executeQuery(context.getConnection(), "SELECT {} ON COLUMNS FROM [Sales]");
+            executeQuery(context.getConnectionWithDefaultRole(), "SELECT {} ON COLUMNS FROM [Sales]");
             fail("Expected exception");
         } catch (Exception e) {
             final String s = e.getMessage();
@@ -342,8 +342,8 @@ public class UdfTest {
             + PlusOrMinusOneUdf.class.getName()
             + "\"/>\n");
          */
-        assertExprReturns(context.getConnection(), "GenericPlusOne(3)", "4");
-        assertExprReturns(context.getConnection(), "GenericMinusOne(3)", "2");
+        assertExprReturns(context.getConnectionWithDefaultRole(), "GenericPlusOne(3)", "4");
+        assertExprReturns(context.getConnectionWithDefaultRole(), "GenericMinusOne(3)", "2");
     }
 
     @Disabled //TODO: UserDefinedFunction
@@ -351,7 +351,7 @@ public class UdfTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testComplexFun(Context context) {
         prepareContext(context);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH MEMBER [Measures].[InverseNormal] AS 'InverseNormal([Measures].[Grocery Sqft] / [Measures].[Store Sqft])', FORMAT_STRING = \"0.000\"\n"
             + "SELECT {[Measures].[InverseNormal]} ON COLUMNS, \n"
             + "  {[Store Type].children} ON ROWS \n"
@@ -381,7 +381,7 @@ public class UdfTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testException(Context context) {
         prepareContext(context);
-        Result result = executeQuery(context.getConnection(),
+        Result result = executeQuery(context.getConnectionWithDefaultRole(),
             "WITH MEMBER [Measures].[InverseNormal] "
             + " AS 'InverseNormal([Measures].[Store Sqft] / [Measures].[Grocery Sqft])',"
             + " FORMAT_STRING = \"0.000000\"\n"
@@ -411,7 +411,7 @@ public class UdfTest {
     void testCurrentDateString(Context context)
     {
         prepareContext(context);
-        String actual = executeExpr(context.getConnection(), "CurrentDateString(\"Ddd mmm dd yyyy\")");
+        String actual = executeExpr(context.getConnectionWithDefaultRole(), "CurrentDateString(\"Ddd mmm dd yyyy\")");
         Date currDate = new Date();
         String dateString = currDate.toString();
         String expected =
@@ -424,7 +424,7 @@ public class UdfTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCurrentDateMemberBefore(Context context) {
         prepareContext(context);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "SELECT { CurrentDateMember([Time].[Time], "
             + "\"[Ti\\me]\\.[yyyy]\\.[Qq]\\.[m]\", BEFORE)} "
             + "ON COLUMNS FROM [Sales]",
@@ -440,7 +440,7 @@ public class UdfTest {
     void testCurrentDateMemberBeforeUsingQuotes(Context context)
     {
         prepareContext(context);
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             SystemWideProperties.instance().SsasCompatibleNaming
             ? "CurrentDateMember([Time].[Time], "
             + "'\"[Time].[Time].[\"yyyy\"].[Q\"q\"].[\"m\"]\"', BEFORE)"
@@ -456,7 +456,7 @@ public class UdfTest {
         prepareContext(context);
         // CurrentDateMember will return null member since the latest date in
         // FoodMart is from '98
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "SELECT { CurrentDateMember([Time].[Time], "
             + "\"[Ti\\me]\\.[yyyy]\\.[Qq]\\.[m]\", AFTER)} "
             + "ON COLUMNS FROM [Sales]",
@@ -473,7 +473,7 @@ public class UdfTest {
         // CurrentDateMember will return null member since the latest date in
         // FoodMart is from '98; apply a function on the return value to
         // ensure null member instead of null is returned
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "SELECT { CurrentDateMember([Time].[Time], "
             + "\"[Ti\\me]\\.[yyyy]\\.[Qq]\\.[m]\", EXACT).lag(1)} "
             + "ON COLUMNS FROM [Sales]",
@@ -489,7 +489,7 @@ public class UdfTest {
         prepareContext(context);
         // CurrentDateMember will return null member since the latest date in
         // FoodMart is from '98
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "SELECT { CurrentDateMember([Time].[Time], "
             + "\"[Ti\\me]\\.[yyyy]\\.[Qq]\\.[m]\", EXACT)} "
             + "ON COLUMNS FROM [Sales]",
@@ -510,7 +510,7 @@ public class UdfTest {
                 : "SELECT { CurrentDateMember([Time.Weekly], "
                   + "\"[Ti\\me\\.Weekl\\y]\\.[All Ti\\me\\.Weekl\\y\\s]\\.[yyyy]\\.[ww]\", BEFORE)} "
                   + "ON COLUMNS FROM [Sales]";
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             query,
             "Axis #0:\n"
             + "{}\n"
@@ -526,7 +526,7 @@ public class UdfTest {
         // CurrentDateMember will return null member since the latest date in
         // FoodMart is from '98; note that first arg is a hierarchy rather
         // than a dimension
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "SELECT { CurrentDateMember([Time.Weekly], "
             + "\"[Ti\\me]\\.[yyyy]\\.[Qq]\\.[m]\", EXACT)} "
             + "ON COLUMNS FROM [Sales]",
@@ -542,7 +542,7 @@ public class UdfTest {
         // omit formatting characters from the format so the current date
         // is hard-coded to actual value in the database so we can test the
         // after logic
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "SELECT { CurrentDateMember([Time].[Time], "
             + "\"[Ti\\me]\\.[1996]\\.[Q4]\", after)} "
             + "ON COLUMNS FROM [Sales]",
@@ -560,7 +560,7 @@ public class UdfTest {
         // omit formatting characters from the format so the current date
         // is hard-coded to actual value in the database so we can test the
         // exact logic
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "SELECT { CurrentDateMember([Time].[Time], "
             + "\"[Ti\\me]\\.[1997]\", EXACT)} "
             + "ON COLUMNS FROM [Sales]",
@@ -578,7 +578,7 @@ public class UdfTest {
         // omit formatting characters from the format so the current date
         // is hard-coded to actual value in the database so we can test the
         // exact logic
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "SELECT { CurrentDateMember([Time].[Time], "
             + "\"[Ti\\me]\\.[1997]\\.[Q2]\\.[5]\", EXACT)} "
             + "ON COLUMNS FROM [Sales]",
@@ -594,7 +594,7 @@ public class UdfTest {
     void testCurrentDateMemberPrev(Context context) {
         prepareContext(context);
         // apply a function on the result of the UDF
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "SELECT { CurrentDateMember([Time].[Time], "
             + "\"[Ti\\me]\\.[yyyy]\\.[Qq]\\.[m]\", BEFORE).PrevMember} "
             + "ON COLUMNS FROM [Sales]",
@@ -611,7 +611,7 @@ public class UdfTest {
         prepareContext(context);
         // Also, try a different style of quoting, because single quote followed
         // by double quote (used in other examples) is difficult to read.
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "SELECT\n"
             + "    { [Measures].[Unit Sales] } ON COLUMNS,\n"
             + "    { CurrentDateMember([Time].[Time], '[\"Time\"]\\.[yyyy]\\.[\"Q\"q]\\.[m]', BEFORE).Lag(3) : "
@@ -636,7 +636,7 @@ public class UdfTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testMatches(Context context) {
         prepareContext(context);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "SELECT {[Measures].[Org Salary]} ON COLUMNS, "
             + "Filter({[Employees].MEMBERS}, "
             + "[Employees].CurrentMember.Name MATCHES '(?i)sam.*') ON ROWS "
@@ -666,7 +666,7 @@ public class UdfTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testNotMatches(Context context) {
         prepareContext(context);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "SELECT {[Measures].[Store Sales]} ON COLUMNS, "
             + "Filter({[Store Type].MEMBERS}, "
             + "[Store Type].CurrentMember.Name NOT MATCHES "
@@ -693,7 +693,7 @@ public class UdfTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testIn(Context context) {
         prepareContext(context);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "SELECT {[Measures].[Unit Sales]} ON COLUMNS, "
             + "FILTER([Product].[Product Family].MEMBERS, "
             + "[Product].[Product Family].CurrentMember IN "
@@ -715,7 +715,7 @@ public class UdfTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testNotIn(Context context) {
         prepareContext(context);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "SELECT {[Measures].[Unit Sales]} ON COLUMNS, "
             + "FILTER([Product].[Product Family].MEMBERS, "
             + "[Product].[Product Family].CurrentMember NOT IN "
@@ -735,7 +735,7 @@ public class UdfTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testChildMemberIn(Context context) {
         prepareContext(context);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "SELECT {[Measures].[Store Sales]} ON COLUMNS, "
             + "{[Store].[Store Name].MEMBERS} ON ROWS "
             + "FROM [Sales]",
@@ -797,7 +797,7 @@ public class UdfTest {
 
         // test when the member arg is at a different level
         // from the set argument
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "SELECT {[Measures].[Store Sales]} ON COLUMNS, "
             + "Filter({[Store].[Store Name].MEMBERS}, "
             + "[Store].[Store Name].CurrentMember IN "
@@ -830,7 +830,7 @@ public class UdfTest {
         updateTestContext(context, SchemaModifiers.UdfTestModifier15::new);
         // The default implementation of getResultType would assume that
         // StringMult(int, string) returns an int, whereas it returns a string.
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "StringMult(5, 'foo') || 'bar'", "foofoofoofoofoobar");
     }
 
@@ -850,7 +850,7 @@ public class UdfTest {
             + "\"/>\n");
          */
         updateTestContext(context, SchemaModifiers.UdfTestModifier15::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with member [Measures].[ABC] as StringMult(1, 'A')\n"
             + "member [Measures].[Unit Sales Formatted] as\n"
             + "  [Measures].[Unit Sales],\n"
@@ -885,7 +885,7 @@ public class UdfTest {
             + AnotherMemberErrorUdf.class.getName() + "\"/>");
          */
         updateTestContext(context, SchemaModifiers.UdfTestModifier16::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH MEMBER [Measures].[Test] AS "
             + "'([Measures].[Store Sales],[Product].[Food],AnotherMemberError([Product].[Drink],[Time].[Time]))'\n"
             + "SELECT {[Measures].[Test]} ON COLUMNS, \n"
@@ -906,7 +906,7 @@ public class UdfTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCachingCurrentDate(Context context) {
         prepareContext(context);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "SELECT {filter([Time].[Month].Members, "
             + "[Time].[Time].CurrentMember in {CurrentDateMember([Time]"
             + ".[Time], '[\"Time\"]\\.[yyyy]\\.[\"Q\"q]\\.[m]', "
@@ -968,7 +968,7 @@ public class UdfTest {
             + "Row #0: 131,558\n"
             + "Row #0: 266,773\n";
         // UDF called directly in axis expression.
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         assertQueryReturns(connection,
             "select Reverse([Gender].Members) on 0\n"
             + "from [Sales]",
@@ -1021,7 +1021,7 @@ public class UdfTest {
             + "\"/>\n");
          */
         updateTestContext(context, SchemaModifiers.UdfTestModifier19::new);
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "MemberName([Gender].[F])", "F");
     }
 
@@ -1037,7 +1037,7 @@ public class UdfTest {
             "<UserDefinedFunction name='StringMult'/>\n");
          */
         updateTestContext(context, SchemaModifiers.UdfTestModifier20::new);
-        assertQueryThrows(context.getConnection(),
+        assertQueryThrows(context.getConnectionWithDefaultRole(),
             "select from [Sales]",
             "Must specify either className attribute or Script element");
     }
@@ -1057,7 +1057,7 @@ public class UdfTest {
             + "</UserDefinedFunction>");
         */
         updateTestContext(context, SchemaModifiers.UdfTestModifier21::new);
-        assertQueryThrows(context.getConnection(),
+        assertQueryThrows(context.getConnectionWithDefaultRole(),
             "select from [Sales]",
             "Must not specify both className attribute and Script element");
     }
@@ -1076,7 +1076,7 @@ public class UdfTest {
             + "</UserDefinedFunction>");
          */
         updateTestContext(context, SchemaModifiers.UdfTestModifier22::new);
-        assertQueryThrows(context.getConnection(),
+        assertQueryThrows(context.getConnectionWithDefaultRole(),
             "select from [Sales]",
             "Invalid script language 'bad'");
     }
@@ -1114,7 +1114,7 @@ public class UdfTest {
             + "</UserDefinedFunction>\n");
          */
         updateTestContext(context, SchemaModifiers.UdfTestModifier23::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with member [Measures].[ABC] as StringMult(1, 'A')\n"
             + "member [Measures].[Unit Sales Formatted] as\n"
             + "  [Measures].[Unit Sales],\n"
@@ -1162,7 +1162,7 @@ public class UdfTest {
             + "</UserDefinedFunction>\n");
          */
         updateTestContext(context, SchemaModifiers.UdfTestModifier24::new);
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "Factorial(4 + 2)",
             "720");
     }
@@ -1198,7 +1198,7 @@ public class UdfTest {
             + "</UserDefinedFunction>\n");
          */
         updateTestContext(context, SchemaModifiers.UdfTestModifier25::new);
-        final Cell cell = executeExprRaw(context.getConnection(), "Factorial(4 + 2)");
+        final Cell cell = executeExprRaw(context.getConnectionWithDefaultRole(), "Factorial(4 + 2)");
         assertMatchesVerbose(
             Pattern.compile(
                 "(?s).*ReferenceError: \"factorial_xx\" is not defined..*"),
@@ -1224,7 +1224,7 @@ public class UdfTest {
             + "'/>");
          */
         updateTestContext(context, SchemaModifiers.UdfTestModifier1::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Measures].[Unit Sales],\n"
             + "      [Measures].[Unit Sales Foo Bar]} on 0\n"
             + "from [Sales]",
@@ -1259,7 +1259,7 @@ public class UdfTest {
          */
         updateTestContext(context, SchemaModifiers.UdfTestModifier1::new);
 
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Measures].[Unit Sales],\n"
             + "      [Measures].[Unit Sales Foo Bar]} on 0\n"
             + "from [Sales]",
@@ -1295,7 +1295,7 @@ public class UdfTest {
         // Note that the result is slightly different to above (a missing ".0").
         // Not a great concern -- in fact it proves that the scripted UDF is
         // being used.
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Measures].[Unit Sales],\n"
             + "      [Measures].[Unit Sales Foo Bar]} on 0\n"
             + "from [Sales]",
@@ -1328,7 +1328,7 @@ public class UdfTest {
          */
         updateTestContext(context, SchemaModifiers.UdfTestModifier3::new);
 
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Measures].[Unit Sales],\n"
             + "      [Measures].[Unit Sales Foo Bar]} on 0\n"
             + "from [Sales]",
@@ -1361,7 +1361,7 @@ public class UdfTest {
          */
         updateTestContext(context, SchemaModifiers.UdfTestModifier4::new);
 
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Measures].[Unit Sales],\n"
             + "      [Measures].[Unit Sales Foo Bar]} on 0\n"
             + "from [Sales]",
@@ -1398,7 +1398,7 @@ public class UdfTest {
          */
         updateTestContext(context, SchemaModifiers.UdfTestModifier5::new);
 
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Measures].[Unit Sales],\n"
             + "      [Measures].[Unit Sales Foo Bar]} on 0\n"
             + "from [Sales]",
@@ -1433,7 +1433,7 @@ public class UdfTest {
             + "  </Dimension>"));
          */
         updateTestContext(context, SchemaModifiers.UdfTestModifier6::new);
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "[Promotion Media2].FirstChild.Caption",
             "fooBulk Mailbar");
     }
@@ -1462,7 +1462,7 @@ public class UdfTest {
             + "  </Dimension>"));
          */
         updateTestContext(context, SchemaModifiers.UdfTestModifier6::new);
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "[Promotion Media2].FirstChild.Caption",
             "fooBulk Mailbar");
     }
@@ -1493,7 +1493,7 @@ public class UdfTest {
             + "  </Dimension>"));
          */
         updateTestContext(context, SchemaModifiers.UdfTestModifier7::new);
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "[Promotion Media2].FirstChild.Caption",
             "fooBulk Mailbar");
     }
@@ -1524,7 +1524,7 @@ public class UdfTest {
          */
         updateTestContext(context, SchemaModifiers.UdfTestModifier8::new);
         final CellSet result =
-            executeOlap4jQuery(context.getConnection(),
+            executeOlap4jQuery(context.getConnectionWithDefaultRole(),
                 "select [Promotions2].Children on 0\n"
                 + "from [Sales]");
         final Member member =
@@ -1565,7 +1565,7 @@ public class UdfTest {
         updateTestContext(context, SchemaModifiers.UdfTestModifier9::new);
 
         final CellSet result =
-            executeOlap4jQuery(context.getConnection(),
+            executeOlap4jQuery(context.getConnectionWithDefaultRole(),
                 "select [Promotions2].Children on 0\n"
                 + "from [Sales]");
         final Member member =
@@ -1611,7 +1611,7 @@ public class UdfTest {
         updateTestContext(context, SchemaModifiers.UdfTestModifier10::new);
 
         final CellSet result =
-            executeOlap4jQuery(context.getConnection(),
+            executeOlap4jQuery(context.getConnectionWithDefaultRole(),
                 "select [Promotions2].Children on 0\n"
                 + "from [Sales]");
         final Member member =

--- a/mondrian/src/test/java/mondrian/test/clearview/BatchedFillTest.java
+++ b/mondrian/src/test/java/mondrian/test/clearview/BatchedFillTest.java
@@ -53,7 +53,7 @@ class BatchedFillTest extends ClearViewBase {
                 // If agg tables are enabled, the SQL generated is 'better' than
                 // expected.
             } else {
-                super.assertQuerySql(context.getConnection(), true);
+                super.assertQuerySql(context.getConnectionWithDefaultRole(), true);
             }
             super.runTest(context);
         }

--- a/mondrian/src/test/java/mondrian/test/clearview/ClearViewBase.java
+++ b/mondrian/src/test/java/mondrian/test/clearview/ClearViewBase.java
@@ -113,7 +113,7 @@ import mondrian.test.SqlPattern;
 
             String mdx = diffRepos.expand(null, "${mdx}");
             String result = Util.NL + TestUtil.toString(
-                    executeQuery(mdx, context.getConnection()));
+                    executeQuery(mdx, context.getConnectionWithDefaultRole()));
             diffRepos.assertEquals("result", "${result}", result);
     }
 

--- a/mondrian/src/test/java/mondrian/test/loader/CsvDBTestCase.java
+++ b/mondrian/src/test/java/mondrian/test/loader/CsvDBTestCase.java
@@ -47,7 +47,7 @@ public abstract class CsvDBTestCase extends BatchTestCase {
             File inputFile = new File(Constants.TESTFILES_DIR + "/mondrian/rolap/agg/" +  getFileName());
 
             CsvDBLoader loader = new CsvDBLoader(context);
-            loader.setConnection(context.getConnection().getDataSource().getConnection());
+            loader.setConnection(context.getConnectionWithDefaultRole().getDataSource().getConnection());
             loader.initialize();
             loader.setInputFile(inputFile);
             DBLoader.Table[] tables = loader.getTables();

--- a/mondrian/src/test/java/mondrian/util/MemoryMonitorTest.java
+++ b/mondrian/src/test/java/mondrian/util/MemoryMonitorTest.java
@@ -307,7 +307,7 @@ Does not work without the notify on add feature.
 //System.out.println("allready notified");
                 return;
             }
-            Connection conn = context.getConnection();
+            Connection conn = context.getConnectionWithDefaultRole();
 
             final int MAX = 100;
 

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/aggregate/AggregateFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/aggregate/AggregateFunDefTest.java
@@ -31,22 +31,22 @@ class AggregateFunDefTest {
     void testAggregateDepends(Context context) {
         // Depends on everything except Measures, Gender
         String s12 = allHiersExcept("[Measures]", "[Gender]" );
-        assertExprDependsOn(context.getConnection(),
+        assertExprDependsOn(context.getConnectionWithDefaultRole(),
             "([Measures].[Unit Sales], [Gender].[F])", s12 );
         // Depends on everything except Customers, Measures, Gender
         String s13 = allHiersExcept( "[Customers]", "[Gender]" );
-        assertExprDependsOn(context.getConnection(),
+        assertExprDependsOn(context.getConnectionWithDefaultRole(),
             "Aggregate([Customers].Members, ([Measures].[Unit Sales], [Gender].[F]))",
             s13 );
         // Depends on everything except Customers
         String s11 = allHiersExcept( "[Customers]" );
-        assertExprDependsOn(context.getConnection(),
+        assertExprDependsOn(context.getConnectionWithDefaultRole(),
             "Aggregate([Customers].Members)",
             s11 );
         // Depends on the current member of the Product dimension, even though
         // [Product].[All Products] is referenced from the expression.
         String s1 = allHiersExcept( "[Customers]" );
-        assertExprDependsOn(context.getConnection(),
+        assertExprDependsOn(context.getConnectionWithDefaultRole(),
             "Aggregate(Filter([Customers].[City].Members, (([Measures].[Unit Sales] / ([Measures].[Unit Sales], [Product]"
                 + ".[All Products])) > 0.1)))",
             s1 );
@@ -55,7 +55,7 @@ class AggregateFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testAggregate(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH MEMBER [Store].[CA plus OR] AS 'AGGREGATE({[Store].[USA].[CA], [Store].[USA].[OR]})'\n"
                 + "SELECT {[Measures].[Unit Sales], [Measures].[Store Sales]} ON COLUMNS,\n"
                 + "      {[Store].[USA].[CA], [Store].[USA].[OR], [Store].[CA plus OR]} ON ROWS\n"
@@ -81,7 +81,7 @@ class AggregateFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testAggregate2(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH\n"
                 + "  Member [Time].[Time].[1st Half Sales] AS 'Aggregate({Time.[1997].[Q1], Time.[1997].[Q2]})'\n"
                 + "  Member [Time].[Time].[2nd Half Sales] AS 'Aggregate({Time.[1997].[Q3], Time.[1997].[Q4]})'\n"
@@ -143,7 +143,7 @@ class AggregateFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testAggregateWithIIF(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with member store.foo as 'iif(3>1,"
                 + "aggregate({[Store].[All Stores].[USA].[OR]}),"
                 + "aggregate({[Store].[All Stores].[USA].[CA]}))' "
@@ -159,7 +159,7 @@ class AggregateFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testAggregate2AllMembers(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH\n"
                 + "  Member [Time].[Time].[1st Half Sales] AS 'Aggregate({Time.[1997].[Q1], Time.[1997].[Q2]})'\n"
                 + "  Member [Time].[Time].[2nd Half Sales] AS 'Aggregate({Time.[1997].[Q3], Time.[1997].[Q4]})'\n"
@@ -222,7 +222,7 @@ class AggregateFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testAggregateToSimulateCompoundSlicer(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH MEMBER [Time].[Time].[1997 H1] as 'Aggregate({[Time].[1997].[Q1], [Time].[1997].[Q2]})'\n"
                 + "  MEMBER [Education Level].[College or higher] as 'Aggregate({[Education Level].[Bachelors Degree], "
                 + "[Education Level].[Graduate Degree]})'\n"

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/aggregate/avg/AvgFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/aggregate/avg/AvgFunDefTest.java
@@ -26,7 +26,7 @@ class AvgFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testIIfSetType_InCrossJoinAndAvg(Context context) {
-        TestUtil.assertExprReturns(context.getConnection(),
+        TestUtil.assertExprReturns(context.getConnectionWithDefaultRole(),
             "Avg(CROSSJOIN([Store Type].[Deluxe Supermarket],IIf(1 = 1, {[Store].[USA].[OR], [Store].[USA].[WA]}, {[Store]"
                 + ".[Mexico], [Store].[USA].[CA]})), [Measures].[Store Sales])",
             "81,031.12" );

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/aggregate/avg/AvgTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/aggregate/avg/AvgTest.java
@@ -25,14 +25,14 @@ public class AvgTest {
 	@ParameterizedTest
 	@ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
 	void testAvg(Context context) {
-		TestUtil.assertExprReturns(context.getConnection(),
+		TestUtil.assertExprReturns(context.getConnectionWithDefaultRole(),
 				"AVG({[Store].[All Stores].[USA].children})", "88,924");
 	}
 
 	@ParameterizedTest
 	@ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
 	void testAvgNumeric(Context context) {
-		TestUtil.assertExprReturns(context.getConnection(),
+		TestUtil.assertExprReturns(context.getConnectionWithDefaultRole(),
 				"AVG({[Store].[All Stores].[USA].children},[Measures].[Store Sales])", "188,412.71");
 	}
 

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/aggregate/count/CountFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/aggregate/count/CountFunDefTest.java
@@ -31,32 +31,32 @@ class CountFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCount(Context context) {
-        assertExprDependsOn(context.getConnection(),
+        assertExprDependsOn(context.getConnectionWithDefaultRole(),
             "count(Crossjoin([Store].[All Stores].[USA].Children, {[Gender].children}), INCLUDEEMPTY)",
             "{[Gender]}" );
 
         String s1 = allHiersExcept( "[Store]" );
-        assertExprDependsOn(context.getConnection(),
+        assertExprDependsOn(context.getConnectionWithDefaultRole(),
             "count(Crossjoin([Store].[All Stores].[USA].Children, "
                 + "{[Gender].children}), EXCLUDEEMPTY)",
             s1 );
 
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "count({[Promotion Media].[Media Type].members})", "14" );
 
         // applied to an empty set
-        assertExprReturns(context.getConnection(), "count({[Gender].Parent}, IncludeEmpty)", "0" );
+        assertExprReturns(context.getConnectionWithDefaultRole(), "count({[Gender].Parent}, IncludeEmpty)", "0" );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCountExcludeEmpty(Context context) {
         String s1 = allHiersExcept( "[Store]" );
-        assertExprDependsOn(context.getConnection(),
+        assertExprDependsOn(context.getConnectionWithDefaultRole(),
             "count(Crossjoin([Store].[USA].Children, {[Gender].children}), EXCLUDEEMPTY)",
             s1 );
 
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with member [Measures].[Promo Count] as \n"
                 + " ' Count(Crossjoin({[Measures].[Unit Sales]},\n"
                 + " {[Promotion Media].[Media Type].members}), EXCLUDEEMPTY)'\n"
@@ -86,7 +86,7 @@ class CountFunDefTest {
                 + "Row #4: 12\n" );
 
         // applied to an empty set
-        assertExprReturns(context.getConnection(), "count({[Gender].Parent}, ExcludeEmpty)", "0" );
+        assertExprReturns(context.getConnectionWithDefaultRole(), "count({[Gender].Parent}, ExcludeEmpty)", "0" );
     }
 
     /**
@@ -99,7 +99,7 @@ class CountFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCountExcludeEmptyNull(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH MEMBER [Measures].[Foo] AS\n"
                 + "    Iif("
                 + hierarchyName( "Time", "Time" )
@@ -163,7 +163,7 @@ class CountFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCountExcludeEmptyOnCubeWithNoCountFacts(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH "
                 + "  MEMBER [Measures].[count] AS '"
                 + "    COUNT([Store Type].[Store Type].MEMBERS, EXCLUDEEMPTY)'"
@@ -180,7 +180,7 @@ class CountFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCountExcludeEmptyOnVirtualCubeWithNoCountFacts(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH "
                 + "  MEMBER [Measures].[count] AS '"
                 + "    COUNT([Store].MEMBERS, EXCLUDEEMPTY)'"

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/ancestor/AncestorTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/ancestor/AncestorTest.java
@@ -35,7 +35,7 @@ public class AncestorTest {
 	@ParameterizedTest
 	@ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
 	void testAncestor(Context context) {
-		Connection con = context.getConnection();
+		Connection con = context.getConnectionWithDefaultRole();
 		Member member = TestUtil.executeSingletonAxis(con,
 				"Ancestor([Store].[USA].[CA].[Los Angeles],[Store Country])");
 		assertEquals("USA", member.getName());
@@ -48,7 +48,7 @@ public class AncestorTest {
 	@ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
 	//
 	void testAncestorNumeric(Context context) {
-		Connection con = context.getConnection();
+		Connection con = context.getConnectionWithDefaultRole();
 
 		Member member = executeSingletonAxis(con, "Ancestor([Store].[USA].[CA].[Los Angeles],1)");
 		assertEquals("CA", member.getName());
@@ -76,14 +76,14 @@ public class AncestorTest {
 	@ParameterizedTest
 	@ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
 	void testAncestorHigher(Context context) {
-		Member member = executeSingletonAxis(context.getConnection(), "Ancestor([Store].[USA],[Store].[Store City])");
+		Member member = executeSingletonAxis(context.getConnectionWithDefaultRole(), "Ancestor([Store].[USA],[Store].[Store City])");
 		assertNull(member); // MSOLAP returns null
 	}
 
 	@ParameterizedTest
 	@ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
 	void testAncestorSameLevel(Context context) {
-		Member member = executeSingletonAxis(context.getConnection(),
+		Member member = executeSingletonAxis(context.getConnectionWithDefaultRole(),
 				"Ancestor([Store].[Canada],[Store].[Store Country])");
 		assertEquals("Canada", member.getName());
 	}
@@ -93,14 +93,14 @@ public class AncestorTest {
 	void testAncestorWrongHierarchy(Context context) {
 		// MSOLAP gives error "Formula error - dimensions are not
 		// valid (they do not match) - in the Ancestor function"
-		assertAxisThrows(context.getConnection(), "Ancestor([Gender].[M],[Store].[Store Country])",
+		assertAxisThrows(context.getConnectionWithDefaultRole(), "Ancestor([Gender].[M],[Store].[Store Country])",
 				"Error while executing query");
 	}
 
 	@ParameterizedTest
 	@ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
 	void testAncestorAllLevel(Context context) {
-		Member member = executeSingletonAxis(context.getConnection(), "Ancestor([Store].[USA].[CA],[Store].Levels(0))");
+		Member member = executeSingletonAxis(context.getConnectionWithDefaultRole(), "Ancestor([Store].[USA].[CA],[Store].Levels(0))");
 		assertTrue(member.isAll());
 	}
 
@@ -109,7 +109,7 @@ public class AncestorTest {
 	void testAncestorWithHiddenParent(Context context) {
 		// final Context testContext =
 		// getContext().withCube( "[Sales Ragged]" );
-		Member member = executeSingletonAxis(context.getConnection(),
+		Member member = executeSingletonAxis(context.getConnectionWithDefaultRole(),
 				"Ancestor([Store].[All Stores].[Israel].[Haifa], [Store].[Store Country])", "[Sales Ragged]");
 
 		assertNotNull(member, "Member must not be null.");
@@ -119,7 +119,7 @@ public class AncestorTest {
 	@ParameterizedTest
 	@ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
 	void testAncestorDepends(Context context) {
-		Connection con = context.getConnection();
+		Connection con = context.getConnectionWithDefaultRole();
 		assertExprDependsOn(con, "Ancestor([Store].CurrentMember, [Store].[Store Country]).Name", "{[Store]}");
 
 		assertExprDependsOn(con, "Ancestor([Store].[All Stores].[USA], [Store].CurrentMember.Level).Name", "{[Store]}");

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/as/AsAliasFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/as/AsAliasFunDefTest.java
@@ -45,7 +45,7 @@ public class AsAliasFunDefTest {
 	@ParameterizedTest
 	@ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
 	void testAs(Context context) {
-		assertAxisReturns(context.getConnection(), "Filter([Customers].Children as t,\n" + "t.Current.Name = 'USA')",
+		assertAxisReturns(context.getConnectionWithDefaultRole(), "Filter([Customers].Children as t,\n" + "t.Current.Name = 'USA')",
 				"[Customers].[USA]");
 	}
 
@@ -54,7 +54,7 @@ public class AsAliasFunDefTest {
 	void testAsWithColon(Context context) {
 		// 'AS' and the ':' operator have similar precedence, so it's worth
 		// checking that they play nice.
-		assertQueryReturns(context.getConnection(), """
+		assertQueryReturns(context.getConnectionWithDefaultRole(), """
 				select
 				  filter(
 				    [Time].[1997].[Q1].[2] : [Time].[1997].[Q3].[9] as t,\
@@ -91,7 +91,7 @@ public class AsAliasFunDefTest {
 	@ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
 	void testAsWithSetOfMembers(Context context) {
 		// Set of members. OK.
-		assertQueryReturns(context.getConnection(), """
+		assertQueryReturns(context.getConnectionWithDefaultRole(), """
 				select Measures.[Unit Sales] on 0,\s
 				  {[Time].[1997].Children as t,\s
 				   Descendants(t, [Time].[Month])} on 1\s
@@ -141,7 +141,7 @@ public class AsAliasFunDefTest {
 	@ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
 	void testAsWithAliasMemberImplicitSet(Context context) {
 		// Alias a member. Implicitly becomes set. OK.
-		assertQueryReturns(context.getConnection(), """
+		assertQueryReturns(context.getConnectionWithDefaultRole(), """
 				select Measures.[Unit Sales] on 0,
 				  {[Time].[1997] as t,
 				   Descendants(t, [Time].[Month])} on 1
@@ -231,7 +231,7 @@ public class AsAliasFunDefTest {
 		// Named set and alias with same name (t) and a second alias (t2).
 		// Reference to t from within descendants resolves to alias, of type
 		// [Time], because it is nearer.
-		assertQueryReturns(context.getConnection(), """
+		assertQueryReturns(context.getConnectionWithDefaultRole(), """
 				with set t as [Gender].Children
 				select
 				  Measures.[Unit Sales] * t on 0,
@@ -249,7 +249,7 @@ public class AsAliasFunDefTest {
 	@ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
 	void testAsWith2AliasesOfSameName(Context context) {
 		// Two aliases with same name. OK.
-		assertQueryReturns(context.getConnection(), """
+		assertQueryReturns(context.getConnectionWithDefaultRole(), """
 				select
 				  Measures.[Unit Sales] * [Gender].Children as t on 0,
 				  {[Time].[1997].Children as t,
@@ -267,7 +267,7 @@ public class AsAliasFunDefTest {
 		// Bug MONDRIAN-648 causes 'AS' to have lower precedence than '*'.
 		if (Bug.BugMondrian648Fixed) {
 			// Note that 'as' has higher precedence than '*'.
-			assertQueryReturns(context.getConnection(), """
+			assertQueryReturns(context.getConnectionWithDefaultRole(), """
 					select
 					  Measures.[Unit Sales] * [Gender].Members as t on 0,
 					  {t} on 1
@@ -304,7 +304,7 @@ public class AsAliasFunDefTest {
 	@ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
 	void testAsWithCalcSetCurrMember(Context context) {
 		// Calculated set, CurrentMember
-		assertQueryReturns(context.getConnection(), """
+		assertQueryReturns(context.getConnectionWithDefaultRole(), """
 				select Measures.[Unit Sales] on 0,
 				  filter(
 				    (Time.Month.Members * Gender.Members) as s,
@@ -338,7 +338,7 @@ public class AsAliasFunDefTest {
 		// As above, but don't override [Gender] in filter condition. Note that
 		// the filter condition is evaluated in the context created by the
 		// filter set. So, only items with [All Gender] pass the filter.
-		assertQueryReturns(context.getConnection(), """
+		assertQueryReturns(context.getConnectionWithDefaultRole(), """
 				select Measures.[Unit Sales] on 0,
 				  filter(
 				    (Time.Month.Members * Gender.Members) as s,
@@ -363,7 +363,7 @@ public class AsAliasFunDefTest {
 	@ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
 	void testAsWithMultiDefOfAliasInSameAxis(Context context) {
 		// Multiple definitions of alias within same axis
-		assertQueryReturns(context.getConnection(), """
+		assertQueryReturns(context.getConnectionWithDefaultRole(), """
 				select Measures.[Unit Sales] on 0,
 				  generate(
 				    [Marital Status].Children as s,
@@ -454,7 +454,7 @@ public class AsAliasFunDefTest {
 	@ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
 	void testAsWithFailingSetAsString(Context context) {
 		// 'set AS string' is invalid
-		assertQueryThrows(context.getConnection(), """
+		assertQueryThrows(context.getConnectionWithDefaultRole(), """
 				select Measures.[Unit Sales] on 0,
 				  filter(
 				    (Time.Month.Members * Gender.Members) as 'foo',
@@ -467,7 +467,7 @@ public class AsAliasFunDefTest {
 	@ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
 	void testAsWithFailingSetAsNumeric(Context context) {
 		// 'set AS numeric' is invalid
-		assertQueryThrows(context.getConnection(), """
+		assertQueryThrows(context.getConnectionWithDefaultRole(), """
 				select Measures.[Unit Sales] on 0,
 				  filter(
 				    (Time.Month.Members * Gender.Members) as 1234,
@@ -480,7 +480,7 @@ public class AsAliasFunDefTest {
 	@ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
 	void testAsWithFailingNumericAsIdentifier(Context context) {
 		// 'numeric AS identifier' is invalid
-		assertQueryThrows(context.getConnection(), """
+		assertQueryThrows(context.getConnectionWithDefaultRole(), """
 				select Measures.[Unit Sales] on 0,
 				  filter(
 				    123 * 456 as s,

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/cache/CacheFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/cache/CacheFunDefTest.java
@@ -30,24 +30,24 @@ class CacheFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCache(Context context) {
         // test various data types: integer, string, member, set, tuple
-        assertExprReturns(context.getConnection(), "Cache(1 + 2)", "3" );
-        assertExprReturns(context.getConnection(), "Cache('foo' || 'bar')", "foobar" );
-        assertAxisReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(), "Cache(1 + 2)", "3" );
+        assertExprReturns(context.getConnectionWithDefaultRole(), "Cache('foo' || 'bar')", "foobar" );
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "[Gender].Children",
             "[Gender].[F]\n"
                 + "[Gender].[M]" );
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "([Gender].[M], [Marital Status].[S].PrevMember)",
             "{[Gender].[M], [Marital Status].[M]}" );
 
         // inside another expression
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Order(Cache([Gender].Children), Cache(([Measures].[Unit Sales], [Time].[1997].[Q1])), BDESC)",
             "[Gender].[M]\n"
                 + "[Gender].[F]" );
 
         // doesn't work with multiple args
-        assertExprThrows(context.getConnection(),
+        assertExprThrows(context.getConnectionWithDefaultRole(),
             "Cache(1, 2)",
             "No function matches signature 'Cache(<Numeric Expression>, <Numeric Expression>)'" );
     }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/caption/dimension/CaptionFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/caption/dimension/CaptionFunDefTest.java
@@ -25,6 +25,6 @@ class CaptionFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDimensionCaption(Context context) {
-        TestUtil.assertExprReturns(context.getConnection(), "[Time].[1997].Dimension.Caption", "Time" );
+        TestUtil.assertExprReturns(context.getConnectionWithDefaultRole(), "[Time].[1997].Dimension.Caption", "Time" );
     }
 }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/caption/hierarchy/CaptionFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/caption/hierarchy/CaptionFunDefTest.java
@@ -26,7 +26,7 @@ class CaptionFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testHierarchyCaption(Context context) {
-        TestUtil.assertExprReturns(context.getConnection(), "[Time].[1997].Hierarchy.Caption", "Time" );
+        TestUtil.assertExprReturns(context.getConnectionWithDefaultRole(), "[Time].[1997].Hierarchy.Caption", "Time" );
     }
 
 }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/caption/level/CaptionFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/caption/level/CaptionFunDefTest.java
@@ -25,7 +25,7 @@ class CaptionFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testLevelCaption(Context context) {
-        TestUtil.assertExprReturns(context.getConnection(), "[Time].[1997].Level.Caption", "Year" );
+        TestUtil.assertExprReturns(context.getConnectionWithDefaultRole(), "[Time].[1997].Level.Caption", "Year" );
     }
 
 }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/caption/member/CaptionFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/caption/member/CaptionFunDefTest.java
@@ -26,13 +26,13 @@ class CaptionFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testMemberCaption(Context context) {
-        TestUtil.assertExprReturns(context.getConnection(), "[Time].[1997].Caption", "1997" );
+        TestUtil.assertExprReturns(context.getConnectionWithDefaultRole(), "[Time].[1997].Caption", "1997" );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testGetCaptionUsingMemberDotCaption(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "SELECT Filter(Store.allmembers, "
                 + "[store].currentMember.caption = \"USA\") on 0 FROM SALES",
             "Axis #0:\n"

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/coalesceempty/CoalesceEmptyFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/coalesceempty/CoalesceEmptyFunDefTest.java
@@ -32,11 +32,11 @@ class CoalesceEmptyFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCoalesceEmptyDepends(Context context) {
-        assertExprDependsOn(context.getConnection(),
+        assertExprDependsOn(context.getConnectionWithDefaultRole(),
             "coalesceempty([Time].[1997], [Gender].[M])",
             allHiers() );
         String s1 = allHiersExcept( "[Measures]", "[Time]" );
-        assertExprDependsOn(context.getConnection(),
+        assertExprDependsOn(context.getConnectionWithDefaultRole(),
             "coalesceempty(([Measures].[Unit Sales], [Time].[1997]),"
                 + " ([Measures].[Store Sales], [Time].[1997].[Q2]))",
             s1 );
@@ -46,7 +46,7 @@ class CoalesceEmptyFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCoalesceEmpty(Context context) {
         // [DF] is all null and [WA] has numbers for 1997 but not for 1998.
-        Result result = executeQuery(context.getConnection(),
+        Result result = executeQuery(context.getConnectionWithDefaultRole(),
             "with\n"
                 + "    member Measures.[Coal1] as 'coalesceempty(([Time].[1997], Measures.[Store Sales]), ([Time].[1998], "
                 + "Measures.[Store Sales]))'\n"
@@ -66,7 +66,7 @@ class CoalesceEmptyFunDefTest {
             result,
             0.001 );
 
-        result = executeQuery(context.getConnection(),
+        result = executeQuery(context.getConnectionWithDefaultRole(),
             "with\n"
                 + "    member Measures.[Sales Per Customer] as 'Measures.[Sales Count] / Measures.[Customer Count]'\n"
                 + "    member Measures.[Coal] as 'coalesceempty(([Measures].[Sales Per Customer], [Store].[All Stores]"
@@ -88,7 +88,7 @@ class CoalesceEmptyFunDefTest {
             result,
             0.001 );
 
-        result = executeQuery(context.getConnection(),
+        result = executeQuery(context.getConnectionWithDefaultRole(),
             "with\n"
                 + "    member Measures.[Sales Per Customer] as 'Measures.[Sales Count] / Measures.[Customer Count]'\n"
                 + "    member Measures.[Coal] as 'coalesceempty(([Measures].[Sales Per Customer], [Store].[All Stores]"
@@ -121,7 +121,7 @@ class CoalesceEmptyFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCoalesceEmpty2(Context context) {
-        Result result = executeQuery(context.getConnection(),
+        Result result = executeQuery(context.getConnectionWithDefaultRole(),
             "with\n"
                 + "    member Measures.[Sales Per Customer] as 'Measures.[Sales Count] / Measures.[Customer Count]'\n"
                 + "    member Measures.[Coal] as 'coalesceempty(([Measures].[Sales Per Customer], [Store].[All Stores]"
@@ -147,7 +147,7 @@ class CoalesceEmptyFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testBrokenContextBug(Context context) {
-        Result result = executeQuery(context.getConnection(),
+        Result result = executeQuery(context.getConnectionWithDefaultRole(),
             "with\n"
                 + "    member Measures.[Sales Per Customer] as 'Measures.[Sales Count] / Measures.[Customer Count]'\n"
                 + "    member Measures.[Coal] as 'coalesceempty(([Measures].[Sales Per Customer], [Store].[All Stores]"

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/correlation/CorrelationFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/correlation/CorrelationFunDefTest.java
@@ -27,7 +27,7 @@ class CorrelationFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCorrelation(Context context) {
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "Correlation({[Store].[All Stores].[USA].children}, [Measures].[Unit Sales], [Measures].[Store Sales]) * 1000000",
             "999,906" );
     }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/covariance/CovarianceFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/covariance/CovarianceFunDefTest.java
@@ -27,7 +27,7 @@ class CovarianceFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCovariance(Context context) {
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "Covariance({[Store].[All Stores].[USA].children}, [Measures].[Unit Sales], [Measures].[Store Sales])",
             "1,355,761,899" );
     }
@@ -35,7 +35,7 @@ class CovarianceFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCovarianceN(Context context) {
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "CovarianceN({[Store].[All Stores].[USA].children}, [Measures].[Unit Sales], [Measures].[Store Sales])",
             "2,033,642,849" );
     }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/crossjoin/CrossJoinFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/crossjoin/CrossJoinFunDefTest.java
@@ -31,7 +31,7 @@ class CrossJoinFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCrossjoinNested(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "  CrossJoin(\n"
                 + "    CrossJoin(\n"
                 + "      [Gender].members,\n"
@@ -79,7 +79,7 @@ class CrossJoinFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCrossjoinSingletonTuples(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "CrossJoin({([Gender].[M])}, {([Marital Status].[S])})",
             "{[Gender].[M], [Marital Status].[S]}" );
     }
@@ -87,7 +87,7 @@ class CrossJoinFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCrossjoinSingletonTuplesNested(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "CrossJoin({([Gender].[M])}, CrossJoin({([Marital Status].[S])}, [Store].children))",
             "{[Gender].[M], [Marital Status].[S], [Store].[Canada]}\n"
                 + "{[Gender].[M], [Marital Status].[S], [Store].[Mexico]}\n"
@@ -97,7 +97,7 @@ class CrossJoinFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCrossjoinAsterisk(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "{[Gender].[M]} * {[Marital Status].[S]}",
             "{[Gender].[M], [Marital Status].[S]}" );
     }
@@ -105,7 +105,7 @@ class CrossJoinFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCrossjoinAsteriskTuple(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Measures].[Unit Sales]} ON COLUMNS, "
                 + "NON EMPTY [Store].[All Stores] "
                 + " * ([Product].[All Products], [Gender]) "
@@ -123,7 +123,7 @@ class CrossJoinFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCrossjoinAsteriskAssoc(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Order({[Gender].Children} * {[Marital Status].Children} * {[Time].[1997].[Q2].Children},"
                 + "[Measures].[Unit Sales])",
             "{[Gender].[F], [Marital Status].[M], [Time].[1997].[Q2].[4]}\n"
@@ -143,7 +143,7 @@ class CrossJoinFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCrossjoinAsteriskInsideBraces(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "{[Gender].[M] * [Marital Status].[S] * [Time].[1997].[Q2].Children}",
             "{[Gender].[M], [Marital Status].[S], [Time].[1997].[Q2].[4]}\n"
                 + "{[Gender].[M], [Marital Status].[S], [Time].[1997].[Q2].[5]}\n"
@@ -153,7 +153,7 @@ class CrossJoinFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCrossJoinAsteriskQuery(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "SELECT {[Measures].members * [1997].children} ON COLUMNS,\n"
                 + " {[Store].[USA].children * [Position].[All Position].children} DIMENSION PROPERTIES [Store].[Store SQFT] "
                 + "ON ROWS\n"
@@ -378,7 +378,7 @@ class CrossJoinFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCrossjoinResolve(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with\n"
                 + "member [Measures].[Filtered Unit Sales] as\n"
                 + " 'IIf((([Measures].[Unit Sales] > 50000.0)\n"
@@ -411,7 +411,7 @@ class CrossJoinFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCrossjoinOrder(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH\n"
                 + "\n"
                 + "SET [S1] AS 'CROSSJOIN({[Time].[1997]}, {[Gender].[Gender].MEMBERS})'\n"
@@ -431,21 +431,21 @@ class CrossJoinFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCrossjoinDupHierarchyFails(Context context) {
-        assertQueryThrows(context.getConnection(),
+        assertQueryThrows(context.getConnectionWithDefaultRole(),
             "select [Measures].[Unit Sales] ON COLUMNS,\n"
                 + " CrossJoin({[Time].[Quarter].[Q1]}, {[Time].[Month].[5]}) ON ROWS\n"
                 + "from [Sales]",
             "Tuple contains more than one member of hierarchy '[Time]'." );
 
         // now with Item, for kicks
-        assertQueryThrows(context.getConnection(),
+        assertQueryThrows(context.getConnectionWithDefaultRole(),
             "select [Measures].[Unit Sales] ON COLUMNS,\n"
                 + " CrossJoin({[Time].[Quarter].[Q1]}, {[Time].[Month].[5]}).Item(0) ON ROWS\n"
                 + "from [Sales]",
             "Tuple contains more than one member of hierarchy '[Time]'." );
 
         // same query using explicit tuple
-        assertQueryThrows(context.getConnection(),
+        assertQueryThrows(context.getConnectionWithDefaultRole(),
             "select [Measures].[Unit Sales] ON COLUMNS,\n"
                 + " ([Time].[Quarter].[Q1], [Time].[Month].[5]) ON ROWS\n"
                 + "from [Sales]",
@@ -469,7 +469,7 @@ class CrossJoinFunDefTest {
                 + "{[Time].[1997].[Q1], [Time.Weekly].[1997].[10]}\n"
                 + "Row #0: 4,395\n";
         final String timeWeekly = hierarchyName( "Time", "Weekly" );
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select [Measures].[Unit Sales] ON COLUMNS,\n"
                 + " CrossJoin({[Time].[Quarter].[Q1]}, {"
                 + timeWeekly + ".[1997].[10]}) ON ROWS\n"
@@ -477,7 +477,7 @@ class CrossJoinFunDefTest {
             expectedResult );
 
         // now with Item, for kicks
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select [Measures].[Unit Sales] ON COLUMNS,\n"
                 + " CrossJoin({[Time].[Quarter].[Q1]}, {"
                 + timeWeekly + ".[1997].[10]}).Item(0) ON ROWS\n"
@@ -485,7 +485,7 @@ class CrossJoinFunDefTest {
             expectedResult );
 
         // same query using explicit tuple
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select [Measures].[Unit Sales] ON COLUMNS,\n"
                 + " ([Time].[Quarter].[Q1], "
                 + timeWeekly + ".[1997].[10]) ON ROWS\n"
@@ -497,7 +497,7 @@ class CrossJoinFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testItemTuple(Context context) {
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "CrossJoin([Gender].[All Gender].children, "
                 + "[Time].[1997].[Q2].children).Item(0).Item(1).UniqueName",
             "[Time].[1997].[Q2].[4]" );

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/descendants/DescendantsByLevelFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/descendants/DescendantsByLevelFunDefTest.java
@@ -41,7 +41,7 @@ class DescendantsByLevelFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDescendantsM(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Descendants([Time].[1997].[Q1])",
             "[Time].[1997].[Q1]\n"
                 + "[Time].[1997].[Q1].[1]\n"
@@ -52,7 +52,7 @@ class DescendantsByLevelFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDescendantsDepends(Context context) {
-        assertSetExprDependsOn(context.getConnection(),
+        assertSetExprDependsOn(context.getConnectionWithDefaultRole(),
             "Descendants([Time].[Time].CurrentMember)",
             "{[Time]}" );
     }
@@ -60,7 +60,7 @@ class DescendantsByLevelFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDescendantsML(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Descendants([Time].[1997], [Time].[Month])",
             months );
     }
@@ -68,7 +68,7 @@ class DescendantsByLevelFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDescendantsMLSelf(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Descendants([Time].[1997], [Time].[Quarter], SELF)",
             quarters );
     }
@@ -76,17 +76,17 @@ class DescendantsByLevelFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDescendantsMLLeaves(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Descendants([Time].[1997], [Time].[Year], LEAVES)",
             "[Time].[1997]" );
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Descendants([Time].[1997], [Time].[Quarter], LEAVES)",
             "[Time].[1997].[Q1]\n" + "[Time].[1997].[Q2]\n" + "[Time].[1997].[Q3]\n" + "[Time].[1997].[Q4]" );
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Descendants([Time].[1997], [Time].[Month], LEAVES)",
             months );
 
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Descendants([Gender], [Gender].[Gender], leaves)",
             "[Gender].[F]\n" + "[Gender].[M]" );
     }
@@ -97,19 +97,19 @@ class DescendantsByLevelFunDefTest {
         // no cities are at leaf level
         //final TestContext raggedContext =
         //  getTestContext().withCube( "[Sales Ragged]" );
-        assertAxisReturns(context.getConnection(), "[Sales Ragged]",
+        assertAxisReturns(context.getConnectionWithDefaultRole(), "[Sales Ragged]",
             "Descendants([Store].[Israel], [Store].[Store City], leaves)",
             "[Store].[Israel].[Israel].[Haifa]\n" + "[Store].[Israel].[Israel].[Tel Aviv]" );
 
         // all cities are leaves
-        assertAxisReturns(context.getConnection(), "[Sales Ragged]",
+        assertAxisReturns(context.getConnectionWithDefaultRole(), "[Sales Ragged]",
             "Descendants([Geography].[Israel], [Geography].[City], leaves)",
             "[Geography].[Israel].[Israel].[Haifa]\n"
                 + "[Geography].[Israel].[Israel].[Tel Aviv]" );
 
         // No state is a leaf (not even Israel, which is both a country and a
         // a state, or Vatican, with is a country/state/city)
-        assertAxisReturns(context.getConnection(), "[Sales Ragged]",
+        assertAxisReturns(context.getConnectionWithDefaultRole(), "[Sales Ragged]",
             "Descendants([Geography], [Geography].[State], leaves)",
             "[Geography].[Canada].[BC]\n" +
                 "[Geography].[Mexico].[DF]\n" +
@@ -130,30 +130,30 @@ class DescendantsByLevelFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDescendantsMNLeaves(Context context) {
         // leaves at depth 0 returns the member itself
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Descendants([Time].[1997].[Q2].[4], 0, Leaves)",
             "[Time].[1997].[Q2].[4]" );
 
         // leaves at depth > 0 returns the member itself
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Descendants([Time].[1997].[Q2].[4], 100, Leaves)",
             "[Time].[1997].[Q2].[4]" );
 
         // leaves at depth < 0 returns all descendants
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Descendants([Time].[1997].[Q2], -1, Leaves)",
             "[Time].[1997].[Q2].[4]\n"
                 + "[Time].[1997].[Q2].[5]\n"
                 + "[Time].[1997].[Q2].[6]" );
 
         // leaves at depth 0 returns the member itself
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Descendants([Time].[1997].[Q2], 0, Leaves)",
             "[Time].[1997].[Q2].[4]\n"
                 + "[Time].[1997].[Q2].[5]\n"
                 + "[Time].[1997].[Q2].[6]" );
 
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Descendants([Time].[1997].[Q2], 3, Leaves)",
             "[Time].[1997].[Q2].[4]\n"
                 + "[Time].[1997].[Q2].[5]\n"
@@ -163,7 +163,7 @@ class DescendantsByLevelFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDescendantsMLSelfBefore(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Descendants([Time].[1997], [Time].[Quarter], SELF_AND_BEFORE)",
             year1997 + "\n" + quarters );
     }
@@ -171,7 +171,7 @@ class DescendantsByLevelFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDescendantsMLSelfBeforeAfter(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Descendants([Time].[1997], [Time].[Quarter], SELF_BEFORE_AFTER)",
             hierarchized1997 );
     }
@@ -179,14 +179,14 @@ class DescendantsByLevelFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDescendantsMLBefore(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Descendants([Time].[1997], [Time].[Quarter], BEFORE)", year1997 );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDescendantsMLBeforeAfter(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Descendants([Time].[1997], [Time].[Quarter], BEFORE_AND_AFTER)",
             year1997 + "\n" + months );
     }
@@ -194,56 +194,56 @@ class DescendantsByLevelFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDescendantsMLAfter(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Descendants([Time].[1997], [Time].[Quarter], AFTER)", months );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDescendantsMLAfterEnd(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Descendants([Time].[1997], [Time].[Month], AFTER)", "" );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDescendantsM0(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Descendants([Time].[1997], 0)", year1997 );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDescendantsM2(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Descendants([Time].[1997], 2)", months );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDescendantsM2Self(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Descendants([Time].[1997], 2, Self)", months );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDescendantsM2Leaves(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Descendants([Time].[1997], 2, Leaves)", months );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDescendantsMFarLeaves(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Descendants([Time].[1997], 10000, Leaves)", months );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDescendantsMEmptyLeaves(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Descendants([Time].[1997], , Leaves)",
             months );
     }
@@ -251,7 +251,7 @@ class DescendantsByLevelFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDescendantsMEmptyLeavesFail(Context context) {
-        assertAxisThrows(context.getConnection(),
+        assertAxisThrows(context.getConnectionWithDefaultRole(),
             "Descendants([Time].[1997],)",
             "No function matches signature 'Descendants(<Member>, <Empty>)" );
     }
@@ -259,7 +259,7 @@ class DescendantsByLevelFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDescendantsMEmptyLeavesFail2(Context context) {
-        assertAxisThrows(context.getConnection(),
+        assertAxisThrows(context.getConnectionWithDefaultRole(),
             "Descendants([Time].[1997], , AFTER)",
             "depth must be specified unless DESC_FLAG is LEAVES" );
     }
@@ -267,7 +267,7 @@ class DescendantsByLevelFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDescendantsMFarSelf(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Descendants([Time].[1997], 10000, Self)",
             "" );
     }
@@ -275,7 +275,7 @@ class DescendantsByLevelFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDescendantsMNY(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Descendants([Time].[1997], 1, BEFORE_AND_AFTER)",
             year1997 + "\n" + months );
     }
@@ -283,7 +283,7 @@ class DescendantsByLevelFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDescendants2ndHier(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Descendants([Time.Weekly].[1997].[10], [Time.Weekly].[Day])",
             "[Time].[Weekly].[1997].[10].[1]\n"
                 + "[Time].[Weekly].[1997].[10].[23]\n"
@@ -298,7 +298,7 @@ class DescendantsByLevelFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDescendantsParentChild(Context context) {
         //getTestContext().withCube( "HR" ).
-        assertAxisReturns(context.getConnection(), "HR",
+        assertAxisReturns(context.getConnectionWithDefaultRole(), "HR",
             "Descendants([Employees], 2)",
             "[Employees].[Sheri Nowmer].[Derrick Whelply]\n"
                 + "[Employees].[Sheri Nowmer].[Michael Spence]\n"
@@ -312,7 +312,7 @@ class DescendantsByLevelFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDescendantsParentChildBefore(Context context) {
-        assertAxisReturns(context.getConnection(), "HR",
+        assertAxisReturns(context.getConnectionWithDefaultRole(), "HR",
             "Descendants([Employees], 2, BEFORE)",
             "[Employees].[All Employees]\n"
                 + "[Employees].[Sheri Nowmer]" );
@@ -323,13 +323,13 @@ class DescendantsByLevelFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDescendantsParentChildLeaves(Context context) {
         //final TestContext testContext = getTestContext().withCube( "HR" );
-        DataSource dataSource = context.getConnection().getDataSource();
+        DataSource dataSource = context.getConnectionWithDefaultRole().getDataSource();
         if (Bug.avoidSlowTestOnLucidDB( context.getDialect())) {
             return;
         }
 
         // leaves, restricted by level
-        assertAxisReturns(context.getConnection(), "HR",
+        assertAxisReturns(context.getConnectionWithDefaultRole(), "HR",
             "Descendants([Employees].[All Employees].[Sheri Nowmer].[Michael Spence], [Employees].[Employee Id], LEAVES)",
             "[Employees].[Sheri Nowmer].[Michael Spence].[Daniel Wolter].[Michael John Troyer].[Mary Sandidge].[John "
                 + "Brooks]\n"
@@ -492,9 +492,9 @@ class DescendantsByLevelFunDefTest {
                 + "[Employees].[Sheri Nowmer].[Michael Spence].[Dianne Collins].[Lawrence Hurkett].[Carol Ann Rockne]" );
 
         // leaves, restricted by depth
-        assertAxisReturns(context.getConnection(), "HR",
+        assertAxisReturns(context.getConnectionWithDefaultRole(), "HR",
             "Descendants([Employees], 1, LEAVES)", "" );
-        assertAxisReturns(context.getConnection(), "HR",
+        assertAxisReturns(context.getConnectionWithDefaultRole(), "HR",
             "Descendants([Employees], 2, LEAVES)",
             "[Employees].[Sheri Nowmer].[Roberta Damstra].[Jennifer Cooper]\n"
                 + "[Employees].[Sheri Nowmer].[Roberta Damstra].[Peggy Petty]\n"
@@ -513,7 +513,7 @@ class DescendantsByLevelFunDefTest {
                 + "[Employees].[Sheri Nowmer].[Donna Arnold].[Howard Bechard]\n"
                 + "[Employees].[Sheri Nowmer].[Donna Arnold].[Doris Carter]" );
 
-        assertAxisReturns(context.getConnection(), "HR",
+        assertAxisReturns(context.getConnectionWithDefaultRole(), "HR",
             "Descendants([Employees], 3, LEAVES)",
             "[Employees].[Sheri Nowmer].[Roberta Damstra].[Jennifer Cooper]\n"
                 + "[Employees].[Sheri Nowmer].[Roberta Damstra].[Peggy Petty]\n"
@@ -533,7 +533,7 @@ class DescendantsByLevelFunDefTest {
                 + "[Employees].[Sheri Nowmer].[Donna Arnold].[Doris Carter]" );
 
         // note that depth is RELATIVE to the starting member
-        assertAxisReturns(context.getConnection(), "HR",
+        assertAxisReturns(context.getConnectionWithDefaultRole(), "HR",
             "Descendants([Employees].[Sheri Nowmer].[Roberta Damstra], 1, LEAVES)",
             "[Employees].[Sheri Nowmer].[Roberta Damstra].[Jennifer Cooper]\n"
                 + "[Employees].[Sheri Nowmer].[Roberta Damstra].[Peggy Petty]\n"
@@ -541,26 +541,26 @@ class DescendantsByLevelFunDefTest {
                 + "[Employees].[Sheri Nowmer].[Roberta Damstra].[Phyllis Burchett]" );
 
         // Howard Bechard is a leaf member -- appears even at depth 0
-        assertAxisReturns(context.getConnection(), "HR",
+        assertAxisReturns(context.getConnectionWithDefaultRole(), "HR",
             "Descendants([Employees].[All Employees].[Sheri Nowmer].[Donna Arnold].[Howard Bechard], 0, LEAVES)",
             "[Employees].[Sheri Nowmer].[Donna Arnold].[Howard Bechard]" );
-        assertAxisReturns(context.getConnection(), "HR",
+        assertAxisReturns(context.getConnectionWithDefaultRole(), "HR",
             "Descendants([Employees].[All Employees].[Sheri Nowmer].[Donna Arnold].[Howard Bechard], 1, LEAVES)",
             "[Employees].[Sheri Nowmer].[Donna Arnold].[Howard Bechard]" );
 
-        TestUtil.assertExprReturns(context.getConnection(), "HR",
+        TestUtil.assertExprReturns(context.getConnectionWithDefaultRole(), "HR",
             "Count(Descendants([Employees], 2, LEAVES))", "16" );
-        TestUtil.assertExprReturns(context.getConnection(), "HR",
+        TestUtil.assertExprReturns(context.getConnectionWithDefaultRole(), "HR",
             "Count(Descendants([Employees], 3, LEAVES))", "16" );
-        TestUtil.assertExprReturns(context.getConnection(), "HR",
+        TestUtil.assertExprReturns(context.getConnectionWithDefaultRole(), "HR",
             "Count(Descendants([Employees], 4, LEAVES))", "63" );
-        TestUtil.assertExprReturns(context.getConnection(), "HR",
+        TestUtil.assertExprReturns(context.getConnectionWithDefaultRole(), "HR",
             "Count(Descendants([Employees], 999, LEAVES))", "1,044" );
 
         // Negative depth acts like +infinity (per MSAS).  Run the test several
         // times because we had a non-deterministic bug here.
         for ( int i = 0; i < 100; ++i ) {
-            TestUtil.assertExprReturns(context.getConnection(), "HR",
+            TestUtil.assertExprReturns(context.getConnectionWithDefaultRole(), "HR",
                 "Count(Descendants([Employees], -1, LEAVES))", "1,044" );
         }
     }
@@ -568,7 +568,7 @@ class DescendantsByLevelFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDescendantsSBA(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Descendants([Time].[1997], 1, SELF_BEFORE_AFTER)",
             hierarchized1997 );
     }
@@ -576,7 +576,7 @@ class DescendantsByLevelFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDescendantsSet(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Descendants({[Time].[1997].[Q4], [Time].[1997].[Q2]}, 1)",
             "[Time].[1997].[Q4].[10]\n"
                 + "[Time].[1997].[Q4].[11]\n"
@@ -584,7 +584,7 @@ class DescendantsByLevelFunDefTest {
                 + "[Time].[1997].[Q2].[4]\n"
                 + "[Time].[1997].[Q2].[5]\n"
                 + "[Time].[1997].[Q2].[6]" );
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Descendants({[Time].[1997]}, [Time].[Month], LEAVES)",
             months );
     }
@@ -592,10 +592,10 @@ class DescendantsByLevelFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDescendantsSetEmpty(Context context) {
-        assertAxisThrows(context.getConnection(),
+        assertAxisThrows(context.getConnectionWithDefaultRole(),
             "Descendants({}, 1)",
             "Cannot deduce type of set" );
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Descendants(Filter({[Time].[Time].Members}, 1=0), 1)",
             "" );
     }
@@ -603,15 +603,15 @@ class DescendantsByLevelFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testItemMember(Context context) {
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "Descendants([Time].[1997], [Time].[Month]).Item(1).Item(0).UniqueName",
             "[Time].[1997].[Q1].[2]" );
 
         // Access beyond the list yields the Null member.
         if ( isDefaultNullMemberRepresentation() ) {
-            assertExprReturns(context.getConnection(),
+            assertExprReturns(context.getConnectionWithDefaultRole(),
                 "[Time].[1997].Children.Item(6).UniqueName", "[Time].[#null]" );
-            assertExprReturns(context.getConnection(),
+            assertExprReturns(context.getConnectionWithDefaultRole(),
                 "[Time].[1997].Children.Item(-1).UniqueName", "[Time].[#null]" );
         }
     }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/dimension/DimensionFunctionsTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/dimension/DimensionFunctionsTest.java
@@ -37,19 +37,19 @@ public class DimensionFunctionsTest {
 	@ParameterizedTest
 	@ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
 	void testDimensionHierarchy(Context context) {
-		TestUtil.assertExprReturns(context.getConnection(), "[Time].Dimension.Name", "Time");
+		TestUtil.assertExprReturns(context.getConnectionWithDefaultRole(), "[Time].Dimension.Name", "Time");
 	}
 
 	@ParameterizedTest
 	@ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
 	void testLevelDimension(Context context) {
-		TestUtil.assertExprReturns(context.getConnection(), "[Time].[Year].Dimension.UniqueName", "[Time]");
+		TestUtil.assertExprReturns(context.getConnectionWithDefaultRole(), "[Time].[Year].Dimension.UniqueName", "[Time]");
 	}
 
 	@ParameterizedTest
 	@ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
 	void testMemberDimension(Context context) {
-		TestUtil.assertExprReturns(context.getConnection(), "[Time].[1997].[Q2].Dimension.UniqueName", "[Time]");
+		TestUtil.assertExprReturns(context.getConnectionWithDefaultRole(), "[Time].[1997].[Q2].Dimension.UniqueName", "[Time]");
 	}
 
 

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/dimensions/DimensionsFunctionsTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/dimensions/DimensionsFunctionsTest.java
@@ -41,27 +41,27 @@ public class DimensionsFunctionsTest {
 	@ParameterizedTest
 	@ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
 	void testDimensionsNumeric(Context context) {
-		TestUtil.assertExprDependsOn(context.getConnection(), "Dimensions(2).Name", "{}");
-		TestUtil.assertMemberExprDependsOn(context.getConnection(), "Dimensions(3).CurrentMember",
+		TestUtil.assertExprDependsOn(context.getConnectionWithDefaultRole(), "Dimensions(2).Name", "{}");
+		TestUtil.assertMemberExprDependsOn(context.getConnectionWithDefaultRole(), "Dimensions(3).CurrentMember",
 				FunctionTest.allHiers());
-		TestUtil.assertExprReturns(context.getConnection(), "Dimensions(2).Name", "Store Size in SQFT");
+		TestUtil.assertExprReturns(context.getConnectionWithDefaultRole(), "Dimensions(2).Name", "Store Size in SQFT");
 		// bug 1426134 -- Dimensions(0) throws 'Index '0' out of bounds'
-		TestUtil.assertExprReturns(context.getConnection(), "Dimensions(0).Name", "Measures");
-		TestUtil.assertExprThrows(context.getConnection(), "Dimensions(-1).Name", "Index '-1' out of bounds");
-		TestUtil.assertExprThrows(context.getConnection(), "Dimensions(100).Name", "Index '100' out of bounds");
+		TestUtil.assertExprReturns(context.getConnectionWithDefaultRole(), "Dimensions(0).Name", "Measures");
+		TestUtil.assertExprThrows(context.getConnectionWithDefaultRole(), "Dimensions(-1).Name", "Index '-1' out of bounds");
+		TestUtil.assertExprThrows(context.getConnectionWithDefaultRole(), "Dimensions(100).Name", "Index '100' out of bounds");
 		// Since Dimensions returns a Hierarchy, can apply CurrentMember.
-		assertAxisReturns(context.getConnection(), "Dimensions(3).CurrentMember", "[Store Type].[All Store Types]");
+		assertAxisReturns(context.getConnectionWithDefaultRole(), "Dimensions(3).CurrentMember", "[Store Type].[All Store Types]");
 	}
 
 	@ParameterizedTest
 	@ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
 	void testDimensionsString(Context context) {
-		TestUtil.assertExprDependsOn(context.getConnection(), "Dimensions(\"foo\").UniqueName", "{}");
-		TestUtil.assertMemberExprDependsOn(context.getConnection(), "Dimensions(\"foo\").CurrentMember",
+		TestUtil.assertExprDependsOn(context.getConnectionWithDefaultRole(), "Dimensions(\"foo\").UniqueName", "{}");
+		TestUtil.assertMemberExprDependsOn(context.getConnectionWithDefaultRole(), "Dimensions(\"foo\").CurrentMember",
 				FunctionTest.allHiers());
-		TestUtil.assertExprReturns(context.getConnection(), "Dimensions(\"Store\").UniqueName", "[Store]");
+		TestUtil.assertExprReturns(context.getConnectionWithDefaultRole(), "Dimensions(\"Store\").UniqueName", "[Store]");
 		// Since Dimensions returns a Hierarchy, can apply Children.
-		assertAxisReturns(context.getConnection(), "Dimensions(\"Store\").Children", """
+		assertAxisReturns(context.getConnectionWithDefaultRole(), "Dimensions(\"Store\").Children", """
 				[Store].[Canada]
 				[Store].[Mexico]
 				[Store].[USA]""");
@@ -74,8 +74,8 @@ public class DimensionsFunctionsTest {
 				Crossjoin(
 				{Dimensions("Measures").CurrentMember.Hierarchy.CurrentMember},
 				{Dimensions("Product")})""";
-		assertAxisReturns(context.getConnection(), expression, "{[Measures].[Unit Sales], [Product].[All Products]}");
-		TestUtil.assertSetExprDependsOn(context.getConnection(), expression, FunctionTest.allHiers());
+		assertAxisReturns(context.getConnectionWithDefaultRole(), expression, "{[Measures].[Unit Sales], [Product].[All Products]}");
+		TestUtil.assertSetExprDependsOn(context.getConnectionWithDefaultRole(), expression, FunctionTest.allHiers());
 	}
 
 }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/drilldownlevel/DrilldownLevelFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/drilldownlevel/DrilldownLevelFunDefTest.java
@@ -28,7 +28,7 @@ class DrilldownLevelFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDrilldownLevel(Context context) {
         // Expect all children of USA
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "DrilldownLevel({[Store].[USA]}, [Store].[Store Country])",
             "[Store].[USA]\n"
                 + "[Store].[USA].[CA]\n"
@@ -36,14 +36,14 @@ class DrilldownLevelFunDefTest {
                 + "[Store].[USA].[WA]" );
 
         // Expect same set, because [USA] is already drilled
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "DrilldownLevel({[Store].[USA], [Store].[USA].[CA]}, [Store].[Store Country])",
             "[Store].[USA]\n"
                 + "[Store].[USA].[CA]" );
 
         // Expect drill, because [USA] isn't already drilled. You can't
         // drill down on [CA] and get to [USA]
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "DrilldownLevel({[Store].[USA].[CA],[Store].[USA]}, [Store].[Store Country])",
             "[Store].[USA].[CA]\n"
                 + "[Store].[USA]\n"
@@ -51,7 +51,7 @@ class DrilldownLevelFunDefTest {
                 + "[Store].[USA].[OR]\n"
                 + "[Store].[USA].[WA]" );
 
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "DrilldownLevel({[Store].[USA].[CA],[Store].[USA]},, 0)",
             "[Store].[USA].[CA]\n"
                 + "[Store].[USA].[CA].[Alameda]\n"
@@ -64,7 +64,7 @@ class DrilldownLevelFunDefTest {
                 + "[Store].[USA].[OR]\n"
                 + "[Store].[USA].[WA]" );
 
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "DrilldownLevel({[Store].[USA].[CA],[Store].[USA]} * {[Gender].Members},, 0)",
             "{[Store].[USA].[CA], [Gender].[All Gender]}\n"
                 + "{[Store].[USA].[CA].[Alameda], [Gender].[All Gender]}\n"
@@ -97,7 +97,7 @@ class DrilldownLevelFunDefTest {
                 + "{[Store].[USA].[OR], [Gender].[M]}\n"
                 + "{[Store].[USA].[WA], [Gender].[M]}" );
 
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "DrilldownLevel({[Store].[USA].[CA],[Store].[USA]} * {[Gender].Members},, 1)",
             "{[Store].[USA].[CA], [Gender].[All Gender]}\n"
                 + "{[Store].[USA].[CA], [Gender].[F]}\n"

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/drilldownleveltopbottom/DrilldownLevelTopBottomFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/drilldownleveltopbottom/DrilldownLevelTopBottomFunDefTest.java
@@ -29,28 +29,28 @@ class DrilldownLevelTopBottomFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDrilldownLevelTop(Context context) {
         // <set>, <n>, <level>
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "DrilldownLevelTop({[Store].[USA]}, 2, [Store].[Store Country])",
             "[Store].[USA]\n"
                 + "[Store].[USA].[WA]\n"
                 + "[Store].[USA].[CA]" );
 
         // similarly DrilldownLevelBottom
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "DrilldownLevelBottom({[Store].[USA]}, 2, [Store].[Store Country])",
             "[Store].[USA]\n"
                 + "[Store].[USA].[OR]\n"
                 + "[Store].[USA].[CA]" );
 
         // <set>, <n>
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "DrilldownLevelTop({[Store].[USA]}, 2)",
             "[Store].[USA]\n"
                 + "[Store].[USA].[WA]\n"
                 + "[Store].[USA].[CA]" );
 
         // <n> greater than number of children
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "DrilldownLevelTop({[Store].[USA], [Store].[Canada]}, 4)",
             "[Store].[USA]\n"
                 + "[Store].[USA].[WA]\n"
@@ -60,22 +60,22 @@ class DrilldownLevelTopBottomFunDefTest {
                 + "[Store].[Canada].[BC]" );
 
         // <n> negative
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "DrilldownLevelTop({[Store].[USA]}, 2 - 3)",
             "[Store].[USA]" );
 
         // <n> zero
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "DrilldownLevelTop({[Store].[USA]}, 2 - 2)",
             "[Store].[USA]" );
 
         // <n> null
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "DrilldownLevelTop({[Store].[USA]}, null)",
             "[Store].[USA]" );
 
         // mixed bag, no level, all expanded
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "DrilldownLevelTop({[Store].[USA], "
                 + "[Store].[USA].[CA].[San Francisco], "
                 + "[Store].[All Stores], "
@@ -94,7 +94,7 @@ class DrilldownLevelTopBottomFunDefTest {
                 + "[Store].[Canada].[BC].[Victoria]" );
 
         // mixed bag, only specified level expanded
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "DrilldownLevelTop({[Store].[USA], "
                 + "[Store].[USA].[CA].[San Francisco], "
                 + "[Store].[All Stores], "
@@ -106,7 +106,7 @@ class DrilldownLevelTopBottomFunDefTest {
                 + "[Store].[Canada].[BC]" );
 
         // bad level
-        assertAxisThrows(context.getConnection(),
+        assertAxisThrows(context.getConnectionWithDefaultRole(),
             "DrilldownLevelTop({[Store].[USA]}, 2, [Customers].[Country])",
             "Level '[Customers].[Country]' not compatible with "
                 + "member '[Store].[USA]'" );
@@ -116,14 +116,14 @@ class DrilldownLevelTopBottomFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDrilldownMemberEmptyExpr(Context context) {
         // no level, with expression
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "DrilldownLevelTop({[Store].[USA]}, 2, , [Measures].[Unit Sales])",
             "[Store].[USA]\n"
                 + "[Store].[USA].[WA]\n"
                 + "[Store].[USA].[CA]" );
 
         // reverse expression
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "DrilldownLevelTop("
                 + "{[Store].[USA]}, 2, , - [Measures].[Unit Sales])",
             "[Store].[USA]\n"

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/drilldownmember/DrilldownMemberFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/drilldownmember/DrilldownMemberFunDefTest.java
@@ -28,7 +28,7 @@ class DrilldownMemberFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDrilldownMember(Context context) {
         // Expect all children of USA
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "DrilldownMember({[Store].[USA]}, {[Store].[USA]})",
             "[Store].[USA]\n"
                 + "[Store].[USA].[CA]\n"
@@ -36,7 +36,7 @@ class DrilldownMemberFunDefTest {
                 + "[Store].[USA].[WA]" );
 
         // Expect all children of USA.CA and USA.OR
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "DrilldownMember({[Store].[USA].[CA], [Store].[USA].[OR]}, "
                 + "{[Store].[USA].[CA], [Store].[USA].[OR], [Store].[USA].[WA]})",
             "[Store].[USA].[CA]\n"
@@ -51,18 +51,18 @@ class DrilldownMemberFunDefTest {
 
 
         // Second set is empty
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "DrilldownMember({[Store].[USA]}, {})",
             "[Store].[USA]" );
 
         // Drill down a leaf member
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "DrilldownMember({[Store].[All Stores].[USA].[CA].[San Francisco].[Store 14]}, "
                 + "{[Store].[USA].[CA].[San Francisco].[Store 14]})",
             "[Store].[USA].[CA].[San Francisco].[Store 14]" );
 
         // Complex case with option recursive
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "DrilldownMember({[Store].[All Stores].[USA]}, "
                 + "{[Store].[All Stores].[USA], [Store].[All Stores].[USA].[CA], "
                 + "[Store].[All Stores].[USA].[CA].[San Diego], [Store].[All Stores].[USA].[WA]}, "
@@ -86,7 +86,7 @@ class DrilldownMemberFunDefTest {
                 + "[Store].[USA].[WA].[Yakima]" );
 
         // Sets of tuples
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "DrilldownMember({([Store Type].[Supermarket], [Store].[USA])}, {[Store].[USA]})",
             "{[Store Type].[Supermarket], [Store].[USA]}\n"
                 + "{[Store Type].[Supermarket], [Store].[USA].[CA]}\n"

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/except/ExceptFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/except/ExceptFunDefTest.java
@@ -31,11 +31,11 @@ class ExceptFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testExceptEmpty(Context context) {
         // If left is empty, result is empty.
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Except(Filter([Gender].Members, 1=0), {[Gender].[M]})", "" );
 
         // If right is empty, result is left.
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Except({[Gender].[M]}, Filter([Gender].Members, 1=0))",
             "[Gender].[M]" );
     }
@@ -47,7 +47,7 @@ class ExceptFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testExceptCrossjoin(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Except(CROSSJOIN({[Promotion Media].[All Media]},\n"
                 + "                  [Product].[All Products].Children),\n"
                 + "       CROSSJOIN({[Promotion Media].[All Media]},\n"
@@ -59,7 +59,7 @@ class ExceptFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testExtract(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Extract(\n"
                 + "Crossjoin({[Gender].[F], [Gender].[M]},\n"
                 + "          {[Marital Status].Members}),\n"
@@ -67,40 +67,40 @@ class ExceptFunDefTest {
             "[Gender].[F]\n" + "[Gender].[M]" );
 
         // Extract(<set>) with no dimensions is not valid
-        assertAxisThrows(context.getConnection(),
+        assertAxisThrows(context.getConnectionWithDefaultRole(),
             "Extract(Crossjoin({[Gender].[F], [Gender].[M]}, {[Marital Status].Members}))",
             "No function matches signature 'Extract(<Set>)'" );
 
         // Extract applied to non-constant dimension should fail
-        assertAxisThrows(context.getConnection(),
+        assertAxisThrows(context.getConnectionWithDefaultRole(),
             "Extract(Crossjoin([Gender].Members, [Store].Children), [Store].Hierarchy.Dimension)",
             "not a constant hierarchy: [Store].Hierarchy.Dimension" );
 
         // Extract applied to non-constant hierarchy should fail
-        assertAxisThrows(context.getConnection(),
+        assertAxisThrows(context.getConnectionWithDefaultRole(),
             "Extract(Crossjoin([Gender].Members, [Store].Children), [Store].Hierarchy)",
             "not a constant hierarchy: [Store].Hierarchy" );
 
         // Extract applied to set of members is OK (if silly). Duplicates are
         // removed, as always.
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Extract({[Gender].[M], [Gender].Members}, [Gender])",
             "[Gender].[M]\n"
                 + "[Gender].[All Gender]\n"
                 + "[Gender].[F]" );
 
         // Extract of hierarchy not in set fails
-        assertAxisThrows(context.getConnection(),
+        assertAxisThrows(context.getConnectionWithDefaultRole(),
             "Extract(Crossjoin([Gender].Members, [Store].Children), [Marital Status])",
             "hierarchy [Marital Status] is not a hierarchy of the expression Crossjoin([Gender].Members, [Store].Children)" );
 
         // Extract applied to empty set returns empty set
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Extract(Crossjoin({[Gender].Parent}, [Store].Children), [Store])",
             "" );
 
         // Extract applied to asymmetric set
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Extract(\n"
                 + "{([Gender].[M], [Marital Status].[M]),\n"
                 + " ([Gender].[F], [Marital Status].[M]),\n"
@@ -109,7 +109,7 @@ class ExceptFunDefTest {
             "[Gender].[M]\n" + "[Gender].[F]" );
 
         // Extract applied to asymmetric set (other side)
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Extract(\n"
                 + "{([Gender].[M], [Marital Status].[M]),\n"
                 + " ([Gender].[F], [Marital Status].[M]),\n"
@@ -119,7 +119,7 @@ class ExceptFunDefTest {
                 + "[Marital Status].[S]" );
 
         // Extract more than one hierarchy
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Extract(\n"
                 + "[Gender].Children * [Marital Status].Children * [Time].[1997].Children * [Store].[USA].Children,\n"
                 + "[Time], [Marital Status])",
@@ -133,7 +133,7 @@ class ExceptFunDefTest {
                 + "{[Time].[1997].[Q4], [Marital Status].[S]}" );
 
         // Extract duplicate hierarchies fails
-        assertAxisThrows(context.getConnection(),
+        assertAxisThrows(context.getConnectionWithDefaultRole(),
             "Extract(\n"
                 + "{([Gender].[M], [Marital Status].[M]),\n"
                 + " ([Gender].[F], [Marital Status].[M]),\n"
@@ -160,7 +160,7 @@ class ExceptFunDefTest {
                     + ".Children, [Customers].[USA].[CA].Children}), [Customers].[USA].[CA]) ON ROWS FROM [Sales] "
             };
         for ( String mdx : mdxA ) {
-            TestUtil.assertQueryReturns(context.getConnection(),
+            TestUtil.assertQueryReturns(context.getConnectionWithDefaultRole(),
                 mdx,
                 "Axis #0:\n"
                     + "{}\n"

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/exists/ExistsFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/exists/ExistsFunDefTest.java
@@ -28,7 +28,7 @@ class ExistsFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testExistsMembersLevel2(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select exists(\n"
                 + "  {[Customers].[All Customers],\n"
                 + "   [Customers].[Country].Members,\n"
@@ -53,7 +53,7 @@ class ExistsFunDefTest {
         // the tuple in the second arg in this case should implicitly
         // contain [Customers].[All Customers], so the whole tuple list
         // from the first arg should be returned.
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select non empty exists(\n"
                 + "  {[Customers].[All Customers],\n"
                 + "   [Customers].[All Customers].Children,\n"
@@ -74,7 +74,7 @@ class ExistsFunDefTest {
                 + "Row #0: 67,659\n"
                 + "Row #0: 124,366\n" );
 
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select exists( "
                 + "[Customers].[USA].[CA], (Store.[USA], Gender.[F])) "
                 + "on 0 from sales",
@@ -89,7 +89,7 @@ class ExistsFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testExistsWithMultipleHierarchies(Context context) {
         // tests queries w/ a multi-hierarchy dim in either or both args.
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select exists( "
                 + "crossjoin( time.[1997], {[Time.Weekly].[1997].[16]}), "
                 + " { Gender.F } ) on 0 from sales",
@@ -99,7 +99,7 @@ class ExistsFunDefTest {
                 + "{[Time].[1997], [Time.Weekly].[1997].[16]}\n"
                 + "Row #0: 3,839\n" );
 
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select exists( "
                 + "time.[1997].[Q1], {[Time.Weekly].[1997].[4]}) "
                 + " on 0 from sales",
@@ -109,7 +109,7 @@ class ExistsFunDefTest {
                 + "{[Time].[1997].[Q1]}\n"
                 + "Row #0: 66,291\n" );
 
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select exists( "
                 + "{ Gender.F }, "
                 + "crossjoin( time.[1997], {[Time.Weekly].[1997].[16]})  ) "
@@ -120,7 +120,7 @@ class ExistsFunDefTest {
                 + "{[Gender].[F]}\n"
                 + "Row #0: 131,558\n" );
 
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select exists( "
                 + "{ time.[1998] }, "
                 + "crossjoin( time.[1997], {[Time.Weekly].[1997].[16]})  ) "
@@ -136,7 +136,7 @@ class ExistsFunDefTest {
         // default mem for Time is 1997
 
         // non-all default on right side.
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select exists( [Time].[1998].[Q1], Gender.[All Gender]) on 0 from sales",
             "Axis #0:\n"
                 + "{}\n"
@@ -144,7 +144,7 @@ class ExistsFunDefTest {
 
         // switching to an explicit member on the hierarchy chain should return
         // 1998.Q1
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select exists( [Time].[1998].[Q1], ([Time].[1998], Gender.[All Gender])) on 0 from sales",
             "Axis #0:\n"
                 + "{}\n"
@@ -154,7 +154,7 @@ class ExistsFunDefTest {
 
 
         // non-all default on left side
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select exists( "
                 + "Gender.[All Gender], (Gender.[F], [Time].[1998].[Q1])) "
                 + "on 0 from sales",
@@ -162,7 +162,7 @@ class ExistsFunDefTest {
                 + "{}\n"
                 + "Axis #1:\n" );
 
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select exists( "
                 + "(Time.[1998].[Q1].[1], Gender.[All Gender]), (Gender.[F], [Time].[1998].[Q1])) "
                 + "on 0 from sales",
@@ -176,7 +176,7 @@ class ExistsFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testExistsMembers2Hierarchies(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select exists(\n"
                 + "  {[Customers].[All Customers],\n"
                 + "   [Customers].[All Customers].Children,\n"
@@ -210,7 +210,7 @@ class ExistsFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testExistsTuplesAll(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select exists(\n"
                 + "  crossjoin({[Product].[All Products]},{[Customers].[All Customers]}),\n"
                 + "  {[Customers].[All Customers]})\n"
@@ -225,7 +225,7 @@ class ExistsFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testExistsTuplesLevel2(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select exists(\n"
                 + "  crossjoin({[Product].[All Products]},{[Customers].[All Customers].Children}),\n"
                 + "  {[Customers].[All Customers].[USA]})\n"
@@ -240,7 +240,7 @@ class ExistsFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testExistsTuplesLevel23(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select exists(\n"
                 + "  crossjoin({[Customers].[State Province].Members}, {[Product].[All Products]}),\n"
                 + "  {[Customers].[All Customers].[USA]})\n"
@@ -259,7 +259,7 @@ class ExistsFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testExistsTuples2Dim(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select exists(\n"
                 + "  crossjoin({[Customers].[State Province].Members}, {[Product].[Product Family].Members}),\n"
                 + "  {([Product].[Product Department].[Dairy],[Customers].[All Customers].[USA])})\n"
@@ -278,7 +278,7 @@ class ExistsFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testExistsTuplesDiffDim(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select exists(\n"
                 + "  crossjoin(\n"
                 + "    crossjoin({[Customers].[State Province].Members},\n"
@@ -302,7 +302,7 @@ class ExistsFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testExistsMembersAll(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select exists(\n"
                 + "  {[Customers].[All Customers],\n"
                 + "   [Customers].[Country].Members,\n"

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/format/FormatFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/format/FormatFunDefTest.java
@@ -28,7 +28,7 @@ class FormatFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testFormatFixed(Context context) {
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "Format(12.2, \"#,##0.00\")",
             "12.20" );
     }
@@ -36,7 +36,7 @@ class FormatFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testFormatVariable(Context context) {
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "Format(1234.5, \"#,#\" || \"#0.00\")",
             "1,234.50" );
     }
@@ -44,7 +44,7 @@ class FormatFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testFormatMember(Context context) {
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "Format([Store].[USA].[CA], \"#,#\" || \"#0.00\")",
             "74,748.00" );
     }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/generate/GenerateFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/generate/GenerateFunDefTest.java
@@ -39,21 +39,21 @@ class GenerateFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testGenerateDepends(Context context) {
-        assertSetExprDependsOn(context.getConnection(),
+        assertSetExprDependsOn(context.getConnectionWithDefaultRole(),
             "Generate([Product].CurrentMember.Children, Crossjoin({[Product].CurrentMember}, Crossjoin([Store].[Store "
                 + "State].Members, [Store Type].Members)), ALL)",
             "{[Product]}" );
-        assertSetExprDependsOn(context.getConnection(),
+        assertSetExprDependsOn(context.getConnectionWithDefaultRole(),
             "Generate([Product].[All Products].Children, Crossjoin({[Product].CurrentMember}, Crossjoin([Store].[Store "
                 + "State].Members, [Store Type].Members)), ALL)",
             "{}" );
-        assertSetExprDependsOn(context.getConnection(),
+        assertSetExprDependsOn(context.getConnectionWithDefaultRole(),
             "Generate({[Store].[USA], [Store].[USA].[CA]}, {[Store].CurrentMember.Children})",
             "{}" );
-        assertSetExprDependsOn(context.getConnection(),
+        assertSetExprDependsOn(context.getConnectionWithDefaultRole(),
             "Generate({[Store].[USA], [Store].[USA].[CA]}, {[Gender].CurrentMember})",
             "{[Gender]}" );
-        assertSetExprDependsOn(context.getConnection(),
+        assertSetExprDependsOn(context.getConnectionWithDefaultRole(),
             "Generate({[Store].[USA], [Store].[USA].[CA]}, {[Gender].[M]})",
             "{}" );
     }
@@ -61,7 +61,7 @@ class GenerateFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testGenerate(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Generate({[Store].[USA], [Store].[USA].[CA]}, {[Store].CurrentMember.Children})",
             "[Store].[USA].[CA]\n"
                 + "[Store].[USA].[OR]\n"
@@ -77,13 +77,13 @@ class GenerateFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testGenerateNonSet(Context context) {
         // SSAS implicitly converts arg #2 to a set
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Generate({[Store].[USA], [Store].[USA].[CA]}, [Store].PrevMember, ALL)",
             "[Store].[Mexico]\n"
                 + "[Store].[Mexico].[Zacatecas]" );
 
         // SSAS implicitly converts arg #1 to a set
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Generate([Store].[USA], [Store].PrevMember, ALL)",
             "[Store].[Mexico]" );
     }
@@ -91,7 +91,7 @@ class GenerateFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testGenerateAll(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Generate({[Store].[USA].[CA], [Store].[USA].[OR].[Portland]},"
                 + " Ascendants([Store].CurrentMember),"
                 + " ALL)",
@@ -107,7 +107,7 @@ class GenerateFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testGenerateUnique(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Generate({[Store].[USA].[CA], [Store].[USA].[OR].[Portland]},"
                 + " Ascendants([Store].CurrentMember))",
             "[Store].[USA].[CA]\n"
@@ -120,7 +120,7 @@ class GenerateFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testGenerateUniqueTuple(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Generate({([Store].[USA].[CA],[Product].[All Products]), "
                 + "([Store].[USA].[CA],[Product].[All Products])},"
                 + "{([Store].CurrentMember, [Product].CurrentMember)})",
@@ -131,7 +131,7 @@ class GenerateFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testGenerateCrossJoin(Context context) {
         // Note that the different regions have different Top 2.
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Generate({[Store].[USA].[CA], [Store].[USA].[CA].[San Francisco]},\n"
                 + "  CrossJoin({[Store].CurrentMember},\n"
                 + "    TopCount([Product].[Brand Name].members, \n"
@@ -147,11 +147,11 @@ class GenerateFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testGenerateString(Context context) {
-        TestUtil.assertExprReturns(context.getConnection(),
+        TestUtil.assertExprReturns(context.getConnectionWithDefaultRole(),
             "Generate({Time.[1997], Time.[1998]},"
                 + " Time.[Time].CurrentMember.Name)",
             "19971998" );
-        TestUtil.assertExprReturns(context.getConnection(),
+        TestUtil.assertExprReturns(context.getConnectionWithDefaultRole(),
             "Generate({Time.[1997], Time.[1998]},"
                 + " Time.[Time].CurrentMember.Name, \" and \")",
             "1997 and 1998" );
@@ -166,7 +166,7 @@ class GenerateFunDefTest {
         ((TestConfig)context.getConfig()).setQueryTimeout(5);
         SystemWideProperties.instance().EnableNativeNonEmpty = false;
         try {
-            executeAxis(context.getConnection(),
+            executeAxis(context.getConnectionWithDefaultRole(),
                 "Generate([Product].[Product Name].members,"
                     + "  Generate([Customers].[Name].members, "
                     + "    {([Store].CurrentMember, [Product].CurrentMember, [Customers].CurrentMember)}))" );
@@ -182,7 +182,7 @@ class GenerateFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testGenerateForStringMemberProperty(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH MEMBER [Store].[Lineage of Time] AS\n"
                 + " Generate(Ascendants([Time].CurrentMember), [Time].CurrentMember.Properties(\"MEMBER_CAPTION\"), \",\")\n"
                 + " SELECT\n"

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/headtail/HeadTailFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/headtail/HeadTailFunDefTest.java
@@ -29,7 +29,7 @@ class HeadTailFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testHead(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Head([Store].Children, 2)",
             "[Store].[Canada]\n"
                 + "[Store].[Mexico]" );
@@ -38,7 +38,7 @@ class HeadTailFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testHeadNegative(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Head([Store].Children, 2 - 3)",
             "" );
     }
@@ -46,7 +46,7 @@ class HeadTailFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testHeadDefault(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Head([Store].Children)",
             "[Store].[Canada]" );
     }
@@ -54,7 +54,7 @@ class HeadTailFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testHeadOvershoot(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Head([Store].Children, 2 + 2)",
             "[Store].[Canada]\n"
                 + "[Store].[Mexico]\n"
@@ -64,11 +64,11 @@ class HeadTailFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testHeadEmpty(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Head([Gender].[F].Children, 2)",
             "" );
 
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Head([Gender].[F].Children)",
             "" );
     }
@@ -79,7 +79,7 @@ class HeadTailFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testHeadBug(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "SELECT\n"
                 + "                        UNION(\n"
                 + "                            {([Customers].CURRENTMEMBER)},\n"
@@ -107,7 +107,7 @@ class HeadTailFunDefTest {
                 + "Row #0: 266,773\n"
                 + "Row #0: 266,773\n" );
 
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH\n"
                 + "    MEMBER\n"
                 + "        [Customers].[COG_OQP_INT_t2]AS '1',\n"
@@ -140,7 +140,7 @@ class HeadTailFunDefTest {
                 + "Row #0: 266,773\n" );
 
         // More minimal test case. Also demonstrates similar problem with Tail.
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Union(\n"
                 + "  Union(\n"
                 + "    Tail([Customers].[USA].[CA].Children, 2),\n"
@@ -160,7 +160,7 @@ class HeadTailFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testTail(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Tail([Store].Children, 2)",
             "[Store].[Mexico]\n"
                 + "[Store].[USA]" );
@@ -169,7 +169,7 @@ class HeadTailFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testTailNegative(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Tail([Store].Children, 2 - 3)",
             "" );
     }
@@ -177,7 +177,7 @@ class HeadTailFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testTailDefault(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Tail([Store].Children)",
             "[Store].[USA]" );
     }
@@ -185,7 +185,7 @@ class HeadTailFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testTailOvershoot(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Tail([Store].Children, 2 + 2)",
             "[Store].[Canada]\n"
                 + "[Store].[Mexico]\n"
@@ -195,11 +195,11 @@ class HeadTailFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testTailEmpty(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Tail([Gender].[F].Children, 2)",
             "" );
 
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Tail([Gender].[F].Children)",
             "" );
     }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/hierarchize/HierarchizeFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/hierarchize/HierarchizeFunDefTest.java
@@ -33,7 +33,7 @@ class HierarchizeFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testHierarchize(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Hierarchize(\n"
                 + "    {[Product].[All Products], "
                 + "     [Product].[Food],\n"
@@ -53,7 +53,7 @@ class HierarchizeFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testHierarchizePost(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Hierarchize(\n"
                 + "    {[Product].[All Products], "
                 + "     [Product].[Food],\n"
@@ -71,7 +71,7 @@ class HierarchizeFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testHierarchizePC(Context context) {
         //getTestContext().withCube( "HR" ).
-        assertAxisReturns(context.getConnection(), "HR",
+        assertAxisReturns(context.getConnectionWithDefaultRole(), "HR",
             "Hierarchize(\n"
                 + "   { Subset([Employees].Members, 90, 10),\n"
                 + "     Head([Employees].Members, 5) })",
@@ -105,7 +105,7 @@ class HierarchizeFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testHierarchizeCrossJoinPre(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Hierarchize(\n"
                 + "  CrossJoin(\n"
                 + "    {[Product].[All Products], "
@@ -132,7 +132,7 @@ class HierarchizeFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testHierarchizeCrossJoinPost(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Hierarchize(\n"
                 + "  CrossJoin(\n"
                 + "    {[Product].[All Products], "
@@ -199,7 +199,7 @@ class HierarchizeFunDefTest {
         + "</Cube>" );
      */
         withSchema(context, SchemaModifiers.FunctionTestModifier3::new);
-        final Connection connection = context.getConnection();
+        final Connection connection = context.getConnectionWithDefaultRole();
 
         // The [Time_Alphabetical] is ordered alphabetically by month
         assertAxisReturns(connection, "[Sales_Hierarchize]",

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/hierarchy/member/HierarchyCurrentMemberFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/hierarchy/member/HierarchyCurrentMemberFunDefTest.java
@@ -38,7 +38,7 @@ class HierarchyCurrentMemberFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCurrentMember(Context context) {
         // <Dimension>.CurrentMember
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         assertAxisReturns(connection, "[Gender].CurrentMember", "[Gender].[All Gender]" );
         // <Hierarchy>.CurrentMember
         assertAxisReturns(connection,
@@ -54,7 +54,7 @@ class HierarchyCurrentMemberFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCurrentMemberDepends(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         assertMemberExprDependsOn(connection,
             "[Gender].CurrentMember",
             "{[Gender]}" );
@@ -81,7 +81,7 @@ class HierarchyCurrentMemberFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCurrentMemberFromSlicer(Context context) {
-        Result result = executeQuery(context.getConnection(),
+        Result result = executeQuery(context.getConnectionWithDefaultRole(),
             "with member [Measures].[Foo] as '[Gender].CurrentMember.Name'\n"
                 + "select {[Measures].[Foo]} on columns\n"
                 + "from Sales where ([Gender].[F])" );
@@ -91,7 +91,7 @@ class HierarchyCurrentMemberFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCurrentMemberFromDefaultMember(Context context) {
-        Result result = executeQuery(context.getConnection(),
+        Result result = executeQuery(context.getConnectionWithDefaultRole(),
             "with member [Measures].[Foo] as"
                 + " '[Time].[Time].CurrentMember.Name'\n"
                 + "select {[Measures].[Foo]} on columns\n"
@@ -116,7 +116,7 @@ class HierarchyCurrentMemberFunDefTest {
                 + "select {[Measures].[Unit Sales], [Measures].[Foo]} ON COLUMNS,\n"
                 + "  {[Product].[Food].[Dairy]} ON ROWS\n"
                 + "from [Sales]";
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         Result result =
             executeQuery(connection,
                 queryString + " where [Time].[1997]" );
@@ -166,7 +166,7 @@ class HierarchyCurrentMemberFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCurrentMemberFromAxis(Context context) {
-        Result result = executeQuery(context.getConnection(),
+        Result result = executeQuery(context.getConnectionWithDefaultRole(),
             "with member [Measures].[Foo] as"
                 + " '[Gender].CurrentMember.Name"
                 + " || [Marital Status].CurrentMember.Name'\n"
@@ -185,7 +185,7 @@ class HierarchyCurrentMemberFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCurrentMemberInCalcMember(Context context) {
-        Result result = executeQuery(context.getConnection(),
+        Result result = executeQuery(context.getConnectionWithDefaultRole(),
             "with member [Measures].[Foo] as '[Measures].CurrentMember.Name'\n"
                 + "select {[Measures].[Foo]} on columns\n"
                 + "from Sales" );

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/iif/IifFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/iif/IifFunDefTest.java
@@ -28,7 +28,7 @@ class IifFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testIIfMember(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "IIf(1 > 2,[Store].[USA],[Store].[Canada].[BC])",
             "[Store].[Canada].[BC]" );
     }
@@ -36,7 +36,7 @@ class IifFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testIIfLevel(Context context) {
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "IIf(1 > 2, [Store].[Store Country],[Store].[Store City]).Name",
             "Store City" );
     }
@@ -45,14 +45,14 @@ class IifFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testIIfHierarchy(Context context) {
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "IIf(1 > 2, [Time], [Store]).Name",
             "Store" );
 
         // Call Iif(<Logical>, <Dimension>, <Hierarchy>). Argument #3, the
         // hierarchy [Time.Weekly] is implicitly converted to
         // the dimension [Time] to match argument #2 which is a dimension.
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "IIf(1 > 2, [Time], [Time.Weekly]).Name",
             "Time" );
     }
@@ -61,7 +61,7 @@ class IifFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testIIfDimension(Context context) {
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "IIf(1 > 2, [Store], [Time]).Name",
             "Time" );
     }
@@ -70,7 +70,7 @@ class IifFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testIIfSet(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "IIf(1 > 2, {[Store].[USA], [Store].[USA].[CA]}, {[Store].[Mexico], [Store].[USA].[OR]})",
             "[Store].[Mexico]\n"
                 + "[Store].[USA].[OR]" );
@@ -80,7 +80,7 @@ class IifFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testIIfSetType_InCrossJoin(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "CROSSJOIN([Store Type].[Deluxe Supermarket],IIf(1 = 1, {[Store].[USA], [Store].[USA].[CA]}, {[Store].[Mexico],"
                 + " [Store].[USA].[OR]}))",
             "{[Store Type].[Deluxe Supermarket], [Store].[USA]}\n"

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/iif/IifNumericFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/iif/IifNumericFunDefTest.java
@@ -28,14 +28,14 @@ class IifNumericFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testIIfNumeric(Context context) {
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "IIf(([Measures].[Unit Sales],[Product].[Drink].[Alcoholic Beverages].[Beer and Wine]) > 100, 45, 32)",
             "45" );
 
         // Compare two members. The system needs to figure out that they are
         // both numeric, and use the right overloaded version of ">", otherwise
         // we'll get a ClassCastException at runtime.
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "IIf([Measures].[Unit Sales] > [Measures].[Store Sales], 45, 32)",
             "32" );
     }
@@ -43,10 +43,10 @@ class IifNumericFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testIIfWithNullAndNumber(Context context) {
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "IIf(([Measures].[Unit Sales],[Product].[Drink].[Alcoholic Beverages].[Beer and Wine]) > 100, null,20)",
             "" );
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "IIf(([Measures].[Unit Sales],[Product].[Drink].[Alcoholic Beverages].[Beer and Wine]) > 100, 20,null)",
             "20" );
     }
@@ -54,7 +54,7 @@ class IifNumericFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testIifFWithBooleanBooleanAndNumericParameterForReturningTruePart(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "SELECT Filter(Store.allmembers, "
                 + "iif(measures.profit < 400000,"
                 + "[store].currentMember.NAME = \"USA\", 0)) on 0 FROM SALES",
@@ -68,7 +68,7 @@ class IifNumericFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testIifWithBooleanBooleanAndNumericParameterForReturningFalsePart(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "SELECT Filter([Store].[USA].[CA].[Beverly Hills].children, "
                 + "iif(measures.profit > 400000,"
                 + "[store].currentMember.NAME = \"USA\", 1)) on 0 FROM SALES",
@@ -82,7 +82,7 @@ class IifNumericFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testIIFWithBooleanBooleanAndNumericParameterForReturningZero(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "SELECT Filter(Store.allmembers, "
                 + "iif(measures.profit > 400000,"
                 + "[store].currentMember.NAME = \"USA\", 0)) on 0 FROM SALES",

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/iif/IifStringFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/iif/IifStringFunDefTest.java
@@ -27,7 +27,7 @@ class IifStringFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testIIf(Context context) {
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "IIf(([Measures].[Unit Sales],[Product].[Drink].[Alcoholic Beverages].[Beer and Wine]) > 100, \"Yes\",\"No\")",
             "Yes" );
     }
@@ -35,10 +35,10 @@ class IifStringFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testIIfWithStringAndNull(Context context) {
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "IIf(([Measures].[Unit Sales],[Product].[Drink].[Alcoholic Beverages].[Beer and Wine]) > 100, null,\"foo\")",
             "" );
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "IIf(([Measures].[Unit Sales],[Product].[Drink].[Alcoholic Beverages].[Beer and Wine]) > 100, \"foo\",null)",
             "foo" );
     }
@@ -46,10 +46,10 @@ class IifStringFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testIsEmptyWithNull(Context context) {
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "iif (isempty(null), \"is empty\", \"not is empty\")",
             "is empty" );
-        assertExprReturns(context.getConnection(), "iif (isempty(null), 1, 2)", "1" );
+        assertExprReturns(context.getConnectionWithDefaultRole(), "iif (isempty(null), 1, 2)", "1" );
     }
 
 }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/intersect/IntersectFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/intersect/IntersectFunDefTest.java
@@ -30,7 +30,7 @@ class IntersectFunDefTest {
     void testIntersectAll(Context context) {
         // Note: duplicates retained from left, not from right; and order is
         // preserved.
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Intersect({[Time].[1997].[Q2], [Time].[1997], [Time].[1997].[Q1], [Time].[1997].[Q2]}, "
                 + "{[Time].[1998], [Time].[1997], [Time].[1997].[Q2], [Time].[1997]}, "
                 + "ALL)",
@@ -44,7 +44,7 @@ class IntersectFunDefTest {
     void testIntersect(Context context) {
         // Duplicates not preserved. Output in order that first duplicate
         // occurred.
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Intersect(\n"
                 + "  {[Time].[1997].[Q2], [Time].[1997], [Time].[1997].[Q1], [Time].[1997].[Q2]}, "
                 + "{[Time].[1998], [Time].[1997], [Time].[1997].[Q2], [Time].[1997]})",
@@ -55,7 +55,7 @@ class IntersectFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testIntersectTuples(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Intersect(\n"
                 + "  {([Time].[1997].[Q2], [Gender].[M]),\n"
                 + "   ([Time].[1997], [Gender].[F]),\n"
@@ -72,7 +72,7 @@ class IntersectFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testIntersectRightEmpty(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Intersect({[Time].[1997]}, {})",
             "" );
     }
@@ -80,7 +80,7 @@ class IntersectFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testIntersectLeftEmpty(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Intersect({}, {[Store].[USA].[CA]})",
             "" );
     }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/lastperiods/LastPeriodsFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/lastperiods/LastPeriodsFunDefTest.java
@@ -27,43 +27,43 @@ class LastPeriodsFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testLastPeriods(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "LastPeriods(0, [Time].[1998])", "" );
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "LastPeriods(1, [Time].[1998])", "[Time].[1998]" );
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "LastPeriods(-1, [Time].[1998])", "[Time].[1998]" );
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "LastPeriods(2, [Time].[1998])",
             "[Time].[1997]\n" + "[Time].[1998]" );
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "LastPeriods(-2, [Time].[1997])",
             "[Time].[1997]\n" + "[Time].[1998]" );
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "LastPeriods(5000, [Time].[1998])",
             "[Time].[1997]\n" + "[Time].[1998]" );
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "LastPeriods(-5000, [Time].[1997])",
             "[Time].[1997]\n" + "[Time].[1998]" );
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "LastPeriods(2, [Time].[1998].[Q2])",
             "[Time].[1998].[Q1]\n" + "[Time].[1998].[Q2]" );
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "LastPeriods(4, [Time].[1998].[Q2])",
             "[Time].[1997].[Q3]\n"
                 + "[Time].[1997].[Q4]\n"
                 + "[Time].[1998].[Q1]\n"
                 + "[Time].[1998].[Q2]" );
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "LastPeriods(-2, [Time].[1997].[Q2])",
             "[Time].[1997].[Q2]\n" + "[Time].[1997].[Q3]" );
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "LastPeriods(-4, [Time].[1997].[Q2])",
             "[Time].[1997].[Q2]\n"
                 + "[Time].[1997].[Q3]\n"
                 + "[Time].[1997].[Q4]\n"
                 + "[Time].[1998].[Q1]" );
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "LastPeriods(5000, [Time].[1998].[Q2])",
             "[Time].[1997].[Q1]\n"
                 + "[Time].[1997].[Q2]\n"
@@ -71,16 +71,16 @@ class LastPeriodsFunDefTest {
                 + "[Time].[1997].[Q4]\n"
                 + "[Time].[1998].[Q1]\n"
                 + "[Time].[1998].[Q2]" );
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "LastPeriods(-5000, [Time].[1998].[Q2])",
             "[Time].[1998].[Q2]\n"
                 + "[Time].[1998].[Q3]\n"
                 + "[Time].[1998].[Q4]" );
 
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "LastPeriods(2, [Time].[1998].[Q2].[5])",
             "[Time].[1998].[Q2].[4]\n" + "[Time].[1998].[Q2].[5]" );
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "LastPeriods(12, [Time].[1998].[Q2].[5])",
             "[Time].[1997].[Q2].[6]\n"
                 + "[Time].[1997].[Q3].[7]\n"
@@ -94,10 +94,10 @@ class LastPeriodsFunDefTest {
                 + "[Time].[1998].[Q1].[3]\n"
                 + "[Time].[1998].[Q2].[4]\n"
                 + "[Time].[1998].[Q2].[5]" );
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "LastPeriods(-2, [Time].[1998].[Q2].[4])",
             "[Time].[1998].[Q2].[4]\n" + "[Time].[1998].[Q2].[5]" );
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "LastPeriods(-12, [Time].[1997].[Q2].[6])",
             "[Time].[1997].[Q2].[6]\n"
                 + "[Time].[1997].[Q3].[7]\n"
@@ -111,15 +111,15 @@ class LastPeriodsFunDefTest {
                 + "[Time].[1998].[Q1].[3]\n"
                 + "[Time].[1998].[Q2].[4]\n"
                 + "[Time].[1998].[Q2].[5]" );
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "LastPeriods(2, [Gender].[M])",
             "[Gender].[F]\n" + "[Gender].[M]" );
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "LastPeriods(-2, [Gender].[F])",
             "[Gender].[F]\n" + "[Gender].[M]" );
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "LastPeriods(2, [Gender])", "[Gender].[All Gender]" );
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "LastPeriods(2, [Gender].Parent)", "" );
     }
 

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/leadlag/LeadLagFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/leadlag/LeadLagFunDefTest.java
@@ -30,70 +30,70 @@ class LeadLagFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testLag(Context context) {
-        Member member = executeSingletonAxis(context.getConnection(), "[Time].[1997].[Q4].[12].Lag(4)" );
+        Member member = executeSingletonAxis(context.getConnectionWithDefaultRole(), "[Time].[1997].[Q4].[12].Lag(4)" );
         assertEquals( "8", member.getName() );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testLagFirstInLevel(Context context) {
-        Member member = executeSingletonAxis(context.getConnection(), "[Gender].[F].Lag(1)" );
+        Member member = executeSingletonAxis(context.getConnectionWithDefaultRole(), "[Gender].[F].Lag(1)" );
         assertNull( member );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testLagAll(Context context) {
-        Member member = executeSingletonAxis(context.getConnection(), "[Gender].DefaultMember.Lag(2)" );
+        Member member = executeSingletonAxis(context.getConnectionWithDefaultRole(), "[Gender].DefaultMember.Lag(2)" );
         assertNull( member );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testLagRoot(Context context) {
-        Member member = executeSingletonAxis(context.getConnection(), "[Time].[1998].Lag(1)" );
+        Member member = executeSingletonAxis(context.getConnectionWithDefaultRole(), "[Time].[1998].Lag(1)" );
         assertEquals( "1997", member.getName() );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testLagRootTooFar(Context context) {
-        Member member = executeSingletonAxis(context.getConnection(), "[Time].[1998].Lag(2)" );
+        Member member = executeSingletonAxis(context.getConnectionWithDefaultRole(), "[Time].[1998].Lag(2)" );
         assertNull( member );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testLead(Context context) {
-        Member member = executeSingletonAxis(context.getConnection(), "[Time].[1997].[Q2].[4].Lead(4)" );
+        Member member = executeSingletonAxis(context.getConnectionWithDefaultRole(), "[Time].[1997].[Q2].[4].Lead(4)" );
         assertEquals( "8", member.getName() );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testLeadNegative(Context context) {
-        Member member = executeSingletonAxis(context.getConnection(), "[Gender].[M].Lead(-1)" );
+        Member member = executeSingletonAxis(context.getConnectionWithDefaultRole(), "[Gender].[M].Lead(-1)" );
         assertEquals( "F", member.getName() );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testLeadLastInLevel(Context context) {
-        Member member = executeSingletonAxis(context.getConnection(), "[Gender].[M].Lead(3)" );
+        Member member = executeSingletonAxis(context.getConnectionWithDefaultRole(), "[Gender].[M].Lead(3)" );
         assertNull( member );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testLeadNull(Context context) {
-        Member member = executeSingletonAxis(context.getConnection(), "[Gender].Parent.Lead(1)" );
+        Member member = executeSingletonAxis(context.getConnectionWithDefaultRole(), "[Gender].Parent.Lead(1)" );
         assertNull( member );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testLeadZero(Context context) {
-        Member member = executeSingletonAxis(context.getConnection(), "[Gender].[F].Lead(0)" );
+        Member member = executeSingletonAxis(context.getConnectionWithDefaultRole(), "[Gender].[F].Lead(0)" );
         assertEquals( "F", member.getName() );
     }
 

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/level/member/MemberLevelFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/level/member/MemberLevelFunDefTest.java
@@ -24,7 +24,7 @@ class MemberLevelFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testMemberLevel(Context context) {
-        TestUtil.assertExprReturns(context.getConnection(),
+        TestUtil.assertExprReturns(context.getConnectionWithDefaultRole(),
             "[Time].[1997].[Q1].[1].Level.UniqueName",
             "[Time].[Month]" );
     }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/level/numeric/LevelsNumericPropertyDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/level/numeric/LevelsNumericPropertyDefTest.java
@@ -26,7 +26,7 @@ class LevelsNumericPropertyDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testLevelsNumeric(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         TestUtil.assertExprReturns(connection, "[Time].[Time].Levels(2).Name", "Month" );
         TestUtil.assertExprReturns(connection, "[Time].[Time].Levels(0).Name", "Year" );
         TestUtil.assertExprReturns(connection, "[Product].Levels(0).Name", "(All)" );
@@ -35,14 +35,14 @@ class LevelsNumericPropertyDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testLevelsTooSmall(Context context) {
-        TestUtil.assertExprThrows(context.getConnection(),
+        TestUtil.assertExprThrows(context.getConnectionWithDefaultRole(),
             "[Time].[Time].Levels(-1).Name", "Index '-1' out of bounds" );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testLevelsTooLarge(Context context) {
-        TestUtil.assertExprThrows(context.getConnection(),
+        TestUtil.assertExprThrows(context.getConnectionWithDefaultRole(),
             "[Time].[Time].Levels(8).Name", "Index '8' out of bounds" );
     }
 

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/levels/string/LevelsStringFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/levels/string/LevelsStringFunDefTest.java
@@ -25,7 +25,7 @@ class LevelsStringFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testLevelsStringFail(Context context) {
-        TestUtil.assertExprThrows(context.getConnection(),
+        TestUtil.assertExprThrows(context.getConnectionWithDefaultRole(),
             "Levels(\"nonexistent\").UniqueName",
             "Level 'nonexistent' not found" );
     }
@@ -33,7 +33,7 @@ class LevelsStringFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testLevelsString(Context context) {
-      TestUtil.assertExprReturns(context.getConnection(),
+      TestUtil.assertExprReturns(context.getConnectionWithDefaultRole(),
         "Levels(\"[Time].[Year]\").UniqueName",
         "[Time].[Year]" );
     }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/levels/string/LevelsStringPropertyDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/levels/string/LevelsStringPropertyDefTest.java
@@ -25,14 +25,14 @@ class LevelsStringPropertyDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testHierarchyLevelsString(Context context) {
-        TestUtil.assertExprReturns(context.getConnection(),
+        TestUtil.assertExprReturns(context.getConnectionWithDefaultRole(),
             "[Time].[Time].Levels(\"Year\").UniqueName", "[Time].[Year]" );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testHierarchyLevelsStringFail(Context context) {
-        TestUtil.assertExprThrows(context.getConnection(),
+        TestUtil.assertExprThrows(context.getConnectionWithDefaultRole(),
             "[Time].[Time].Levels(\"nonexistent\").UniqueName",
             "Level 'nonexistent' not found in hierarchy '[Time]'" );
     }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/linreg/LinRegFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/linreg/LinRegFunDefTest.java
@@ -41,7 +41,7 @@ class LinRegFunDefTest {
         //   [Time].CurrentMember.Lag(9) : [Time].CurrentMember
         // is equivalent to
         //   LastPeriods(10)
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH MEMBER \n"
                 + "[Measures].[Intercept] AS \n"
                 + "  'LinRegIntercept([Time].CurrentMember.Lag(10) : [Time].CurrentMember, [Measures].[Unit Sales], "
@@ -110,7 +110,7 @@ class LinRegFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testLinRegPointMonth(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH MEMBER \n"
                 + "[Measures].[Test] as \n"
                 + "  'LinRegPoint(\n"
@@ -170,7 +170,7 @@ class LinRegFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testLinRegIntercept(Context context) {
-        FunctionTest.assertExprReturns(context.getConnection(),
+        FunctionTest.assertExprReturns(context.getConnectionWithDefaultRole(),
             "LinRegIntercept([Time].[Month].members,"
                 + " [Measures].[Unit Sales], [Measures].[Store Sales])",
             -126.65,
@@ -205,7 +205,7 @@ Intel platforms):
         // Mondrian can not return "missing data" value -1.#IND
         // empty set
         if ( false ) {
-            assertExprReturns(context.getConnection(),
+            assertExprReturns(context.getConnectionWithDefaultRole(),
                 "LinRegIntercept({[Time].Parent},"
                     + " [Measures].[Unit Sales], [Measures].[Store Sales])",
                 "-1.#IND" ); // MSAS returns -1.#IND (whatever that means)
@@ -213,14 +213,14 @@ Intel platforms):
 
         // first expr constant
         if ( false ) {
-            assertExprReturns(context.getConnection(),
+            assertExprReturns(context.getConnectionWithDefaultRole(),
                 "LinRegIntercept([Time].[Month].members,"
                     + " 7, [Measures].[Store Sales])",
                 "$7.00" );
         }
 
         // format does not add '$'
-        FunctionTest.assertExprReturns(context.getConnection(),
+        FunctionTest.assertExprReturns(context.getConnectionWithDefaultRole(),
             "LinRegIntercept([Time].[Month].members,"
                 + " 7, [Measures].[Store Sales])",
             7.00,
@@ -229,7 +229,7 @@ Intel platforms):
         // Mondrian can not return "missing data" value -1.#IND
         // second expr constant
         if ( false ) {
-            assertExprReturns(context.getConnection(),
+            assertExprReturns(context.getConnectionWithDefaultRole(),
                 "LinRegIntercept([Time].[Month].members,"
                     + " [Measures].[Unit Sales], 4)",
                 "-1.#IND" ); // MSAS returns -1.#IND (whatever that means)
@@ -240,7 +240,7 @@ Intel platforms):
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testLinRegSlope(Context context) {
-        FunctionTest.assertExprReturns(context.getConnection(),
+        FunctionTest.assertExprReturns(context.getConnectionWithDefaultRole(),
             "LinRegSlope([Time].[Month].members,"
                 + " [Measures].[Unit Sales], [Measures].[Store Sales])",
             0.4746,
@@ -249,7 +249,7 @@ Intel platforms):
         // Mondrian can not return "missing data" value -1.#IND
         // empty set
         if ( false ) {
-            assertExprReturns(context.getConnection(),
+            assertExprReturns(context.getConnectionWithDefaultRole(),
                 "LinRegSlope({[Time].Parent},"
                     + " [Measures].[Unit Sales], [Measures].[Store Sales])",
                 "-1.#IND" ); // MSAS returns -1.#IND (whatever that means)
@@ -257,7 +257,7 @@ Intel platforms):
 
         // first expr constant
         if ( false ) {
-            assertExprReturns(context.getConnection(),
+            assertExprReturns(context.getConnectionWithDefaultRole(),
                 "LinRegSlope([Time].[Month].members,"
                     + " 7, [Measures].[Store Sales])",
                 "$7.00" );
@@ -265,7 +265,7 @@ Intel platforms):
         // ^^^^
         // copy and paste error
 
-        FunctionTest.assertExprReturns(context.getConnection(),
+        FunctionTest.assertExprReturns(context.getConnectionWithDefaultRole(),
             "LinRegSlope([Time].[Month].members,"
                 + " 7, [Measures].[Store Sales])",
             0.00,
@@ -274,7 +274,7 @@ Intel platforms):
         // Mondrian can not return "missing data" value -1.#IND
         // second expr constant
         if ( false ) {
-            assertExprReturns(context.getConnection(),
+            assertExprReturns(context.getConnectionWithDefaultRole(),
                 "LinRegSlope([Time].[Month].members,"
                     + " [Measures].[Unit Sales], 4)",
                 "-1.#IND" ); // MSAS returns -1.#IND (whatever that means)
@@ -286,7 +286,7 @@ Intel platforms):
     void testLinRegPoint(Context context) {
         // NOTE: mdx does not parse
         if ( false ) {
-            assertExprReturns(context.getConnection(),
+            assertExprReturns(context.getConnectionWithDefaultRole(),
                 "LinRegPoint([Measures].[Unit Sales],"
                     + " [Time].CurrentMember[Time].[Month].members,"
                     + " [Measures].[Unit Sales], [Measures].[Store Sales])",
@@ -296,7 +296,7 @@ Intel platforms):
         // Mondrian can not return "missing data" value -1.#IND
         // empty set
         if ( false ) {
-            assertExprReturns(context.getConnection(),
+            assertExprReturns(context.getConnectionWithDefaultRole(),
                 "LinRegPoint([Measures].[Unit Sales],"
                     + " {[Time].Parent},"
                     + " [Measures].[Unit Sales], [Measures].[Store Sales])",
@@ -306,7 +306,7 @@ Intel platforms):
         // Expected value is wrong
         // zeroth expr constant
         if ( false ) {
-            assertExprReturns(context.getConnection(),
+            assertExprReturns(context.getConnectionWithDefaultRole(),
                 "LinRegPoint(-1,"
                     + " [Time].[Month].members,"
                     + " 7, [Measures].[Store Sales])", "-127.124" );
@@ -314,14 +314,14 @@ Intel platforms):
 
         // first expr constant
         if ( false ) {
-            assertExprReturns(context.getConnection(),
+            assertExprReturns(context.getConnectionWithDefaultRole(),
                 "LinRegPoint([Measures].[Unit Sales],"
                     + " [Time].[Month].members,"
                     + " 7, [Measures].[Store Sales])", "$7.00" );
         }
 
         // format does not add '$'
-        FunctionTest.assertExprReturns(context.getConnection(),
+        FunctionTest.assertExprReturns(context.getConnectionWithDefaultRole(),
             "LinRegPoint([Measures].[Unit Sales],"
                 + " [Time].[Month].members,"
                 + " 7, [Measures].[Store Sales])",
@@ -331,7 +331,7 @@ Intel platforms):
         // Mondrian can not return "missing data" value -1.#IND
         // second expr constant
         if ( false ) {
-            assertExprReturns(context.getConnection(),
+            assertExprReturns(context.getConnectionWithDefaultRole(),
                 "LinRegPoint([Measures].[Unit Sales],"
                     + " [Time].[Month].members,"
                     + " [Measures].[Unit Sales], 4)",
@@ -345,7 +345,7 @@ Intel platforms):
     void _testLinRegR2(Context context) {
         // Why would R2 equal the slope
         if ( false ) {
-            assertExprReturns(context.getConnection(),
+            assertExprReturns(context.getConnectionWithDefaultRole(),
                 "LinRegR2([Time].[Month].members,"
                     + " [Measures].[Unit Sales], [Measures].[Store Sales])",
                 "0.4746" );
@@ -354,14 +354,14 @@ Intel platforms):
         // Mondrian can not return "missing data" value -1.#IND
         // empty set
         if ( false ) {
-            assertExprReturns(context.getConnection(),
+            assertExprReturns(context.getConnectionWithDefaultRole(),
                 "LinRegR2({[Time].Parent},"
                     + " [Measures].[Unit Sales], [Measures].[Store Sales])",
                 "-1.#IND" ); // MSAS returns -1.#IND (whatever that means)
         }
 
         // first expr constant
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "LinRegR2([Time].[Month].members,"
                 + " 7, [Measures].[Store Sales])",
             "$7.00" );
@@ -369,7 +369,7 @@ Intel platforms):
         // Mondrian can not return "missing data" value -1.#IND
         // second expr constant
         if ( false ) {
-            assertExprReturns(context.getConnection(),
+            assertExprReturns(context.getConnectionWithDefaultRole(),
                 "LinRegR2([Time].[Month].members,"
                     + " [Measures].[Unit Sales], 4)",
                 "-1.#IND" ); // MSAS returns -1.#IND (whatever that means)
@@ -381,25 +381,25 @@ Intel platforms):
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void _testLinRegVariance(Context context) {
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "LinRegVariance([Time].[Month].members,"
                 + " [Measures].[Unit Sales], [Measures].[Store Sales])",
             "0.4746" );
 
         // empty set
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "LinRegVariance({[Time].Parent},"
                 + " [Measures].[Unit Sales], [Measures].[Store Sales])",
             "-1.#IND" ); // MSAS returns -1.#IND (whatever that means)
 
         // first expr constant
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "LinRegVariance([Time].[Month].members,"
                 + " 7, [Measures].[Store Sales])",
             "$7.00" );
 
         // second expr constant
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "LinRegVariance([Time].[Month].members,"
                 + " [Measures].[Unit Sales], 4)",
             "-1.#IND" ); // MSAS returns -1.#IND (whatever that means)

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/linreg/PointFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/linreg/PointFunDefTest.java
@@ -28,7 +28,7 @@ class PointFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testLinRegPointQuarter(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH MEMBER [Measures].[Test] as \n"
                 + "  'LinRegPoint(\n"
                 + "    Rank(Time.[Time].CurrentMember, Time.[Time].CurrentMember.Level.Members),\n"

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/logical/IsEmptyFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/logical/IsEmptyFunDefTest.java
@@ -29,7 +29,7 @@ class IsEmptyFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testIsEmptyWithAggregate(Context context) {
-        TestUtil.assertQueryReturns(context.getConnection(),
+        TestUtil.assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH MEMBER [gender].[foo] AS 'isEmpty(Aggregate({[Gender].m}))' "
                 + "SELECT {Gender.foo} on 0 from sales",
             "Axis #0:\n"
@@ -42,7 +42,7 @@ class IsEmptyFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testIsEmpty(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         assertBooleanExprReturns(connection, "[Gender].[All Gender].Parent IS NULL", true );
 
         // Any functions that return a member from parameters that

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/logical/IsFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/logical/IsFunDefTest.java
@@ -28,16 +28,16 @@ class IsFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testIsMember(Context context) {
-        assertBooleanExprReturns(context.getConnection(),
+        assertBooleanExprReturns(context.getConnectionWithDefaultRole(),
             " Store.[USA].parent IS Store.[All Stores]", true );
-        assertBooleanExprReturns(context.getConnection(),
+        assertBooleanExprReturns(context.getConnectionWithDefaultRole(),
             " [Store].[USA].[CA].parent IS [Store].[Mexico]", false );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testIsString(Context context) {
-        assertExprThrows(context.getConnection(),
+        assertExprThrows(context.getConnectionWithDefaultRole(),
             " [Store].[USA].Name IS \"USA\" ",
             "No function matches signature '<String> IS <String>'" );
     }
@@ -45,7 +45,7 @@ class IsFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testIsNumeric(Context context) {
-        assertExprThrows(context.getConnection(),
+        assertExprThrows(context.getConnectionWithDefaultRole(),
             " [Store].[USA].Level.Ordinal IS 25 ",
             "No function matches signature '<Numeric Expression> IS <Numeric Expression>'" );
     }
@@ -53,25 +53,25 @@ class IsFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testIsTuple(Context context) {
-        assertBooleanExprReturns(context.getConnection(),
+        assertBooleanExprReturns(context.getConnectionWithDefaultRole(),
             " (Store.[USA], Gender.[M]) IS (Store.[USA], Gender.[M])", true );
-        assertBooleanExprReturns(context.getConnection(),
+        assertBooleanExprReturns(context.getConnectionWithDefaultRole(),
             " (Store.[USA], Gender.[M]) IS (Gender.[M], Store.[USA])", true );
-        assertBooleanExprReturns(context.getConnection(),
+        assertBooleanExprReturns(context.getConnectionWithDefaultRole(),
             " (Store.[USA], Gender.[M]) IS (Gender.[M], Store.[USA]) "
                 + "OR [Gender] IS NULL",
             true );
-        assertBooleanExprReturns(context.getConnection(),
+        assertBooleanExprReturns(context.getConnectionWithDefaultRole(),
             " (Store.[USA], Gender.[M]) IS (Gender.[M], Store.[USA]) "
                 + "AND [Gender] IS NULL",
             false );
-        assertBooleanExprReturns(context.getConnection(),
+        assertBooleanExprReturns(context.getConnectionWithDefaultRole(),
             " (Store.[USA], Gender.[M]) IS (Store.[USA], Gender.[F])",
             false );
-        assertBooleanExprReturns(context.getConnection(),
+        assertBooleanExprReturns(context.getConnectionWithDefaultRole(),
             " (Store.[USA], Gender.[M]) IS (Store.[USA])",
             false );
-        assertBooleanExprReturns(context.getConnection(),
+        assertBooleanExprReturns(context.getConnectionWithDefaultRole(),
             " (Store.[USA], Gender.[M]) IS Store.[USA]",
             false );
     }
@@ -79,26 +79,26 @@ class IsFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testIsLevel(Context context) {
-        assertBooleanExprReturns(context.getConnection(),
+        assertBooleanExprReturns(context.getConnectionWithDefaultRole(),
             " Store.[USA].level IS Store.[Store Country] ", true );
-        assertBooleanExprReturns(context.getConnection(),
+        assertBooleanExprReturns(context.getConnectionWithDefaultRole(),
             " Store.[USA].[CA].level IS Store.[Store Country] ", false );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testIsHierarchy(Context context) {
-        assertBooleanExprReturns(context.getConnection(),
+        assertBooleanExprReturns(context.getConnectionWithDefaultRole(),
             " Store.[USA].hierarchy IS Store.[Mexico].hierarchy ", true );
-        assertBooleanExprReturns(context.getConnection(),
+        assertBooleanExprReturns(context.getConnectionWithDefaultRole(),
             " Store.[USA].hierarchy IS Gender.[M].hierarchy ", false );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testIsDimension(Context context) {
-        assertBooleanExprReturns(context.getConnection(), " Store.[USA].dimension IS Store ", true );
-        assertBooleanExprReturns(context.getConnection()," Gender.[M].dimension IS Store ", false );
+        assertBooleanExprReturns(context.getConnectionWithDefaultRole(), " Store.[USA].dimension IS Store ", true );
+        assertBooleanExprReturns(context.getConnectionWithDefaultRole()," Gender.[M].dimension IS Store ", false );
     }
 
 }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/logical/IsNullFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/logical/IsNullFunDefTest.java
@@ -28,15 +28,15 @@ class IsNullFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testIsNull(Context context) {
-        assertBooleanExprReturns(context.getConnection(), " Measures.[Profit] IS NULL ", false );
-        assertBooleanExprReturns(context.getConnection(), " Store.[All Stores] IS NULL ", false );
-        assertBooleanExprReturns(context.getConnection(), " Store.[All Stores].parent IS NULL ", true );
+        assertBooleanExprReturns(context.getConnectionWithDefaultRole(), " Measures.[Profit] IS NULL ", false );
+        assertBooleanExprReturns(context.getConnectionWithDefaultRole(), " Store.[All Stores] IS NULL ", false );
+        assertBooleanExprReturns(context.getConnectionWithDefaultRole(), " Store.[All Stores].parent IS NULL ", true );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testIsNullWithCalcMem(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with member Store.foo as '1010' "
                 + "member measures.bar as 'Store.currentmember IS NULL' "
                 + "SELECT measures.bar on 0, {Store.foo} on 1 from sales",

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/median/MedianFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/median/MedianFunDefTest.java
@@ -28,12 +28,12 @@ class MedianFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testMedian(Context context) {
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "MEDIAN({[Store].[All Stores].[USA].children},"
                 + "[Measures].[Store Sales])",
             "159,167.84" );
         // single value
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "MEDIAN({[Store].[All Stores].[USA]}, [Measures].[Store Sales])",
             "565,238.13" );
     }
@@ -41,7 +41,7 @@ class MedianFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testMedian2(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH\n"
                 + "   Member [Time].[Time].[1st Half Sales] AS 'Sum({[Time].[1997].[Q1], [Time].[1997].[Q2]})'\n"
                 + "   Member [Time].[Time].[2nd Half Sales] AS 'Sum({[Time].[1997].[Q3], [Time].[1997].[Q4]})'\n"

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/member/AncestorsFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/member/AncestorsFunDefTest.java
@@ -30,7 +30,7 @@ class AncestorsFunDefTest {
     void testAncestors(Context context) {
         // Test that we can execute Ancestors by passing a level as
         // the depth argument (PC hierarchy)
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         assertQueryReturns(connection,
             "with\n"
                 + "set [*ancestors] as\n"

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/member/cousin/CousinFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/member/cousin/CousinFunDefTest.java
@@ -33,14 +33,14 @@ class CousinFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCousin1(Context context) {
-        Member member = executeSingletonAxis(context.getConnection(), "Cousin([1997].[Q4],[1998])" );
+        Member member = executeSingletonAxis(context.getConnectionWithDefaultRole(), "Cousin([1997].[Q4],[1998])" );
         assertEquals( "[Time].[1998].[Q4]", member.getUniqueName() );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCousin2(Context context) {
-        Member member = executeSingletonAxis(context.getConnection(),
+        Member member = executeSingletonAxis(context.getConnectionWithDefaultRole(),
             "Cousin([1997].[Q4].[12],[1998].[Q1])" );
         assertEquals( "[Time].[1998].[Q1].[3]", member.getUniqueName() );
     }
@@ -48,7 +48,7 @@ class CousinFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCousinOverrun(Context context) {
-        Member member = executeSingletonAxis(context.getConnection(),
+        Member member = executeSingletonAxis(context.getConnectionWithDefaultRole(),
             "Cousin([Customers].[USA].[CA].[San Jose],"
                 + " [Customers].[USA].[OR])" );
         // CA has more cities than OR
@@ -59,7 +59,7 @@ class CousinFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCousinThreeDown(Context context) {
         Member member =
-            executeSingletonAxis(context.getConnection(),
+            executeSingletonAxis(context.getConnectionWithDefaultRole(),
                 "Cousin([Customers].[USA].[CA].[Berkeley].[Barbara Combs],"
                     + " [Customers].[Mexico])" );
         // Barbara Combs is the 6th child
@@ -79,7 +79,7 @@ class CousinFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCousinSameLevel(Context context) {
         Member member =
-            executeSingletonAxis(context.getConnection(), "Cousin([Gender].[M], [Gender].[F])" );
+            executeSingletonAxis(context.getConnectionWithDefaultRole(), "Cousin([Gender].[M], [Gender].[F])" );
         assertEquals( "F", member.getName() );
     }
 
@@ -87,14 +87,14 @@ class CousinFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCousinHigherLevel(Context context) {
         Member member =
-            executeSingletonAxis(context.getConnection(), "Cousin([Time].[1997], [Time].[1998].[Q1])" );
+            executeSingletonAxis(context.getConnectionWithDefaultRole(), "Cousin([Time].[1997], [Time].[1998].[Q1])" );
         assertNull( member );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCousinWrongHierarchy(Context context) {
-        assertAxisThrows(context.getConnection(),
+        assertAxisThrows(context.getConnectionWithDefaultRole(),
             "Cousin([Time].[1997], [Gender].[M])",
             MessageFormat.format(cousinHierarchyMismatch,
                 "[Time].[1997]",

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/member/defaultmember/DefaultMemberFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/member/defaultmember/DefaultMemberFunDefTest.java
@@ -51,7 +51,7 @@ class DefaultMemberFunDefTest {
         // [Time] has no default member and no all, so the default member is
         // the first member of the first level.
         Result result =
-            executeQuery(context.getConnection(),
+            executeQuery(context.getConnectionWithDefaultRole(),
                 "select {[Time].[Time].DefaultMember} on columns\n"
                     + "from Sales" );
         assertEquals(
@@ -60,7 +60,7 @@ class DefaultMemberFunDefTest {
 
         // [Time].[Weekly] has an all member and no explicit default.
         result =
-            executeQuery(context.getConnection(),
+            executeQuery(context.getConnectionWithDefaultRole(),
                 "select {[Time.Weekly].DefaultMember} on columns\n"
                     + "from Sales" );
         assertEquals(
@@ -188,7 +188,7 @@ class DefaultMemberFunDefTest {
         // In this variant of the schema, Time2.Weekly has an explicit default
         // member.
         result =
-            executeQuery(context.getConnection(),
+            executeQuery(context.getConnectionWithDefaultRole(),
                 "select {[Time2.Weekly].DefaultMember} on columns\n"
                     + "from Sales" );
         assertEquals(
@@ -199,7 +199,7 @@ class DefaultMemberFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDimensionDefaultMember(Context context) {
-      Member member = executeSingletonAxis(context.getConnection(), "[Measures].DefaultMember" );
+      Member member = executeSingletonAxis(context.getConnectionWithDefaultRole(), "[Measures].DefaultMember" );
       assertEquals( "Unit Sales", member.getName() );
     }
 

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/member/firstchild/FirstChildFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/member/firstchild/FirstChildFunDefTest.java
@@ -31,7 +31,7 @@ class FirstChildFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testFirstChildFirstInLevel(Context context) {
-        Member member = executeSingletonAxis(context.getConnection(), "[Time].[1997].[Q4].FirstChild" );
+        Member member = executeSingletonAxis(context.getConnectionWithDefaultRole(), "[Time].[1997].[Q4].FirstChild" );
         assertEquals( "10", member.getName() );
     }
 
@@ -39,7 +39,7 @@ class FirstChildFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testFirstChildAll(Context context) {
         Member member =
-            executeSingletonAxis(context.getConnection(), "[Gender].[All Gender].FirstChild" );
+            executeSingletonAxis(context.getConnectionWithDefaultRole(), "[Gender].[All Gender].FirstChild" );
         assertEquals( "F", member.getName() );
     }
 
@@ -47,7 +47,7 @@ class FirstChildFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testFirstChildOfChildless(Context context) {
         Member member =
-            executeSingletonAxis(context.getConnection(), "[Gender].[All Gender].[F].FirstChild" );
+            executeSingletonAxis(context.getConnectionWithDefaultRole(), "[Gender].[All Gender].[F].FirstChild" );
         assertNull( member );
     }
 

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/member/firstsibling/FirstSiblingFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/member/firstsibling/FirstSiblingFunDefTest.java
@@ -32,7 +32,7 @@ class FirstSiblingFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testFirstSiblingFirstInLevel(Context context) {
-        Member member = executeSingletonAxis(context.getConnection(), "[Gender].[F].FirstSibling" );
+        Member member = executeSingletonAxis(context.getConnectionWithDefaultRole(), "[Gender].[F].FirstSibling" );
         assertEquals( "F", member.getName() );
     }
 
@@ -40,7 +40,7 @@ class FirstSiblingFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testFirstSiblingLastInLevel(Context context) {
         Member member =
-            executeSingletonAxis(context.getConnection(), "[Time].[1997].[Q4].FirstSibling" );
+            executeSingletonAxis(context.getConnectionWithDefaultRole(), "[Time].[1997].[Q4].FirstSibling" );
         assertEquals( "Q1", member.getName() );
     }
 
@@ -48,7 +48,7 @@ class FirstSiblingFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testFirstSiblingAll(Context context) {
         Member member =
-            executeSingletonAxis(context.getConnection(), "[Gender].[All Gender].FirstSibling" );
+            executeSingletonAxis(context.getConnectionWithDefaultRole(), "[Gender].[All Gender].FirstSibling" );
         assertTrue( member.isAll() );
     }
 
@@ -58,7 +58,7 @@ class FirstSiblingFunDefTest {
         // The [Measures] hierarchy does not have an 'all' member, so
         // [Unit Sales] does not have a parent.
         Member member =
-            executeSingletonAxis(context.getConnection(), "[Measures].[Store Sales].FirstSibling" );
+            executeSingletonAxis(context.getConnectionWithDefaultRole(), "[Measures].[Store Sales].FirstSibling" );
         assertEquals( "Unit Sales", member.getName() );
     }
 
@@ -66,7 +66,7 @@ class FirstSiblingFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testFirstSiblingNull(Context context) {
         Member member =
-            executeSingletonAxis(context.getConnection(), "[Gender].[F].FirstChild.FirstSibling" );
+            executeSingletonAxis(context.getConnectionWithDefaultRole(), "[Gender].[F].FirstChild.FirstSibling" );
         assertNull( member );
     }
 

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/member/lastchild/LastChildFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/member/lastchild/LastChildFunDefTest.java
@@ -30,28 +30,28 @@ class LastChildFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testLastChild(Context context) {
-        Member member = executeSingletonAxis(context.getConnection(), "[Gender].LastChild" );
+        Member member = executeSingletonAxis(context.getConnectionWithDefaultRole(), "[Gender].LastChild" );
         assertEquals( "M", member.getName() );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testLastChildLastInLevel(Context context) {
-        Member member = executeSingletonAxis(context.getConnection(), "[Time].[1997].[Q4].LastChild" );
+        Member member = executeSingletonAxis(context.getConnectionWithDefaultRole(), "[Time].[1997].[Q4].LastChild" );
         assertEquals( "12", member.getName() );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testLastChildAll(Context context) {
-        Member member = executeSingletonAxis(context.getConnection(), "[Gender].[All Gender].LastChild" );
+        Member member = executeSingletonAxis(context.getConnectionWithDefaultRole(), "[Gender].[All Gender].LastChild" );
         assertEquals( "M", member.getName() );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testLastChildOfChildless(Context context) {
-        Member member = executeSingletonAxis(context.getConnection(), "[Gender].[M].LastChild" );
+        Member member = executeSingletonAxis(context.getConnectionWithDefaultRole(), "[Gender].[M].LastChild" );
         assertNull( member );
     }
 

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/member/lastsibling/LastSiblingFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/member/lastsibling/LastSiblingFunDefTest.java
@@ -31,14 +31,14 @@ class LastSiblingFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testLastSibling(Context context) {
-        Member member = executeSingletonAxis(context.getConnection(), "[Gender].[F].LastSibling" );
+        Member member = executeSingletonAxis(context.getConnectionWithDefaultRole(), "[Gender].[F].LastSibling" );
         assertEquals( "M", member.getName() );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testLastSiblingFirstInLevel(Context context) {
-        Member member = executeSingletonAxis(context.getConnection(), "[Time].[1997].[Q1].LastSibling" );
+        Member member = executeSingletonAxis(context.getConnectionWithDefaultRole(), "[Time].[1997].[Q1].LastSibling" );
         assertEquals( "Q4", member.getName() );
     }
 
@@ -46,7 +46,7 @@ class LastSiblingFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testLastSiblingAll(Context context) {
         Member member =
-            executeSingletonAxis(context.getConnection(), "[Gender].[All Gender].LastSibling" );
+            executeSingletonAxis(context.getConnectionWithDefaultRole(), "[Gender].[All Gender].LastSibling" );
         assertTrue( member.isAll() );
     }
 
@@ -55,7 +55,7 @@ class LastSiblingFunDefTest {
     void testLastSiblingRoot(Context context) {
         // The [Time] hierarchy does not have an 'all' member, so
         // [1997], [1998] do not have parents.
-        Member member = executeSingletonAxis(context.getConnection(), "[Time].[1998].LastSibling" );
+        Member member = executeSingletonAxis(context.getConnectionWithDefaultRole(), "[Time].[1998].LastSibling" );
         assertEquals( "1998", member.getName() );
     }
 
@@ -63,7 +63,7 @@ class LastSiblingFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testLastSiblingNull(Context context) {
         Member member =
-            executeSingletonAxis(context.getConnection(), "[Gender].[F].FirstChild.LastSibling" );
+            executeSingletonAxis(context.getConnectionWithDefaultRole(), "[Gender].[F].FirstChild.LastSibling" );
         assertNull( member );
     }
 

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/member/namedsetcurrentordinal/NamedSetCurrentOrdinalFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/member/namedsetcurrentordinal/NamedSetCurrentOrdinalFunDefTest.java
@@ -37,7 +37,7 @@ class NamedSetCurrentOrdinalFunDefTest {
         if ( Util.RETROWOVEN) {
             return;
         }
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with set [Time Regular] as [Time].[Time].Members\n"
                 + " set [Time Reversed] as"
                 + " Order([Time Regular], [Time Regular].CurrentOrdinal, BDESC)\n"
@@ -127,7 +127,7 @@ class NamedSetCurrentOrdinalFunDefTest {
         if ( Util.RETROWOVEN) {
             return;
         }
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             " with set [Time Regular] as [Time].[Time].Members\n"
                 + "set [Every Other Time] as\n"
                 + "  Generate(\n"
@@ -183,7 +183,7 @@ class NamedSetCurrentOrdinalFunDefTest {
         if ( Util.RETROWOVEN) {
             return;
         }
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with set [Time Regular] as [Time].[Time].Members\n"
                 + " set [Time Subset] as "
                 + "   Filter([Time Regular], [Time Regular].CurrentOrdinal = 3"

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/member/nextmember/NextMemberFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/member/nextmember/NextMemberFunDefTest.java
@@ -30,7 +30,7 @@ class NextMemberFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testBasic2(Context context) {
         Result result =
-            executeQuery(context.getConnection(),
+            executeQuery(context.getConnectionWithDefaultRole(),
                 "select {[Gender].[F].NextMember} ON COLUMNS from Sales" );
         assertEquals(
             "M",
@@ -41,7 +41,7 @@ class NextMemberFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testFirstInLevel2(Context context) {
         Result result =
-            executeQuery(context.getConnection(),
+            executeQuery(context.getConnectionWithDefaultRole(),
                 "select {[Gender].[M].NextMember} ON COLUMNS from Sales" );
         assertEquals( 0, result.getAxes()[ 0 ].getPositions().size() );
     }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/member/parentcalc/ParentFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/member/parentcalc/ParentFunDefTest.java
@@ -34,7 +34,7 @@ class ParentFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testParent(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         assertMemberExprDependsOn(connection,
             "[Gender].Parent",
             "{[Gender]}" );
@@ -51,7 +51,7 @@ class ParentFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testParentPC(Context context) {
         //final Context testContext = getContext().withCube( "HR" );
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         assertAxisReturns(connection, "HR",
             "[Employees].Parent",
             "" );
@@ -91,7 +91,7 @@ class ParentFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testBasic5(Context context) {
         Result result =
-            executeQuery(context.getConnection(),
+            executeQuery(context.getConnectionWithDefaultRole(),
                 "select{ [Product].[All Products].[Drink].Parent} on columns "
                     + "from Sales" );
         assertEquals(
@@ -103,7 +103,7 @@ class ParentFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testFirstInLevel5(Context context) {
         Result result =
-            executeQuery(context.getConnection(),
+            executeQuery(context.getConnectionWithDefaultRole(),
                 "select {[Time].[1997].[Q2].[4].Parent} on columns,"
                     + "{[Gender].[M]} on rows from Sales" );
         assertEquals(
@@ -115,7 +115,7 @@ class ParentFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testAll5(Context context) {
         Result result =
-            executeQuery(context.getConnection(),
+            executeQuery(context.getConnectionWithDefaultRole(),
                 "select {[Time].[1997].[Q2].Parent} on columns,"
                     + "{[Gender].[M]} on rows from Sales" );
         // previous to [Gender].[All] is null, so no members are returned

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/member/prevmember/PrevMemberFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/member/prevmember/PrevMemberFunDefTest.java
@@ -29,7 +29,7 @@ class PrevMemberFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testAll2(Context context) {
         Result result =
-            executeQuery(context.getConnection(), "select {[Gender].PrevMember} ON COLUMNS from Sales" );
+            executeQuery(context.getConnectionWithDefaultRole(), "select {[Gender].PrevMember} ON COLUMNS from Sales" );
         // previous to [Gender].[All] is null, so no members are returned
         assertEquals( 0, result.getAxes()[ 0 ].getPositions().size() );
     }
@@ -38,7 +38,7 @@ class PrevMemberFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testBasic(Context context) {
         Result result =
-            executeQuery(context.getConnection(),
+            executeQuery(context.getConnectionWithDefaultRole(),
                 "select {[Gender].[M].PrevMember} ON COLUMNS from Sales" );
         assertEquals(
             "F",
@@ -49,7 +49,7 @@ class PrevMemberFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testFirstInLevel(Context context) {
         Result result =
-            executeQuery(context.getConnection(),
+            executeQuery(context.getConnectionWithDefaultRole(),
                 "select {[Gender].[F].PrevMember} ON COLUMNS from Sales" );
         assertEquals( 0, result.getAxes()[ 0 ].getPositions().size() );
     }
@@ -58,7 +58,7 @@ class PrevMemberFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testAll(Context context) {
         Result result =
-            executeQuery(context.getConnection(), "select {[Gender].PrevMember} ON COLUMNS from Sales" );
+            executeQuery(context.getConnectionWithDefaultRole(), "select {[Gender].PrevMember} ON COLUMNS from Sales" );
         // previous to [Gender].[All] is null, so no members are returned
         assertEquals( 0, result.getAxes()[ 0 ].getPositions().size() );
     }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/member/strtomember/StrToMemberFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/member/strtomember/StrToMemberFunDefTest.java
@@ -34,7 +34,7 @@ class StrToMemberFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testStrToMember(Context context) {
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "StrToMember(\"[Time].[1997].[Q2].[4]\").Name",
             "4" );
     }
@@ -42,7 +42,7 @@ class StrToMemberFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testStrToMemberUniqueName(Context context) {
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "StrToMember(\"[Store].[USA].[CA]\").Name",
             "CA" );
     }
@@ -50,7 +50,7 @@ class StrToMemberFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testStrToMemberFullyQualifiedName(Context context) {
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "StrToMember(\"[Store].[All Stores].[USA].[CA]\").Name",
             "CA" );
     }
@@ -60,13 +60,13 @@ class StrToMemberFunDefTest {
     void testStrToMemberNull(Context context) {
         // SSAS 2005 gives "#Error An MDX expression was expected. An empty
         // expression was specified."
-        assertExprThrows(context.getConnection(),
+        assertExprThrows(context.getConnectionWithDefaultRole(),
             "StrToMember(null).Name",
             "An MDX expression was expected. An empty expression was specified" );
-        assertExprThrows(context.getConnection(),
+        assertExprThrows(context.getConnectionWithDefaultRole(),
             "StrToSet(null, [Gender]).Count",
             "An MDX expression was expected. An empty expression was specified" );
-        assertExprThrows(context.getConnection(),
+        assertExprThrows(context.getConnectionWithDefaultRole(),
             "StrToTuple(null, [Gender]).Name",
             "An MDX expression was expected. An empty expression was specified" );
     }
@@ -84,7 +84,7 @@ class StrToMemberFunDefTest {
 
         // [Product].[Drugs] is invalid, becomes null member, and is dropped
         // from list
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select \n"
                 + "  {[Product].[Food],\n"
                 + "    StrToMember(\"[Product].[Drugs]\")} on columns,\n"
@@ -99,36 +99,36 @@ class StrToMemberFunDefTest {
                 + "Row #0: 191,940\n" );
 
         // Hierarchy is inferred from leading edge
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "StrToMember(\"[Marital Status].[Separated]\").Hierarchy.Name",
             "Marital Status" );
 
         // Null member is returned
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "StrToMember(\"[Marital Status].[Separated]\").Name",
             "#null" );
 
         // Use longest valid prefix, so get [Time].[Weekly] rather than just
         // [Time].
         final String timeWeekly = hierarchyName( "Time", "Weekly" );
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "StrToMember(\"" + timeWeekly
                 + ".[1996].[Q1]\").Hierarchy.UniqueName",
             timeWeekly );
 
         // If hierarchy is invalid, throw an error even though
         // IgnoreInvalidMembersDuringQuery is set.
-        assertExprThrows(context.getConnection(),
+        assertExprThrows(context.getConnectionWithDefaultRole(),
             "StrToMember(\"[Unknown Hierarchy].[Invalid].[Member]\").Name",
             "MDX object '[Unknown Hierarchy].[Invalid].[Member]' not found in cube 'Sales'" );
-        assertExprThrows(context.getConnection(),
+        assertExprThrows(context.getConnectionWithDefaultRole(),
             "StrToMember(\"[Unknown Hierarchy].[Invalid]\").Name",
             "MDX object '[Unknown Hierarchy].[Invalid]' not found in cube 'Sales'" );
-        assertExprThrows(context.getConnection(),
+        assertExprThrows(context.getConnectionWithDefaultRole(),
             "StrToMember(\"[Unknown Hierarchy]\").Name",
             "MDX object '[Unknown Hierarchy]' not found in cube 'Sales'" );
 
-        assertAxisThrows(context.getConnection(),
+        assertAxisThrows(context.getConnectionWithDefaultRole(),
             "StrToMember(\"\")",
             "MDX object '' not found in cube 'Sales'" );
 

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/member/validmeasure/ValidMeasureFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/member/validmeasure/ValidMeasureFunDefTest.java
@@ -32,7 +32,7 @@ class ValidMeasureFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testValidMeasure(Context context) {
-        TestUtil.assertQueryReturns(context.getConnection(),
+        TestUtil.assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with\n"
                 + "member measures.[with VM] as 'validmeasure([measures].[unit sales])'\n"
                 + "select { measures.[with VM]} on 0,\n"
@@ -55,7 +55,7 @@ class ValidMeasureFunDefTest {
     void _testValidMeasureNonEmpty(Context context) {
         // Note that [with VM2] is NULL where it needs to be - and therefore
         // does not prevent NON EMPTY from eliminating empty rows.
-        TestUtil.assertQueryReturns(context.getConnection(),
+        TestUtil.assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with set [Foo] as ' Crossjoin({[Time].Children}, {[Measures].[Warehouse Sales]}) '\n"
                 + " member [Measures].[with VM] as 'ValidMeasure([Measures].[Unit Sales])'\n"
                 + " member [Measures].[with VM2] as 'Iif(Count(Filter([Foo], not isempty([Measures].CurrentMember))) > 0, "
@@ -102,7 +102,7 @@ class ValidMeasureFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testValidMeasureTupleHasAnotherMember(Context context) {
-        TestUtil.assertQueryReturns(context.getConnection(),
+        TestUtil.assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with\n"
                 + "member measures.[with VM] as 'validmeasure(([measures].[unit sales],[customers].[all customers]))'\n"
                 + "select { measures.[with VM]} on 0,\n"
@@ -123,7 +123,7 @@ class ValidMeasureFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testValidMeasureDepends(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         String s12 = FunctionTest.allHiersExcept( "[Measures]" );
         TestUtil.assertExprDependsOn(connection,
             "ValidMeasure([Measures].[Unit Sales])", s12 );
@@ -144,7 +144,7 @@ class ValidMeasureFunDefTest {
     void testValidMeasureNonVirtualCube(Context context) {
         // verify ValidMeasure used outside of a virtual cube
         // is effectively a no-op.
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         TestUtil.assertQueryReturns(connection,
             "with member measures.vm as 'ValidMeasure(measures.[Store Sales])'"
                 + " select measures.[vm] on 0 from Sales",
@@ -182,7 +182,7 @@ class ValidMeasureFunDefTest {
             "The function ValidMeasure cannot be used with the measure '[Measures].[calc]' because it is a calculated "
                 + "member." );
         // Check the working version
-        TestUtil.assertQueryReturns(context.getConnection(),
+        TestUtil.assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with \n"
                 + "member measures.vm as 'ValidMeasure(measures.[warehouse sales])' \n"
                 + "select from [warehouse and sales] where (measures.vm, gender.f) \n",

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/minmax/MinMaxFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/minmax/MinMaxFunDefTest.java
@@ -29,7 +29,7 @@ class MinMaxFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testMax(Context context) {
-        FunctionTest.assertExprReturns(context.getConnection(),
+        FunctionTest.assertExprReturns(context.getConnectionWithDefaultRole(),
             "MAX({[Store].[All Stores].[USA].children},[Measures].[Store Sales])",
             "263,793.22" );
     }
@@ -38,7 +38,7 @@ class MinMaxFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testMaxNegative(Context context) {
         // Bug 1771928, "Max() works incorrectly with negative values"
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with \n"
                 + "  member [Customers].[Neg] as '-1'\n"
                 + "  member [Customers].[Min] as 'Min({[Customers].[Neg]})'\n"
@@ -59,7 +59,7 @@ class MinMaxFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testMin(Context context) {
-        FunctionTest.assertExprReturns(context.getConnection(),
+        FunctionTest.assertExprReturns(context.getConnectionWithDefaultRole(),
             "MIN({[Store].[All Stores].[USA].children},[Measures].[Store Sales])",
             "142,277.07" );
     }
@@ -67,7 +67,7 @@ class MinMaxFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testMinTuple(Context context) {
-        FunctionTest.assertExprReturns(context.getConnection(),
+        FunctionTest.assertExprReturns(context.getConnectionWithDefaultRole(),
             "Min([Customers].[All Customers].[USA].Children, ([Measures].[Unit Sales], [Gender].[All Gender].[F]))",
             "33,036" );
     }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/name/dimension/NameFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/name/dimension/NameFunDefTest.java
@@ -28,7 +28,7 @@ class NameFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDimensionName(Context context) {
-        assertExprReturns(context.getConnection(), "[Time].[1997].Dimension.Name", "Time" );
+        assertExprReturns(context.getConnectionWithDefaultRole(), "[Time].[1997].Dimension.Name", "Time" );
     }
 
 }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/name/hierarchy/NameFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/name/hierarchy/NameFunDefTest.java
@@ -27,7 +27,7 @@ class NameFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testHierarchyName(Context context) {
-        assertExprReturns(context.getConnection(), "[Time].[1997].Hierarchy.Name", "Time" );
+        assertExprReturns(context.getConnectionWithDefaultRole(), "[Time].[1997].Hierarchy.Name", "Time" );
     }
 
 }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/name/level/NameFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/name/level/NameFunDefTest.java
@@ -27,7 +27,7 @@ class NameFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testLevelName(Context context) {
-        assertExprReturns(context.getConnection(), "[Time].[1997].Level.Name", "Year" );
+        assertExprReturns(context.getConnectionWithDefaultRole(), "[Time].[1997].Level.Name", "Year" );
     }
 
 }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/name/member/NameFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/name/member/NameFunDefTest.java
@@ -29,14 +29,14 @@ class NameFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testMemberName(Context context) {
-        assertExprReturns(context.getConnection(), "[Time].[1997].Name", "1997" );
+        assertExprReturns(context.getConnectionWithDefaultRole(), "[Time].[1997].Name", "1997" );
         // dimension name
-        assertExprReturns(context.getConnection(), "[Store].Name", "Store" );
+        assertExprReturns(context.getConnectionWithDefaultRole(), "[Store].Name", "Store" );
         // member name
-        assertExprReturns(context.getConnection(), "[Store].DefaultMember.Name", "All Stores" );
+        assertExprReturns(context.getConnectionWithDefaultRole(), "[Store].DefaultMember.Name", "All Stores" );
         if ( isDefaultNullMemberRepresentation() ) {
             // name of null member
-            assertExprReturns(context.getConnection(), "[Store].Parent.Name", "#null" );
+            assertExprReturns(context.getConnectionWithDefaultRole(), "[Store].Parent.Name", "#null" );
         }
     }
 

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/nonemptycrossjoin/NonEmptyCrossJoinFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/nonemptycrossjoin/NonEmptyCrossJoinFunDefTest.java
@@ -33,10 +33,10 @@ class NonEmptyCrossJoinFunDefTest {
         // NonEmptyCrossJoin needs to evaluate measures to find out whether
         // cells are empty, so it implicitly depends upon all dimensions.
         String s1 = allHiersExcept( "[Store]" );
-        assertSetExprDependsOn(context.getConnection(),
+        assertSetExprDependsOn(context.getConnectionWithDefaultRole(),
             "NonEmptyCrossJoin([Store].[USA].Children, [Gender].Children)", s1 );
 
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "NonEmptyCrossJoin("
                 + "[Customers].[All Customers].[USA].[CA].Children, "
                 + "[Product].[All Products].[Drink].[Alcoholic Beverages].[Beer and Wine].[Beer].[Good].Children)",
@@ -78,16 +78,16 @@ class NonEmptyCrossJoinFunDefTest {
                 + ".[Good].[Good Imported Beer]}" );
 
         // empty set
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "NonEmptyCrossJoin({Gender.Parent}, {Store.Parent})", "" );
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "NonEmptyCrossJoin({Store.Parent}, Gender.Children)", "" );
-        assertAxisReturns(context.getConnection(), "NonEmptyCrossJoin(Store.Members, {})", "" );
+        assertAxisReturns(context.getConnectionWithDefaultRole(), "NonEmptyCrossJoin(Store.Members, {})", "" );
 
         // same dimension twice
         // todo: should throw
         if ( false ) {
-            assertAxisThrows(context.getConnection(),
+            assertAxisThrows(context.getConnectionWithDefaultRole(),
                 "NonEmptyCrossJoin({Store.[USA]}, {Store.[USA].[CA]})",
                 "xxx" );
         }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/nonstandard/CalculatedChildFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/nonstandard/CalculatedChildFunDefTest.java
@@ -34,7 +34,7 @@ class CalculatedChildFunDefTest {
         // Construct calculated children with the same name for both [Drink] and
         // [Non-Consumable].  Then, create a metric to select the calculated
         // child based on current product member.
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with\n"
                 + " member [Product].[All Products].[Drink].[Calculated Child] as '[Product].[All Products].[Drink]"
                 + ".[Alcoholic Beverages]'\n"
@@ -55,7 +55,7 @@ class CalculatedChildFunDefTest {
                 + "{[Product].[Non-Consumable]}\n"
                 + "Row #0: 6,838\n" // Calculated child for [Drink]
                 + "Row #1: 841\n" ); // Calculated child for [Non-Consumable]
-        Member member = executeSingletonAxis(context.getConnection(),
+        Member member = executeSingletonAxis(context.getConnectionWithDefaultRole(),
             "[Product].[All Products].CalculatedChild(\"foobar\")" );
         assertEquals( null, member );
     }
@@ -67,7 +67,7 @@ class CalculatedChildFunDefTest {
         // Construct calculated children with the same name for both [Drink] and
         // [Non-Consumable].  Then, create a metric to select the first
         // calculated child.
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with\n"
                 + " member [Product].[All Products].[Drink].[Calculated Child] as '[Product].[All Products].[Drink]"
                 + ".[Alcoholic Beverages]'\n"
@@ -90,7 +90,7 @@ class CalculatedChildFunDefTest {
                 // Note: For [Non-Consumable], the calculated child for [Drink] was
                 // selected!
                 + "Row #1: 6,838\n" );
-        Member member = executeSingletonAxis(context.getConnection(),
+        Member member = executeSingletonAxis(context.getConnectionWithDefaultRole(),
             "[Product].[All Products].CalculatedChild(\"foobar\")" );
         assertEquals( null, member );
     }
@@ -99,7 +99,7 @@ class CalculatedChildFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCalculatedChildOnMemberWithNoChildren(Context context) {
         Member member =
-            executeSingletonAxis(context.getConnection(),
+            executeSingletonAxis(context.getConnectionWithDefaultRole(),
                 "[Measures].[Store Sales].CalculatedChild(\"foobar\")" );
         assertEquals( null, member );
     }
@@ -108,7 +108,7 @@ class CalculatedChildFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testCalculatedChildOnNullMember(Context context) {
         Member member =
-            executeSingletonAxis(context.getConnection(),
+            executeSingletonAxis(context.getConnectionWithDefaultRole(),
                 "[Measures].[Store Sales].parent.CalculatedChild(\"foobar\")" );
         assertEquals( null, member);
     }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/numeric/ordinal/OrdinalFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/numeric/ordinal/OrdinalFunDefTest.java
@@ -32,7 +32,7 @@ class OrdinalFunDefTest {
     void testOrdinal(Context context) {
         //final Context testContext =
         //  getContext().withCube( "Sales Ragged" );
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         Cell cell =
             executeExprRaw(connection, "Sales Ragged",
                 "[Store].[All Stores].[Vatican].ordinal" );

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/numeric/value/ValueFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/numeric/value/ValueFunDefTest.java
@@ -33,22 +33,22 @@ class ValueFunDefTest {
     void testValue(Context context) {
         // VALUE is usually a cell property, not a member property.
         // We allow it because MS documents it as a function, <Member>.VALUE.
-        TestUtil.assertExprReturns(context.getConnection(), "[Measures].[Store Sales].VALUE", "565,238.13" );
+        TestUtil.assertExprReturns(context.getConnectionWithDefaultRole(), "[Measures].[Store Sales].VALUE", "565,238.13" );
 
         // Depends upon almost everything.
         String s1 = FunctionTest.allHiersExcept( "[Measures]" );
-        assertExprDependsOn(context.getConnection(),
+        assertExprDependsOn(context.getConnectionWithDefaultRole(),
             "[Measures].[Store Sales].VALUE", s1 );
 
         // We do not allow FORMATTED_VALUE.
-        assertExprThrows(context.getConnection(),
+        assertExprThrows(context.getConnectionWithDefaultRole(),
             "[Measures].[Store Sales].FORMATTED_VALUE",
             "MDX object '[Measures].[Store Sales].FORMATTED_VALUE' not found in cube 'Sales'" );
 
-        TestUtil.assertExprReturns(context.getConnection(), "[Measures].[Store Sales].NAME", "Store Sales" );
+        TestUtil.assertExprReturns(context.getConnectionWithDefaultRole(), "[Measures].[Store Sales].NAME", "Store Sales" );
         // MS says that ID and KEY are standard member properties for
         // OLE DB for OLAP, but not for XML/A. We don't support them.
-        assertExprThrows(context.getConnection(),
+        assertExprThrows(context.getConnectionWithDefaultRole(),
             "[Measures].[Store Sales].ID",
             "MDX object '[Measures].[Store Sales].ID' not found in cube 'Sales'" );
 
@@ -60,11 +60,11 @@ class ValueFunDefTest {
         // "<MEMBER>.KEY" syntax because there is not function defined. For
         // other builtin properties, such as NAME, CAPTION there is a builtin
         // function.
-        assertExprThrows(context.getConnection(),
+        assertExprThrows(context.getConnectionWithDefaultRole(),
             "[Measures].[Store Sales].KEY",
             "No function matches signature '<Member>.KEY'" );
 
-        TestUtil.assertExprReturns(context.getConnection(), "[Measures].[Store Sales].CAPTION", "Store Sales" );
+        TestUtil.assertExprReturns(context.getConnectionWithDefaultRole(), "[Measures].[Store Sales].CAPTION", "Store Sales" );
     }
 
 }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/openingclosingperiod/OpeningClosingPeriodFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/openingclosingperiod/OpeningClosingPeriodFunDefTest.java
@@ -51,7 +51,7 @@ class OpeningClosingPeriodFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testClosingPeriodNoArgs(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         assertMemberExprDependsOn(connection,
             "ClosingPeriod()", "{[Time]}" );
         // MSOLAP returns [1997].[Q4], because [Time].CurrentMember =
@@ -63,7 +63,7 @@ class OpeningClosingPeriodFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testClosingPeriodLevel(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         assertMemberExprDependsOn(connection,
             "ClosingPeriod([Time].[Year])", "{[Time]}" );
         assertMemberExprDependsOn(connection,
@@ -160,7 +160,7 @@ class OpeningClosingPeriodFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testClosingPeriodLevelNotInTimeFails(Context context) {
-        assertAxisThrows(context.getConnection(),
+        assertAxisThrows(context.getConnectionWithDefaultRole(),
             "ClosingPeriod([Store].[Store City])",
             "The <level> and <member> arguments to ClosingPeriod must be from "
                 + "the same hierarchy. The level was from '[Store]' but the member "
@@ -174,7 +174,7 @@ class OpeningClosingPeriodFunDefTest {
             // This test is mistaken. Valid forms are ClosingPeriod(<level>)
             // and ClosingPeriod(<level>, <member>), but not
             // ClosingPeriod(<member>)
-            Member member = executeSingletonAxis( context.getConnection(),"ClosingPeriod([USA])" );
+            Member member = executeSingletonAxis( context.getConnectionWithDefaultRole(),"ClosingPeriod([USA])" );
             assertEquals( "WA", member.getName() );
         }
     }
@@ -187,11 +187,11 @@ class OpeningClosingPeriodFunDefTest {
             // This test is mistaken. Valid forms are ClosingPeriod(<level>)
             // and ClosingPeriod(<level>, <member>), but not
             // ClosingPeriod(<member>)
-            member = executeSingletonAxis(context.getConnection(),
+            member = executeSingletonAxis(context.getConnectionWithDefaultRole(),
                 "ClosingPeriod([Time].[1997].[Q3].[8])" );
             assertNull( member );
         } else if ( isDefaultNullMemberRepresentation() ) {
-            assertQueryReturns(context.getConnection(),
+            assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "with member [Measures].[Foo] as ClosingPeriod().uniquename\n"
                     + "select {[Measures].[Foo]} on columns,\n"
                     + "  {[Time].[1997],\n"
@@ -217,7 +217,7 @@ class OpeningClosingPeriodFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testClosingPeriod(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         assertMemberExprDependsOn(connection,
             "ClosingPeriod([Time].[Month], [Time].[Time].CurrentMember)",
             "{[Time]}" );
@@ -310,7 +310,7 @@ class OpeningClosingPeriodFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testClosingPeriodBelow(Context context) {
-        Member member = executeSingletonAxis(context.getConnection(),
+        Member member = executeSingletonAxis(context.getConnectionWithDefaultRole(),
             "ClosingPeriod([Quarter],[1997].[Q3].[8])" );
         assertNull( member );
     }
@@ -319,49 +319,49 @@ class OpeningClosingPeriodFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testOpeningPeriod(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "OpeningPeriod([Time].[Month], [Time].[1997].[Q3])",
             "[Time].[1997].[Q3].[7]" );
 
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "OpeningPeriod([Time].[Quarter], [Time].[1997])",
             "[Time].[1997].[Q1]" );
 
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "OpeningPeriod([Time].[Year], [Time].[1997])", "[Time].[1997]" );
 
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "OpeningPeriod([Time].[Month], [Time].[1997])",
             "[Time].[1997].[Q1].[1]" );
 
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "OpeningPeriod([Product].[Product Name], [Product].[All Products].[Drink])",
             "[Product].[Drink].[Alcoholic Beverages].[Beer and Wine].[Beer].[Good].[Good Imported Beer]" );
 
         //getTestContext().withCube( "[Sales Ragged]" ).
-        assertAxisReturns(context.getConnection(), "[Sales Ragged]",
+        assertAxisReturns(context.getConnectionWithDefaultRole(), "[Sales Ragged]",
             "OpeningPeriod([Store].[Store City], [Store].[All Stores].[Israel])",
             "[Store].[Israel].[Israel].[Haifa]" );
 
         //getTestContext().withCube( "[Sales Ragged]" ).
-        assertAxisReturns(context.getConnection(), "[Sales Ragged]",
+        assertAxisReturns(context.getConnectionWithDefaultRole(), "[Sales Ragged]",
             "OpeningPeriod([Store].[Store State], [Store].[All Stores].[Israel])",
             "" );
 
         // Default member is [Time].[1997].
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "OpeningPeriod([Time].[Month])", "[Time].[1997].[Q1].[1]" );
 
-        assertAxisReturns(context.getConnection(), "OpeningPeriod()", "[Time].[1997].[Q1]" );
+        assertAxisReturns(context.getConnectionWithDefaultRole(), "OpeningPeriod()", "[Time].[1997].[Q1]" );
 
         //TestContext testContext = getTestContext().withCube( "[Sales Ragged]" );
-        assertAxisThrows(context.getConnection(),
+        assertAxisThrows(context.getConnectionWithDefaultRole(),
             "OpeningPeriod([Time].[Year], [Store].[All Stores].[Israel])",
             "The <level> and <member> arguments to OpeningPeriod must be "
                 + "from the same hierarchy. The level was from '[Time]' but "
                 + "the member was from '[Store]'.", "[Sales Ragged]");
 
-        assertAxisThrows(context.getConnection(),
+        assertAxisThrows(context.getConnectionWithDefaultRole(),
             "OpeningPeriod([Store].[Store City])",
             "The <level> and <member> arguments to OpeningPeriod must be "
                 + "from the same hierarchy. The level was from '[Store]' but "
@@ -374,7 +374,7 @@ class OpeningClosingPeriodFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testOpeningPeriodNull(Context context) {
-        assertAxisThrows(context.getConnection(),
+        assertAxisThrows(context.getConnectionWithDefaultRole(),
             "OpeningPeriod([Time].[Month], NULL)",
             "Failed to parse query 'select {OpeningPeriod([Time].[Month], NULL)} on columns from Sales'" );
     }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/operators/and/AndOperatorDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/operators/and/AndOperatorDefTest.java
@@ -28,36 +28,36 @@ class AndOperatorDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testAnd(Context context) {
-        assertBooleanExprReturns(context.getConnection(), " 1=1 AND 2=2 ", true );
+        assertBooleanExprReturns(context.getConnectionWithDefaultRole(), " 1=1 AND 2=2 ", true );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testAnd2(Context context) {
-        assertBooleanExprReturns(context.getConnection(), " 1=1 AND 2=0 ", false );
+        assertBooleanExprReturns(context.getConnectionWithDefaultRole(), " 1=1 AND 2=0 ", false );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testOr(Context context) {
-        assertBooleanExprReturns(context.getConnection(), " 1=0 OR 2=0 ", false );
+        assertBooleanExprReturns(context.getConnectionWithDefaultRole(), " 1=0 OR 2=0 ", false );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testBool1(Context context) {
-        assertExprReturns(context.getConnection(), "1=1 AND 1=0", "false" );
+        assertExprReturns(context.getConnectionWithDefaultRole(), "1=1 AND 1=0", "false" );
     }
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testBool2(Context context) {
-        assertExprReturns(context.getConnection(), "1=1 AND 1=1", "true" );
+        assertExprReturns(context.getConnectionWithDefaultRole(), "1=1 AND 1=1", "true" );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testBool3(Context context) {
-        assertExprReturns(context.getConnection(), "1=1 AND null", "false" );
+        assertExprReturns(context.getConnectionWithDefaultRole(), "1=1 AND null", "false" );
     }
 
 }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/operators/divide/DivideOperatorDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/operators/divide/DivideOperatorDefTest.java
@@ -29,9 +29,9 @@ class DivideOperatorDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDivide(Context context) {
-        assertExprReturns(context.getConnection(), "10 / 5", "2" );
-        assertExprReturns(context.getConnection(), NullNumericExpr + " / - 2", "" );
-        assertExprReturns(context.getConnection(), NullNumericExpr + " / " + NullNumericExpr, "" );
+        assertExprReturns(context.getConnectionWithDefaultRole(), "10 / 5", "2" );
+        assertExprReturns(context.getConnectionWithDefaultRole(), NullNumericExpr + " / - 2", "" );
+        assertExprReturns(context.getConnectionWithDefaultRole(), NullNumericExpr + " / " + NullNumericExpr, "" );
 
         boolean origNullDenominatorProducesNull =
             context.getConfig().nullDenominatorProducesNull();
@@ -39,24 +39,24 @@ class DivideOperatorDefTest {
             // default behavior
             ((TestConfig)context.getConfig()).setNullDenominatorProducesNull(false);
 
-            assertExprReturns(context.getConnection(), "-2 / " + NullNumericExpr, "Infinity" );
-            assertExprReturns(context.getConnection(), "0 / 0", "NaN" );
-            assertExprReturns(context.getConnection(), "-3 / (2 - 2)", "-Infinity" );
+            assertExprReturns(context.getConnectionWithDefaultRole(), "-2 / " + NullNumericExpr, "Infinity" );
+            assertExprReturns(context.getConnectionWithDefaultRole(), "0 / 0", "NaN" );
+            assertExprReturns(context.getConnectionWithDefaultRole(), "-3 / (2 - 2)", "-Infinity" );
 
-            assertExprReturns(context.getConnection(), "NULL/1", "" );
-            assertExprReturns(context.getConnection(), "NULL/NULL", "" );
-            assertExprReturns(context.getConnection(), "1/NULL", "Infinity" );
+            assertExprReturns(context.getConnectionWithDefaultRole(), "NULL/1", "" );
+            assertExprReturns(context.getConnectionWithDefaultRole(), "NULL/NULL", "" );
+            assertExprReturns(context.getConnectionWithDefaultRole(), "1/NULL", "Infinity" );
 
             // when NullOrZeroDenominatorProducesNull is set to true
             ((TestConfig)context.getConfig()).setNullDenominatorProducesNull( true );
 
-            assertExprReturns(context.getConnection(), "-2 / " + NullNumericExpr, "" );
-            assertExprReturns(context.getConnection(), "0 / 0", "NaN" );
-            assertExprReturns(context.getConnection(), "-3 / (2 - 2)", "-Infinity" );
+            assertExprReturns(context.getConnectionWithDefaultRole(), "-2 / " + NullNumericExpr, "" );
+            assertExprReturns(context.getConnectionWithDefaultRole(), "0 / 0", "NaN" );
+            assertExprReturns(context.getConnectionWithDefaultRole(), "-3 / (2 - 2)", "-Infinity" );
 
-            assertExprReturns(context.getConnection(), "NULL/1", "" );
-            assertExprReturns(context.getConnection(), "NULL/NULL", "" );
-            assertExprReturns(context.getConnection(), "1/NULL", "" );
+            assertExprReturns(context.getConnectionWithDefaultRole(), "NULL/1", "" );
+            assertExprReturns(context.getConnectionWithDefaultRole(), "NULL/NULL", "" );
+            assertExprReturns(context.getConnectionWithDefaultRole(), "1/NULL", "" );
         } finally {
             ((TestConfig)context.getConfig()).setNullDenominatorProducesNull( origNullDenominatorProducesNull );
         }
@@ -65,7 +65,7 @@ class DivideOperatorDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDividePrecedence(Context context) {
-        assertExprReturns(context.getConnection(), "24 / 4 / 2 * 10 - -1", "31" );
+        assertExprReturns(context.getConnectionWithDefaultRole(), "24 / 4 / 2 * 10 - -1", "31" );
     }
 
 }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/operators/equal/EqualOperatorDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/operators/equal/EqualOperatorDefTest.java
@@ -29,11 +29,11 @@ class EqualOperatorDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testEq(Context context) {
-        assertBooleanExprReturns(context.getConnection(), " 1.0 = 1 ", true );
+        assertBooleanExprReturns(context.getConnectionWithDefaultRole(), " 1.0 = 1 ", true );
 
-        assertBooleanExprReturns(context.getConnection(),
+        assertBooleanExprReturns(context.getConnectionWithDefaultRole(),
             "[Product].CurrentMember.Level.Ordinal = 2.0", false );
-        checkNullOp(context.getConnection(), "=" );
+        checkNullOp(context.getConnectionWithDefaultRole(), "=" );
     }
 
 }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/operators/equal/EqualStringOperatorDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/operators/equal/EqualStringOperatorDefTest.java
@@ -28,19 +28,19 @@ class EqualStringOperatorDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testStringEquals(Context context) {
-        assertBooleanExprReturns(context.getConnection(), " \"foo\" = \"bar\" ", false );
+        assertBooleanExprReturns(context.getConnectionWithDefaultRole(), " \"foo\" = \"bar\" ", false );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testStringEqualsAssociativity(Context context) {
-        assertBooleanExprReturns(context.getConnection(), " \"foo\" = \"fo\" || \"o\" ", true );
+        assertBooleanExprReturns(context.getConnectionWithDefaultRole(), " \"foo\" = \"fo\" || \"o\" ", true );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testStringEqualsEmpty(Context context) {
-        assertBooleanExprReturns(context.getConnection(), " \"\" = \"\" ", true );
+        assertBooleanExprReturns(context.getConnectionWithDefaultRole(), " \"\" = \"\" ", true );
     }
 
 }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/operators/greater/GreaterOperatorDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/operators/greater/GreaterOperatorDefTest.java
@@ -29,8 +29,8 @@ class GreaterOperatorDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testGt(Context context) {
-        assertBooleanExprReturns(context.getConnection(), " 2 > 1.0 + 1.0 ", false );
-        checkNullOp(context.getConnection(), ">" );
+        assertBooleanExprReturns(context.getConnectionWithDefaultRole(), " 2 > 1.0 + 1.0 ", false );
+        checkNullOp(context.getConnectionWithDefaultRole(), ">" );
     }
 
 }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/operators/greater/GreaterOrEqualOperatorDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/operators/greater/GreaterOrEqualOperatorDefTest.java
@@ -29,8 +29,8 @@ class GreaterOrEqualOperatorDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testGe(Context context) {
-        assertBooleanExprReturns(context.getConnection(), " 2 > 1.0 + 1.0 ", false );
-        checkNullOp(context.getConnection(), ">=" );
+        assertBooleanExprReturns(context.getConnectionWithDefaultRole(), " 2 > 1.0 + 1.0 ", false );
+        checkNullOp(context.getConnectionWithDefaultRole(), ">=" );
     }
 
 }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/operators/less/LessOperatorDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/operators/less/LessOperatorDefTest.java
@@ -29,8 +29,8 @@ class LessOperatorDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testLt(Context context) {
-        assertBooleanExprReturns(context.getConnection(), " 2 < 1.0 + 1.0 ", false );
-        checkNullOp(context.getConnection(), "<" );
+        assertBooleanExprReturns(context.getConnectionWithDefaultRole(), " 2 < 1.0 + 1.0 ", false );
+        checkNullOp(context.getConnectionWithDefaultRole(), "<" );
     }
 
 }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/operators/less/LessOrEqualOperatorDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/operators/less/LessOrEqualOperatorDefTest.java
@@ -29,8 +29,8 @@ class LessOrEqualOperatorDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testLe(Context context) {
-        assertBooleanExprReturns(context.getConnection(), " 2 <= 1.0 + 1.0 ", true );
-        checkNullOp(context.getConnection(), "<=" );
+        assertBooleanExprReturns(context.getConnectionWithDefaultRole(), " 2 <= 1.0 + 1.0 ", true );
+        checkNullOp(context.getConnectionWithDefaultRole(), "<=" );
     }
 
 }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/operators/minus/MinusOperatorDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/operators/minus/MinusOperatorDefTest.java
@@ -28,7 +28,7 @@ class MinusOperatorDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testMinus_bug1234759(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH MEMBER [Customers].[USAMinusMexico]\n"
                 + "AS '([Customers].[All Customers].[USA] - [Customers].[All Customers].[Mexico])'\n"
                 + "SELECT {[Measures].[Unit Sales]} ON COLUMNS,\n"
@@ -54,7 +54,7 @@ class MinusOperatorDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testMinusAssociativity(Context context) {
         // right-associative would give 11-(7-5) = 9, which is wrong
-        assertExprReturns(context.getConnection(), "11-7-5", "-1" );
+        assertExprReturns(context.getConnectionWithDefaultRole(), "11-7-5", "-1" );
     }
 
 }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/operators/minus/MinusPrefixOperatorDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/operators/minus/MinusPrefixOperatorDefTest.java
@@ -27,13 +27,13 @@ class MinusPrefixOperatorDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testUnaryMinus(Context context) {
-        assertExprReturns(context.getConnection(), "-3", "-3" );
+        assertExprReturns(context.getConnectionWithDefaultRole(), "-3", "-3" );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testUnaryMinusMember(Context context) {
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "- ([Measures].[Unit Sales],[Gender].[F])",
             "-131,558" );
     }
@@ -41,37 +41,37 @@ class MinusPrefixOperatorDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testUnaryMinusPrecedence(Context context) {
-        assertExprReturns(context.getConnection(), "1 - -10.5 * 2 -3", "19" );
+        assertExprReturns(context.getConnectionWithDefaultRole(), "1 - -10.5 * 2 -3", "19" );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testNegativeZero(Context context) {
-        assertExprReturns(context.getConnection(), "-0.0", "0" );
+        assertExprReturns(context.getConnectionWithDefaultRole(), "-0.0", "0" );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testNegativeZero1(Context context) {
-        assertExprReturns(context.getConnection(), "-(0.0)", "0" );
+        assertExprReturns(context.getConnectionWithDefaultRole(), "-(0.0)", "0" );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testNegativeZeroSubtract(Context context) {
-        assertExprReturns(context.getConnection(), "-0.0 - 0.0", "0" );
+        assertExprReturns(context.getConnectionWithDefaultRole(), "-0.0 - 0.0", "0" );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testNegativeZeroMultiply(Context context) {
-        assertExprReturns(context.getConnection(), "-1 * 0", "0" );
+        assertExprReturns(context.getConnectionWithDefaultRole(), "-1 * 0", "0" );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testNegativeZeroDivide(Context context) {
-        assertExprReturns(context.getConnection(), "-0.0 / 2", "0" );
+        assertExprReturns(context.getConnectionWithDefaultRole(), "-0.0 / 2", "0" );
     }
 
 }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/operators/multiply/MultiplyOperatorDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/operators/multiply/MultiplyOperatorDefTest.java
@@ -29,18 +29,18 @@ class MultiplyOperatorDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testMultiply(Context context) {
-        assertExprReturns(context.getConnection(), "4*7", "28" );
-        assertExprReturns(context.getConnection(), "5 * " + NullNumericExpr, "" ); // 5 * null --> null
-        assertExprReturns(context.getConnection(), NullNumericExpr + " * - 2", "" );
-        assertExprReturns(context.getConnection(), NullNumericExpr + " - " + NullNumericExpr, "" );
+        assertExprReturns(context.getConnectionWithDefaultRole(), "4*7", "28" );
+        assertExprReturns(context.getConnectionWithDefaultRole(), "5 * " + NullNumericExpr, "" ); // 5 * null --> null
+        assertExprReturns(context.getConnectionWithDefaultRole(), NullNumericExpr + " * - 2", "" );
+        assertExprReturns(context.getConnectionWithDefaultRole(), NullNumericExpr + " - " + NullNumericExpr, "" );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testMultiplyPrecedence(Context context) {
-        assertExprReturns(context.getConnection(), "3 + 4 * 5 + 6", "29" );
-        assertExprReturns(context.getConnection(), "5 * 24 / 4 * 2", "60" );
-        assertExprReturns(context.getConnection(), "48 / 4 / 2", "6" );
+        assertExprReturns(context.getConnectionWithDefaultRole(), "3 + 4 * 5 + 6", "29" );
+        assertExprReturns(context.getConnectionWithDefaultRole(), "5 * 24 / 4 * 2", "60" );
+        assertExprReturns(context.getConnectionWithDefaultRole(), "48 / 4 / 2", "6" );
     }
 
     /**
@@ -59,21 +59,21 @@ class MultiplyOperatorDefTest {
                 + "{[Measures].[A]}\n"
                 + "Row #0: 565,238.13\n"
                 + "Row #1: 319,494,143,605.90\n";
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH MEMBER [Measures].[A] AS\n"
                 + " '([Measures].[Store Sales] * [Measures].[Store Sales])'\n"
                 + "SELECT {[Store]} ON COLUMNS,\n"
                 + " {[Measures].[Store Sales], [Measures].[A]} ON ROWS\n"
                 + "FROM Sales", desiredResult );
         // as above, no parentheses
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH MEMBER [Measures].[A] AS\n"
                 + " '[Measures].[Store Sales] * [Measures].[Store Sales]'\n"
                 + "SELECT {[Store]} ON COLUMNS,\n"
                 + " {[Measures].[Store Sales], [Measures].[A]} ON ROWS\n"
                 + "FROM Sales", desiredResult );
         // as above, plus 0
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH MEMBER [Measures].[A] AS\n"
                 + " '[Measures].[Store Sales] * [Measures].[Store Sales] + 0'\n"
                 + "SELECT {[Store]} ON COLUMNS,\n"

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/operators/not/NotPrefixOperatorDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/operators/not/NotPrefixOperatorDefTest.java
@@ -92,19 +92,19 @@ class NotPrefixOperatorDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testNot(Context context) {
-        assertBooleanExprReturns(context.getConnection(), " NOT 1=1 ", false );
+        assertBooleanExprReturns(context.getConnectionWithDefaultRole(), " NOT 1=1 ", false );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testNotNot(Context context) {
-        assertBooleanExprReturns(context.getConnection(), " NOT NOT 1=1 ", true );
+        assertBooleanExprReturns(context.getConnectionWithDefaultRole(), " NOT NOT 1=1 ", true );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testNotAssociativity(Context context) {
-        assertBooleanExprReturns(context.getConnection(), " 1=1 AND NOT 1=1 OR NOT 1=1 AND 1=1 ", false );
+        assertBooleanExprReturns(context.getConnectionWithDefaultRole(), " 1=1 AND NOT 1=1 OR NOT 1=1 AND 1=1 ", false );
     }
 
 }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/operators/notequal/NotEqualOperatorDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/operators/notequal/NotEqualOperatorDefTest.java
@@ -29,15 +29,15 @@ class NotEqualOperatorDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testNe(Context context) {
-        assertBooleanExprReturns(context.getConnection(), " 2 <> 1.0 + 1.0 ", false );
-        checkNullOp(context.getConnection(), "<>" );
+        assertBooleanExprReturns(context.getConnectionWithDefaultRole(), " 2 <> 1.0 + 1.0 ", false );
+        checkNullOp(context.getConnectionWithDefaultRole(), "<>" );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testNeInfinity(Context context) {
         // Infinity does not equal itself
-        assertBooleanExprReturns(context.getConnection(), "(1 / 0) <> (1 / 0)", false );
+        assertBooleanExprReturns(context.getConnectionWithDefaultRole(), "(1 / 0) <> (1 / 0)", false );
     }
 
 }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/operators/notequal/NotEqualStringOperatorDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/operators/notequal/NotEqualStringOperatorDefTest.java
@@ -28,7 +28,7 @@ class NotEqualStringOperatorDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testStringNe(Context context) {
-        assertBooleanExprReturns(context.getConnection(), " \"foo\" <> \"bar\" ", true );
+        assertBooleanExprReturns(context.getConnectionWithDefaultRole(), " \"foo\" <> \"bar\" ", true );
     }
 
 }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/operators/or/OrOperatorDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/operators/or/OrOperatorDefTest.java
@@ -32,34 +32,34 @@ class OrOperatorDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testOr2(Context context) {
-        assertBooleanExprReturns(context.getConnection(), " 1=0 OR 0=0 ", true );
+        assertBooleanExprReturns(context.getConnectionWithDefaultRole(), " 1=0 OR 0=0 ", true );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testOrAssociativity1(Context context) {
         // Would give 'false' if OR were stronger than AND (wrong!)
-        assertBooleanExprReturns(context.getConnection(), " 1=1 AND 1=0 OR 1=1 ", true );
+        assertBooleanExprReturns(context.getConnectionWithDefaultRole(), " 1=1 AND 1=0 OR 1=1 ", true );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testOrAssociativity2(Context context) {
         // Would give 'false' if OR were stronger than AND (wrong!)
-        assertBooleanExprReturns(context.getConnection(), " 1=1 OR 1=0 AND 1=1 ", true );
+        assertBooleanExprReturns(context.getConnectionWithDefaultRole(), " 1=1 OR 1=0 AND 1=1 ", true );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testOrAssociativity3(Context context) {
-        assertBooleanExprReturns(context.getConnection(), " (1=0 OR 1=1) AND 1=1 ", true );
+        assertBooleanExprReturns(context.getConnectionWithDefaultRole(), " (1=0 OR 1=1) AND 1=1 ", true );
     }
 
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testComplexOrExpr(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         switch (getDatabaseProduct(TestUtil.getDialect(connection).getDialectName())) {
             case INFOBRIGHT:
                 // Skip this test on Infobright, because [Promotion Sales] is

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/operators/or/OrStringOperatorDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/operators/or/OrStringOperatorDefTest.java
@@ -27,7 +27,7 @@ class OrStringOperatorDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testStringConcat(Context context) {
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             " \"foo\" || \"bar\"  ",
             "foobar" );
     }
@@ -35,7 +35,7 @@ class OrStringOperatorDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testStringConcat2(Context context) {
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             " \"foo\" || [Gender].[M].Name || \"\" ",
             "fooM" );
     }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/operators/plus/PlusOperatorDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/operators/plus/PlusOperatorDefTest.java
@@ -30,42 +30,42 @@ class PlusOperatorDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testPlus(Context context) {
-        assertExprDependsOn(context.getConnection(), "1 + 2", "{}" );
+        assertExprDependsOn(context.getConnectionWithDefaultRole(), "1 + 2", "{}" );
         String s1 = allHiersExcept( "[Measures]", "[Gender]" );
-        assertExprDependsOn(context.getConnection(),
+        assertExprDependsOn(context.getConnectionWithDefaultRole(),
             "([Measures].[Unit Sales], [Gender].[F]) + 2", s1 );
 
-        assertExprReturns(context.getConnection(), "1+2", "3" );
-        assertExprReturns(context.getConnection(), "5 + " + NullNumericExpr, "5" ); // 5 + null --> 5
-        assertExprReturns(context.getConnection(), NullNumericExpr + " + " + NullNumericExpr, "" );
-        assertExprReturns(context.getConnection(), NullNumericExpr + " + 0", "0" );
+        assertExprReturns(context.getConnectionWithDefaultRole(), "1+2", "3" );
+        assertExprReturns(context.getConnectionWithDefaultRole(), "5 + " + NullNumericExpr, "5" ); // 5 + null --> 5
+        assertExprReturns(context.getConnectionWithDefaultRole(), NullNumericExpr + " + " + NullNumericExpr, "" );
+        assertExprReturns(context.getConnectionWithDefaultRole(), NullNumericExpr + " + 0", "0" );
     }
 
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testPlus_NULL_plus_1(Context context) {
-        assertExprReturns(context.getConnection(),  "null + 1", "1" );
+        assertExprReturns(context.getConnectionWithDefaultRole(),  "null + 1", "1" );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testPlus_NULL_plus_0(Context context) {
-        assertExprReturns(context.getConnection(),  "null + 0", "0" );
+        assertExprReturns(context.getConnectionWithDefaultRole(),  "null + 0", "0" );
     }
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testPlus_NULL_plus_NULL(Context context) {
-        assertExprReturns(context.getConnection(),  "null + null", "" );
+        assertExprReturns(context.getConnectionWithDefaultRole(),  "null + null", "" );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testMinus(Context context) {
-        assertExprReturns(context.getConnection(), "1-3", "-2" );
-        assertExprReturns(context.getConnection(), "5 - " + NullNumericExpr, "5" ); // 5 - null --> 5
-        assertExprReturns(context.getConnection(), NullNumericExpr + " - - 2", "2" );
-        assertExprReturns(context.getConnection(), NullNumericExpr + " - " + NullNumericExpr, "" );
+        assertExprReturns(context.getConnectionWithDefaultRole(), "1-3", "-2" );
+        assertExprReturns(context.getConnectionWithDefaultRole(), "5 - " + NullNumericExpr, "5" ); // 5 - null --> 5
+        assertExprReturns(context.getConnectionWithDefaultRole(), NullNumericExpr + " - - 2", "2" );
+        assertExprReturns(context.getConnectionWithDefaultRole(), NullNumericExpr + " - " + NullNumericExpr, "" );
     }
 
 }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/operators/xor/XorOperatorDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/operators/xor/XorOperatorDefTest.java
@@ -79,14 +79,14 @@ class XorOperatorDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testXor(Context context) {
-        assertBooleanExprReturns(context.getConnection(), " 1=1 XOR 2=2 ", false );
+        assertBooleanExprReturns(context.getConnectionWithDefaultRole(), " 1=1 XOR 2=2 ", false );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testXorAssociativity(Context context) {
         // Would give 'false' if XOR were stronger than AND (wrong!)
-        assertBooleanExprReturns(context.getConnection(), " 1 = 1 AND 1 = 1 XOR 1 = 0 ", true );
+        assertBooleanExprReturns(context.getConnectionWithDefaultRole(), " 1 = 1 AND 1 = 1 XOR 1 = 0 ", true );
     }
 
 }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/order/OrderFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/order/OrderFunDefTest.java
@@ -46,7 +46,7 @@ class OrderFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testBug715177c(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Order(TopCount({[Store].[USA].[CA].children},"
                 + " [Measures].[Unit Sales], 2), [Measures].[Unit Sales])",
             "[Store].[USA].[CA].[Alameda]\n"
@@ -68,7 +68,7 @@ class OrderFunDefTest {
         // [Marital Status], [Gender].
         String s11 = allHiersExcept(
             "[Product]", "[Measures]", "[Marital Status]", "[Gender]" );
-        assertSetExprDependsOn(context.getConnection(),
+        assertSetExprDependsOn(context.getConnectionWithDefaultRole(),
             "Order("
                 + " Crossjoin([Gender].MEMBERS, [Product].MEMBERS),"
                 + " ([Measures].[Unit Sales], [Marital Status].[S]),"
@@ -79,7 +79,7 @@ class OrderFunDefTest {
         // [Marital Status]. Does depend upon [Gender].
         String s12 = allHiersExcept(
             "[Product]", "[Measures]", "[Marital Status]" );
-        assertSetExprDependsOn(context.getConnection(),
+        assertSetExprDependsOn(context.getConnectionWithDefaultRole(),
             "Order("
                 + " Crossjoin({[Gender].CurrentMember}, [Product].MEMBERS),"
                 + " ([Measures].[Unit Sales], [Marital Status].[S]),"
@@ -88,7 +88,7 @@ class OrderFunDefTest {
 
         // Depends upon everything except [Measures].
         String s13 = allHiersExcept( "[Measures]" );
-        assertSetExprDependsOn(context.getConnection(),
+        assertSetExprDependsOn(context.getConnectionWithDefaultRole(),
             "Order("
                 + "  Crossjoin("
                 + "    [Gender].CurrentMember.Children, "
@@ -99,7 +99,7 @@ class OrderFunDefTest {
 
         String s1 = allHiersExcept(
             "[Measures]", "[Store]", "[Product]", "[Time]" );
-        assertSetExprDependsOn(context.getConnection(),
+        assertSetExprDependsOn(context.getConnectionWithDefaultRole(),
             "  Order(\n"
                 + "    CrossJoin(\n"
                 + "      {[Product].[All Products].[Food].[Eggs],\n"
@@ -119,7 +119,7 @@ class OrderFunDefTest {
 
         // [Measures].[Unit Sales] is a constant member, so it is evaluated in
         // a ContextCalc.
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
 
         String expr = "order([Product].children, [Measures].[Unit Sales])";
         String expected = """
@@ -136,7 +136,7 @@ org.eclipse.daanse.olap.function.def.order.OrderContextCalc(type=SetType<MemberT
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testOrderCalc2(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
 
         String expr = "order([Product].children, ([Time].[1997], [Product].CurrentMember.Parent))";
         String expected = """
@@ -157,7 +157,7 @@ org.eclipse.daanse.olap.function.def.order.OrderContextCalc(type=SetType<MemberT
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testOrderCalc3(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         // No ContextCalc this time. All members are non-variable.
         String expr = "order([Product].children, [Product].CurrentMember.Parent)";
         String expected = """
@@ -174,7 +174,7 @@ org.eclipse.daanse.olap.function.def.order.OrderCurrentMemberCalc(type=SetType<M
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testOrderCalc4(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
 
         String expected = """
 org.eclipse.daanse.olap.function.def.order.OrderContextCalc(type=SetType<MemberType<hierarchy=[Product]>>, resultStyle=MUTABLE_LIST, callCount=0, callMillis=0)
@@ -202,7 +202,7 @@ org.eclipse.daanse.olap.function.def.order.OrderContextCalc(type=SetType<MemberT
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testOrderWithMember(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with member [Measures].[Product Name Length] as "
                 + "'LEN([Product].CurrentMember.Name)'\n"
                 + "select {[Measures].[Product Name Length]} ON COLUMNS,\n"
@@ -228,7 +228,7 @@ org.eclipse.daanse.olap.function.def.order.OrderContextCalc(type=SetType<MemberT
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testOrderNonEmpty(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select NON EMPTY [Gender].Members ON COLUMNS,\n"
                 + "NON EMPTY Order([Product].[All Products].[Drink].Children,\n"
                 + "[Gender].[All Gender].[F], ASC) ON ROWS\n"
@@ -256,7 +256,7 @@ org.eclipse.daanse.olap.function.def.order.OrderContextCalc(type=SetType<MemberT
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testOrder(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Measures].[Unit Sales]} on columns,\n"
                 + " order({\n"
                 + "  [Product].[All Products].[Drink],\n"
@@ -296,7 +296,7 @@ org.eclipse.daanse.olap.function.def.order.OrderContextCalc(type=SetType<MemberT
         // Paradoxically, [Alcoholic Beverages] comes before
         // [Eggs] even though it has a larger value, because
         // its parent [Drink] has a smaller value than [Food].
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Measures].[Unit Sales]} on columns,"
                 + " order({\n"
                 + "  [Product].[All Products].[Drink].[Alcoholic Beverages],\n"
@@ -318,7 +318,7 @@ org.eclipse.daanse.olap.function.def.order.OrderContextCalc(type=SetType<MemberT
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testOrderCrossJoinBreak(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Measures].[Unit Sales]} on columns,\n"
                 + "  Order(\n"
                 + "    CrossJoin(\n"
@@ -353,7 +353,7 @@ org.eclipse.daanse.olap.function.def.order.OrderContextCalc(type=SetType<MemberT
         //    than [Food]
         // 2. [Seattle] generally sorts after [CA] and [OR]
         //    because invisible parent [WA] is greater.
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select CrossJoin(\n"
                 + "    {[Time].[1997],\n"
                 + "     [Time].[1997].[Q1]},\n"
@@ -408,7 +408,7 @@ org.eclipse.daanse.olap.function.def.order.OrderContextCalc(type=SetType<MemberT
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testOrderHierarchicalDesc(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Order(\n"
                 + "    {[Product].[All Products], "
                 + "     [Product].[Food],\n"
@@ -430,7 +430,7 @@ org.eclipse.daanse.olap.function.def.order.OrderContextCalc(type=SetType<MemberT
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testOrderCrossJoinDesc(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Order(\n"
                 + "  CrossJoin(\n"
                 + "    {[Gender].[M], [Gender].[F]},\n"
@@ -466,7 +466,7 @@ org.eclipse.daanse.olap.function.def.order.OrderContextCalc(type=SetType<MemberT
         //    than [Food]
         // 2. [Seattle] generally sorts after [CA] and [OR]
         //    because invisible parent [WA] is greater.
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Measures].[Unit Sales], [Measures].[Store Cost], [Measures].[Store Sales]} ON columns, \n"
                 + "Order(\n"
                 + "  ToggleDrillState(\n"
@@ -503,7 +503,7 @@ org.eclipse.daanse.olap.function.def.order.OrderContextCalc(type=SetType<MemberT
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testOrderBug712702_Simplified(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "SELECT Order({[Time].[Year].members}, [Measures].[Unit Sales]) on columns\n"
                 + "from [Sales]",
             "Axis #0:\n"
@@ -518,7 +518,7 @@ org.eclipse.daanse.olap.function.def.order.OrderContextCalc(type=SetType<MemberT
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testOrderBug712702_Original(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with member [Measures].[Average Unit Sales] as 'Avg(Descendants([Time].[Time].CurrentMember, [Time].[Month]), \n"
                 + "[Measures].[Unit Sales])' \n"
                 + "member [Measures].[Max Unit Sales] as 'Max(Descendants([Time].[Time].CurrentMember, [Time].[Month]), "
@@ -612,7 +612,7 @@ org.eclipse.daanse.olap.function.def.order.OrderContextCalc(type=SetType<MemberT
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testOrderEmpty(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select \n"
                 + "  Order("
                 + "    {},"
@@ -626,7 +626,7 @@ org.eclipse.daanse.olap.function.def.order.OrderContextCalc(type=SetType<MemberT
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testOrderOne(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select \n"
                 + "  Order("
                 + "    {[Customers].[All Customers].[USA].[CA].[Woodland Hills].[Abel Young]},"
@@ -642,7 +642,7 @@ org.eclipse.daanse.olap.function.def.order.OrderContextCalc(type=SetType<MemberT
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testOrderKeyEmpty(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select \n"
                 + "  Order("
                 + "    {},"
@@ -656,7 +656,7 @@ org.eclipse.daanse.olap.function.def.order.OrderContextCalc(type=SetType<MemberT
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testOrderKeyOne(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select \n"
                 + "  Order("
                 + "    {[Customers].[All Customers].[USA].[CA].[Woodland Hills].[Abel Young]},"
@@ -673,7 +673,7 @@ org.eclipse.daanse.olap.function.def.order.OrderContextCalc(type=SetType<MemberT
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testOrderDesc(Context context) {
         // based on olap4j's OlapTest.testSortDimension
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "SELECT\n"
                 + "{[Measures].[Store Sales]} ON COLUMNS,\n"
                 + "{Order(\n"
@@ -705,9 +705,9 @@ org.eclipse.daanse.olap.function.def.order.OrderContextCalc(type=SetType<MemberT
         // Use a fresh connection to make sure bad member ordinals haven't
         // been assigned by previous tests.
         //final Context context = getTestContext().withFreshConnection();
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         try {
-            assertQueryReturns(context.getConnection(),
+            assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "select \n"
                     + "  Order("
                     + "    {[Customers].[All Customers].[USA].[CA].[Woodland Hills].[Abel Young],"
@@ -736,7 +736,7 @@ org.eclipse.daanse.olap.function.def.order.OrderContextCalc(type=SetType<MemberT
         SystemWideProperties.instance().CompareSiblingsByOrderKey = true;
         // Use a fresh connection to make sure bad member ordinals haven't
         // been assigned by previous tests.
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         try {
             assertQueryReturns(connection,
                 "select \n"
@@ -761,7 +761,7 @@ org.eclipse.daanse.olap.function.def.order.OrderContextCalc(type=SetType<MemberT
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testOrderMemberDefaultFlag1(Context context) {
         // flags not specified default to ASC - sort by default measure
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with \n"
                 + "  Member [Measures].[Zero] as '0' \n"
                 + "select \n"
@@ -783,7 +783,7 @@ org.eclipse.daanse.olap.function.def.order.OrderContextCalc(type=SetType<MemberT
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testOrderMemberDefaultFlag2(Context context) {
         // flags not specified default to ASC
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with \n"
                 + "  Member [Measures].[Zero] as '0' \n"
                 + "select \n"
@@ -806,7 +806,7 @@ org.eclipse.daanse.olap.function.def.order.OrderContextCalc(type=SetType<MemberT
     void testOrderMemberMemberValueExpHierarchy(Context context) {
         // Santa Monica and Woodland Hills both don't have orderkey
         // members are sorted by the order of their keys
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select \n"
                 + "  Order("
                 + "    {[Customers].[All Customers].[USA].[CA].[Woodland Hills].[Abel Young],"
@@ -826,7 +826,7 @@ org.eclipse.daanse.olap.function.def.order.OrderContextCalc(type=SetType<MemberT
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testOrderMemberMultiKeysMemberValueExp1(Context context) {
         // sort by unit sales and then customer id (Adeline = 6442, Abe = 570)
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select \n"
                 + "  Order("
                 + "    {[Customers].[USA].[WA].[Issaquah].[Abe Tramel],"
@@ -852,7 +852,7 @@ org.eclipse.daanse.olap.function.def.order.OrderContextCalc(type=SetType<MemberT
         SystemWideProperties.instance().CompareSiblingsByOrderKey = true;
         // Use a fresh connection to make sure bad member ordinals haven't
         // been assigned by previous tests.
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         try {
             assertQueryReturns(connection,
                 "select \n"
@@ -880,7 +880,7 @@ org.eclipse.daanse.olap.function.def.order.OrderContextCalc(type=SetType<MemberT
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testOrderMemberMultiKeysMemberValueExpDepends(Context context) {
         // should preserve order of Abe and Adeline (note second key is [Time])
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select \n"
                 + "  Order("
                 + "    {[Customers].[USA].[WA].[Issaquah].[Abe Tramel],"
@@ -906,7 +906,7 @@ org.eclipse.daanse.olap.function.def.order.OrderContextCalc(type=SetType<MemberT
         SystemWideProperties.instance().CompareSiblingsByOrderKey = true;
         // Use a fresh connection to make sure bad member ordinals haven't
         // been assigned by previous tests.
-        final Connection connection = context.getConnection();
+        final Connection connection = context.getConnectionWithDefaultRole();
         try {
             assertQueryReturns(connection,
                 "with \n"
@@ -942,7 +942,7 @@ org.eclipse.daanse.olap.function.def.order.OrderContextCalc(type=SetType<MemberT
         SystemWideProperties.instance().CompareSiblingsByOrderKey = true;
         // Use a fresh connection to make sure bad member ordinals haven't
         // been assigned by previous tests.
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         try {
             assertQueryReturns(connection,
                 "with \n"
@@ -974,7 +974,7 @@ org.eclipse.daanse.olap.function.def.order.OrderContextCalc(type=SetType<MemberT
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testOrderTupleMultiKeys1(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with \n"
                 + "  set [NECJ] as \n"
                 + "    'NonEmptyCrossJoin( \n"
@@ -1000,7 +1000,7 @@ org.eclipse.daanse.olap.function.def.order.OrderContextCalc(type=SetType<MemberT
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testOrderTupleMultiKeys2(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with \n"
                 + "  set [NECJ] as \n"
                 + "    'NonEmptyCrossJoin( \n"
@@ -1029,7 +1029,7 @@ org.eclipse.daanse.olap.function.def.order.OrderContextCalc(type=SetType<MemberT
     void testOrderTupleMultiKeys3(Context context) {
         // WA unit sales is greater than CA unit sales
         // Santa Monica unit sales (2660) is greater that Woodland hills (2516)
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with \n"
                 + "  set [NECJ] as \n"
                 + "    'NonEmptyCrossJoin( \n"
@@ -1104,7 +1104,7 @@ org.eclipse.daanse.olap.function.def.order.OrderContextCalc(type=SetType<MemberT
     TestUtil.withSchema(context, schema);
      */
         withSchema(context, TestOrderTupleMultiKeyswithVCubeModifier::new);
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with \n"
                 + "  set [CJ] as \n"
                 + "    'CrossJoin( \n"
@@ -1151,7 +1151,7 @@ org.eclipse.daanse.olap.function.def.order.OrderContextCalc(type=SetType<MemberT
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testOrderConstant1(Context context) {
         // sort by customerId (Abel = 7851, Adeline = 6442, Abe = 570)
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select \n"
                 + "  Order("
                 + "    {[Customers].[USA].[WA].[Issaquah].[Abe Tramel],"
@@ -1173,7 +1173,7 @@ org.eclipse.daanse.olap.function.def.order.OrderContextCalc(type=SetType<MemberT
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testOrderDiffrentDim(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select \n"
                 + "  Order("
                 + "    {[Customers].[USA].[WA].[Issaquah].[Abe Tramel],"

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/parallelperiod/ParallelPeriodFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/parallelperiod/ParallelPeriodFunDefTest.java
@@ -58,7 +58,7 @@ class ParallelPeriodFunDefTest {
             + "Row #1: \n"
             + "Row #2: \n"
             + "Row #3: \n";
-        TestUtil.assertQueryReturns(context.getConnection(), query, expected);
+        TestUtil.assertQueryReturns(context.getConnectionWithDefaultRole(), query, expected);
     }
 
     /**
@@ -67,7 +67,7 @@ class ParallelPeriodFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testParallelPeriodWithSlicer(Context context) {
-      TestUtil.assertQueryReturns(context.getConnection(),
+      TestUtil.assertQueryReturns(context.getConnectionWithDefaultRole(),
         "With "
           + "Set [*NATIVE_CJ_SET] as 'NonEmptyCrossJoin([*BASE_MEMBERS_Time],[*BASE_MEMBERS_Product])' "
           + "Set [*BASE_MEMBERS_Measures] as '{[Measures].[*FORMATTED_MEASURE_0], [Measures].[*FORMATTED_MEASURE_1]}' "
@@ -100,7 +100,7 @@ class ParallelPeriodFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testParallelperiodOnLevelsString(Context context) {
-      TestUtil.assertQueryReturns(context.getConnection(),
+      TestUtil.assertQueryReturns(context.getConnectionWithDefaultRole(),
         "with member Measures.[Prev Unit Sales] as 'parallelperiod(Levels(\"[Time].[Month]\"))'\n"
           + "select {[Measures].[Unit Sales], Measures.[Prev Unit Sales]} ON COLUMNS,\n"
           + "[Gender].members ON ROWS\n"
@@ -126,7 +126,7 @@ class ParallelPeriodFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testParallelperiodOnStrToMember(Context context) {
-      assertQueryReturns(context.getConnection(),
+      assertQueryReturns(context.getConnectionWithDefaultRole(),
         "with member Measures.[Prev Unit Sales] as 'parallelperiod(strToMember(\"[Time].[1997].[Q2]\"))'\n"
           + "select {[Measures].[Unit Sales], Measures.[Prev Unit Sales]} ON COLUMNS,\n"
           + "[Gender].members ON ROWS\n"
@@ -148,7 +148,7 @@ class ParallelPeriodFunDefTest {
           + "Row #2: 10,545\n"
           + "Row #2: 10,691\n" );
 
-      assertQueryThrows(context.getConnection(),
+      assertQueryThrows(context.getConnectionWithDefaultRole(),
         "with member Measures.[Prev Unit Sales] as 'parallelperiod(strToMember(\"[Time].[Quarter]\"))'\n"
           + "select {[Measures].[Unit Sales], Measures.[Prev Unit Sales]} ON COLUMNS,\n"
           + "[Gender].members ON ROWS\n"
@@ -161,34 +161,34 @@ class ParallelPeriodFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testParallelPeriod(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "parallelperiod([Time].[Quarter], 1, [Time].[1998].[Q1])",
             "[Time].[1997].[Q4]" );
 
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "parallelperiod([Time].[Quarter], -1, [Time].[1997].[Q1])",
             "[Time].[1997].[Q2]" );
 
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "parallelperiod([Time].[Year], 1, [Time].[1998].[Q1])",
             "[Time].[1997].[Q1]" );
 
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "parallelperiod([Time].[Year], 1, [Time].[1998].[Q1].[1])",
             "[Time].[1997].[Q1].[1]" );
 
         // No args, therefore finds parallel period to [Time].[1997], which
         // would be [Time].[1996], except that that doesn't exist, so null.
-        assertAxisReturns(context.getConnection(), "ParallelPeriod()", "" );
+        assertAxisReturns(context.getConnectionWithDefaultRole(), "ParallelPeriod()", "" );
 
         // Parallel period to [Time].[1997], which would be [Time].[1996],
         // except that that doesn't exist, so null.
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "ParallelPeriod([Time].[Year], 1, [Time].[1997])", "" );
 
         // one parameter, level 2 above member
         if ( isDefaultNullMemberRepresentation() ) {
-            assertQueryReturns(context.getConnection(),
+            assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "WITH MEMBER [Measures].[Foo] AS \n"
                     + " ' ParallelPeriod([Time].[Year]).UniqueName '\n"
                     + "SELECT {[Measures].[Foo]} ON COLUMNS\n"
@@ -202,7 +202,7 @@ class ParallelPeriodFunDefTest {
         }
 
         // one parameter, level 1 above member
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH MEMBER [Measures].[Foo] AS \n"
                 + " ' ParallelPeriod([Time].[Quarter]).UniqueName '\n"
                 + "SELECT {[Measures].[Foo]} ON COLUMNS\n"
@@ -215,7 +215,7 @@ class ParallelPeriodFunDefTest {
                 + "Row #0: [Time].[1997].[Q2].[5]\n" );
 
         // one parameter, level same as member
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH MEMBER [Measures].[Foo] AS \n"
                 + " ' ParallelPeriod([Time].[Month]).UniqueName '\n"
                 + "SELECT {[Measures].[Foo]} ON COLUMNS\n"
@@ -229,7 +229,7 @@ class ParallelPeriodFunDefTest {
 
         //  one parameter, level below member
         if ( isDefaultNullMemberRepresentation() ) {
-            assertQueryReturns(context.getConnection(),
+            assertQueryReturns(context.getConnectionWithDefaultRole(),
                 "WITH MEMBER [Measures].[Foo] AS \n"
                     + " ' ParallelPeriod([Time].[Month]).UniqueName '\n"
                     + "SELECT {[Measures].[Foo]} ON COLUMNS\n"
@@ -255,27 +255,27 @@ class ParallelPeriodFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testParallelPeriodDepends(Context context) {
-        assertMemberExprDependsOn(context.getConnection(),
+        assertMemberExprDependsOn(context.getConnectionWithDefaultRole(),
             "ParallelPeriod([Time].[Quarter], 2.0)", "{[Time]}" );
-        assertMemberExprDependsOn(context.getConnection(),
+        assertMemberExprDependsOn(context.getConnectionWithDefaultRole(),
             "ParallelPeriod([Time].[Quarter], 2.0, [Time].[1997].[Q3])", "{}" );
-        assertMemberExprDependsOn(context.getConnection(),
+        assertMemberExprDependsOn(context.getConnectionWithDefaultRole(),
             "ParallelPeriod()",
             "{[Time]}" );
-        assertMemberExprDependsOn(context.getConnection(),
+        assertMemberExprDependsOn(context.getConnectionWithDefaultRole(),
             "ParallelPeriod([Product].[Food])", "{[Product]}" );
         // [Gender].[M] is used here as a numeric expression!
         // The numeric expression DOES depend upon [Product].
         // The expression as a whole depends upon everything except [Gender].
         String s1 = allHiersExcept( "[Gender]" );
-        assertMemberExprDependsOn(context.getConnection(),
+        assertMemberExprDependsOn(context.getConnectionWithDefaultRole(),
             "ParallelPeriod([Product].[Product Family], [Gender].[M], [Product].[Food])",
             s1 );
         // As above
         String s11 = allHiersExcept( "[Gender]" );
-        assertMemberExprDependsOn(context.getConnection(),
+        assertMemberExprDependsOn(context.getConnectionWithDefaultRole(),
             "ParallelPeriod([Product].[Product Family], [Gender].[M])", s11 );
-        assertSetExprDependsOn(context.getConnection(),
+        assertSetExprDependsOn(context.getConnectionWithDefaultRole(),
             "parallelperiod([Time].[Time].CurrentMember)",
             "{[Time]}" );
     }
@@ -283,7 +283,7 @@ class ParallelPeriodFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testParallelPeriodLevelLag(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with member [Measures].[Prev Unit Sales] as "
                 + "        '([Measures].[Unit Sales], parallelperiod([Time].[Quarter], 2))' "
                 + "select "
@@ -310,7 +310,7 @@ class ParallelPeriodFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testParallelPeriodLevel(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with "
                 + "    member [Measures].[Prev Unit Sales] as "
                 + "        '([Measures].[Unit Sales], parallelperiod([Time].[Quarter]))' "

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/percentile/PercentileFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/percentile/PercentileFunDefTest.java
@@ -28,27 +28,27 @@ class PercentileFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testPercentile(Context context) {
         // same result as median
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "Percentile({[Store].[All Stores].[USA].children}, [Measures].[Store Sales], 50)",
             "159,167.84" );
         // same result as min
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "Percentile({[Store].[All Stores].[USA].children}, [Measures].[Store Sales], 0)",
             "142,277.07" );
         // same result as max
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "Percentile({[Store].[All Stores].[USA].children}, [Measures].[Store Sales], 100)",
             "263,793.22" );
         // check some real percentile cases
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "Percentile({[Store].[All Stores].[USA].[WA].children}, [Measures].[Store Sales], 50)",
             "49,634.46" );
         // the next two results correspond to MS Excel 2013.
         // See MONDRIAN-2343 jira issue.
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "Percentile({[Store].[All Stores].[USA].[WA].children}, [Measures].[Store Sales], 100/7*2)",
             "18,732.09" );
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "Percentile({[Store].[All Stores].[USA].[WA].children}, [Measures].[Store Sales], 95)",
             "68,259.66" );
     }
@@ -61,13 +61,13 @@ class PercentileFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testPercentileBugMondrian1045(Context context) {
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "Percentile({[Store].[All Stores].[USA]}, [Measures].[Store Sales], 50)",
             "565,238.13" );
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "Percentile({[Store].[All Stores].[USA]}, [Measures].[Store Sales], 40)",
             "565,238.13" );
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "Percentile({[Store].[All Stores].[USA]}, [Measures].[Store Sales], 95)",
             "565,238.13" );
     }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/periodstodate/PeriodsToDateFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/periodstodate/PeriodsToDateFunDefTest.java
@@ -31,20 +31,20 @@ class PeriodsToDateFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testPeriodsToDate(Context context) {
-        assertSetExprDependsOn(context.getConnection(), "PeriodsToDate()", "{[Time]}" );
-        assertSetExprDependsOn(context.getConnection(),
+        assertSetExprDependsOn(context.getConnectionWithDefaultRole(), "PeriodsToDate()", "{[Time]}" );
+        assertSetExprDependsOn(context.getConnectionWithDefaultRole(),
             "PeriodsToDate([Time].[Year])",
             "{[Time]}" );
-        assertSetExprDependsOn(context.getConnection(),
+        assertSetExprDependsOn(context.getConnectionWithDefaultRole(),
             "PeriodsToDate([Time].[Year], [Time].[1997].[Q2].[5])", "{}" );
 
         // two args
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "PeriodsToDate([Time].[Quarter], [Time].[1997].[Q2].[5])",
             "[Time].[1997].[Q2].[4]\n" + "[Time].[1997].[Q2].[5]" );
 
         // equivalent to above
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "TopCount("
                 + "  Descendants("
                 + "    Ancestor("
@@ -54,7 +54,7 @@ class PeriodsToDateFunDefTest {
             "[Time].[1997].[Q2].[4]\n" + "[Time].[1997].[Q2].[5]" );
 
         // one arg
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with member [Measures].[Foo] as ' SetToStr(PeriodsToDate([Time].[Quarter])) '\n"
                 + "select {[Measures].[Foo]} on columns\n"
                 + "from [Sales]\n"
@@ -66,7 +66,7 @@ class PeriodsToDateFunDefTest {
                 + "Row #0: {[Time].[1997].[Q2].[4], [Time].[1997].[Q2].[5]}\n" );
 
         // zero args
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with member [Measures].[Foo] as ' SetToStr(PeriodsToDate()) '\n"
                 + "select {[Measures].[Foo]} on columns\n"
                 + "from [Sales]\n"
@@ -81,7 +81,7 @@ class PeriodsToDateFunDefTest {
         // The default level is the level above the current member -- so
         // choosing a member at the highest level might trip up the
         // implementation.
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with member [Measures].[Foo] as ' SetToStr(PeriodsToDate()) '\n"
                 + "select {[Measures].[Foo]} on columns\n"
                 + "from [Sales]\n"
@@ -94,7 +94,7 @@ class PeriodsToDateFunDefTest {
 
         // Testcase for bug 1598379, which caused NPE because the args[0].type
         // knew its dimension but not its hierarchy.
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with member [Measures].[Position] as\n"
                 + " 'Sum("
                 + "PeriodsToDate([Time].[Time].Levels(0),"
@@ -129,7 +129,7 @@ class PeriodsToDateFunDefTest {
                 + "Row #1: 89,598.48\n"
                 + "Row #1: 139,628.35\n" );
 
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select\n"
                 + "{[Measures].[Unit Sales]} on columns,\n"
                 + "periodstodate(\n"
@@ -150,7 +150,7 @@ class PeriodsToDateFunDefTest {
 
         // TODO: enable
         if ( false ) {
-            assertExprThrows(context.getConnection(),
+            assertExprThrows(context.getConnectionWithDefaultRole(),
                 "Sum(PeriodsToDate([Time.Weekly].[Year], [Time].CurrentMember), [Measures].[Unit Sales])",
                 "wrong dimension" );
         }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/periodstodate/xtd/XtdFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/periodstodate/xtd/XtdFunDefTest.java
@@ -48,25 +48,25 @@ public class XtdFunDefTest {
 	@ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
 	void testYtd(Context context) {
 
-		assertAxisReturns(context.getConnection(), "Ytd()", "[Time].[1997]");
+		assertAxisReturns(context.getConnectionWithDefaultRole(), "Ytd()", "[Time].[1997]");
 
-		assertAxisReturns(context.getConnection(), "Ytd([Time].[1997].[Q3])", """
+		assertAxisReturns(context.getConnectionWithDefaultRole(), "Ytd([Time].[1997].[Q3])", """
 				[Time].[1997].[Q1]
 				[Time].[1997].[Q2]
 				[Time].[1997].[Q3]""");
 
-		assertAxisReturns(context.getConnection(), "Ytd([Time].[1997].[Q2].[4])", """
+		assertAxisReturns(context.getConnectionWithDefaultRole(), "Ytd([Time].[1997].[Q2].[4])", """
 				[Time].[1997].[Q1].[1]
 				[Time].[1997].[Q1].[2]
 				[Time].[1997].[Q1].[3]
 				[Time].[1997].[Q2].[4]""");
 
-		assertAxisThrows(context.getConnection(), "Ytd([Store])",
+		assertAxisThrows(context.getConnectionWithDefaultRole(), "Ytd([Store])",
 				"Argument to function 'Ytd' must belong to Time hierarchy");
 
-		assertSetExprDependsOn(context.getConnection(), "Ytd()", "{[Time], " + TimeWeekly + "}");
+		assertSetExprDependsOn(context.getConnectionWithDefaultRole(), "Ytd()", "{[Time], " + TimeWeekly + "}");
 
-		assertSetExprDependsOn(context.getConnection(), "Ytd([Time].[1997].[Q2])", "{}");
+		assertSetExprDependsOn(context.getConnectionWithDefaultRole(), "Ytd([Time].[1997].[Q2])", "{}");
 	}
 
 	/**
@@ -78,7 +78,7 @@ public class XtdFunDefTest {
 	@ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
 	void testGeneratePlusXtd(Context context) {
 		
-		assertAxisReturns(context.getConnection(), """
+		assertAxisReturns(context.getConnectionWithDefaultRole(), """
 				generate(
 				  {[Time].[1997].[Q1].[2], [Time].[1997].[Q3].[7]},
 				 {Ytd( [Time].[Time].currentMember)})""", """
@@ -90,7 +90,7 @@ public class XtdFunDefTest {
 				[Time].[1997].[Q2].[6]
 				[Time].[1997].[Q3].[7]""");
 		
-		assertAxisReturns(context.getConnection(), """
+		assertAxisReturns(context.getConnectionWithDefaultRole(), """
 				generate(
 				  {[Time].[1997].[Q1].[2], [Time].[1997].[Q3].[7]},
 				 {Ytd( [Time].[Time].currentMember)}, ALL)""", """
@@ -104,10 +104,10 @@ public class XtdFunDefTest {
 				[Time].[1997].[Q2].[6]
 				[Time].[1997].[Q3].[7]""");
 		
-		FunctionTest.assertExprReturns(context.getConnection(),
+		FunctionTest.assertExprReturns(context.getConnectionWithDefaultRole(),
 				"count(generate({[Time].[1997].[Q4].[11]}, {Qtd( [Time].[Time].currentMember)}))", 2, 0);
 		
-		FunctionTest.assertExprReturns(context.getConnection(),
+		FunctionTest.assertExprReturns(context.getConnectionWithDefaultRole(),
 				"count(generate({[Time].[1997].[Q4].[11]}, {Mtd( [Time].[Time].currentMember)}))", 1, 0);
 	}
 
@@ -115,7 +115,7 @@ public class XtdFunDefTest {
 	@ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
 	void testQtd(Context context) {
 		// zero args
-		assertQueryReturns(context.getConnection(), """
+		assertQueryReturns(context.getConnectionWithDefaultRole(), """
 				with member [Measures].[Foo] as ' SetToStr(Qtd()) '
 				select {[Measures].[Foo]} on columns
 				from [Sales]
@@ -128,16 +128,16 @@ public class XtdFunDefTest {
 				""");
 
 		// one arg, a month
-		assertAxisReturns(context.getConnection(), "Qtd([Time].[1997].[Q2].[5])",
+		assertAxisReturns(context.getConnectionWithDefaultRole(), "Qtd([Time].[1997].[Q2].[5])",
 				"[Time].[1997].[Q2].[4]\n" + "[Time].[1997].[Q2].[5]");
 
 		// one arg, a quarter
-		assertAxisReturns(context.getConnection(), "Qtd([Time].[1997].[Q2])", "[Time].[1997].[Q2]");
+		assertAxisReturns(context.getConnectionWithDefaultRole(), "Qtd([Time].[1997].[Q2])", "[Time].[1997].[Q2]");
 
 		// one arg, a year
-		assertAxisReturns(context.getConnection(), "Qtd([Time].[1997])", "");
+		assertAxisReturns(context.getConnectionWithDefaultRole(), "Qtd([Time].[1997])", "");
 
-		assertAxisThrows(context.getConnection(), "Qtd([Store])",
+		assertAxisThrows(context.getConnectionWithDefaultRole(), "Qtd([Store])",
 				"Argument to function 'Qtd' must belong to Time hierarchy");
 	}
 
@@ -145,7 +145,7 @@ public class XtdFunDefTest {
 	@ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
 	void testMtd(Context context) {
 		// zero args
-		assertQueryReturns(context.getConnection(), """
+		assertQueryReturns(context.getConnectionWithDefaultRole(), """
 				with member [Measures].[Foo] as ' SetToStr(Mtd()) '
 				select {[Measures].[Foo]} on columns
 				from [Sales]
@@ -158,15 +158,15 @@ public class XtdFunDefTest {
 				""");
 
 		// one arg, a month
-		assertAxisReturns(context.getConnection(), "Mtd([Time].[1997].[Q2].[5])", "[Time].[1997].[Q2].[5]");
+		assertAxisReturns(context.getConnectionWithDefaultRole(), "Mtd([Time].[1997].[Q2].[5])", "[Time].[1997].[Q2].[5]");
 
 		// one arg, a quarter
-		assertAxisReturns(context.getConnection(), "Mtd([Time].[1997].[Q2])", "");
+		assertAxisReturns(context.getConnectionWithDefaultRole(), "Mtd([Time].[1997].[Q2])", "");
 
 		// one arg, a year
-		assertAxisReturns(context.getConnection(), "Mtd([Time].[1997])", "");
+		assertAxisReturns(context.getConnectionWithDefaultRole(), "Mtd([Time].[1997])", "");
 
-		assertAxisThrows(context.getConnection(), "Mtd([Store])",
+		assertAxisThrows(context.getConnectionWithDefaultRole(), "Mtd([Store])",
 				"Argument to function 'Mtd' must belong to Time hierarchy");
 	}
 

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/properties/PropertiesFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/properties/PropertiesFunDefTest.java
@@ -34,7 +34,7 @@ class PropertiesFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testPropertiesExpr(Context context) {
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "[Store].[USA].[CA].[Beverly Hills].[Store 6].Properties(\"Store Type\")",
             "Gourmet Supermarket" );
     }
@@ -49,17 +49,17 @@ class PropertiesFunDefTest {
     void testPropertiesOnDimension(Context context) {
         // [Store] is a dimension. When called with a property like FirstChild,
         // it is implicitly converted to a member.
-        assertAxisReturns(context.getConnection(), "[Store].FirstChild", "[Store].[Canada]" );
+        assertAxisReturns(context.getConnectionWithDefaultRole(), "[Store].FirstChild", "[Store].[Canada]" );
 
         // The same should happen with the <Member>.Properties(<String>)
         // function; now the bug is fixed, it does. Dimension is implicitly
         // converted to member.
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "[Store].Properties('MEMBER_UNIQUE_NAME')",
             "[Store].[All Stores]" );
 
         // Hierarchy is implicitly converted to member.
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "[Store].[USA].Hierarchy.Properties('MEMBER_UNIQUE_NAME')",
             "[Store].[All Stores]" );
     }
@@ -70,7 +70,7 @@ class PropertiesFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testPropertiesNonExistent(Context context) {
-        assertExprThrows(context.getConnection(),
+        assertExprThrows(context.getConnectionWithDefaultRole(),
             "[Store].[USA].[CA].[Beverly Hills].[Store 6].Properties(\"Foo\")",
             "Property 'Foo' is not valid for" );
     }
@@ -78,7 +78,7 @@ class PropertiesFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testPropertiesFilter(Context context) {
-        Result result = executeQuery(context.getConnection(),
+        Result result = executeQuery(context.getConnectionWithDefaultRole(),
             "SELECT { [Store Sales] } ON COLUMNS,\n"
                 + " TOPCOUNT(Filter( [Store].[Store Name].Members,\n"
                 + "                   [Store].CurrentMember.Properties(\"Store Type\") = \"Supermarket\"),\n"
@@ -90,7 +90,7 @@ class PropertiesFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testPropertyInCalculatedMember(Context context) {
-        Result result = executeQuery(context.getConnection(),
+        Result result = executeQuery(context.getConnectionWithDefaultRole(),
             "WITH MEMBER [Measures].[Store Sales per Sqft]\n"
                 + "AS '[Measures].[Store Sales] / "
                 + "  [Store].CurrentMember.Properties(\"Store Sqft\")'\n"

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/rank/RankFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/rank/RankFunDefTest.java
@@ -43,22 +43,22 @@ class RankFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testRank(Context context) {
         // Member within set
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "Rank([Store].[USA].[CA], "
                 + "{[Store].[USA].[OR],"
                 + " [Store].[USA].[CA],"
                 + " [Store].[USA]})", "2" );
         // Member not in set
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "Rank([Store].[USA].[WA], "
                 + "{[Store].[USA].[OR],"
                 + " [Store].[USA].[CA],"
                 + " [Store].[USA]})", "0" );
         // Member not in empty set
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "Rank([Store].[USA].[WA], {})", "0" );
         // Null member not in set returns null.
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "Rank([Store].Parent, "
                 + "{[Store].[USA].[OR],"
                 + " [Store].[USA].[CA],"
@@ -66,32 +66,32 @@ class RankFunDefTest {
         // Null member in empty set. (MSAS returns an error "Formula error -
         // dimension count is not valid - in the Rank function" but I think
         // null is the correct behavior.)
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "Rank([Gender].Parent, {})", "" );
         // Member occurs twice in set -- pick first
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "Rank([Store].[USA].[WA], \n"
                 + "{[Store].[USA].[WA],"
                 + " [Store].[USA].[CA],"
                 + " [Store].[USA],"
                 + " [Store].[USA].[WA]})", "1" );
         // Tuple not in set
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "Rank(([Gender].[F], [Marital Status].[M]), \n"
                 + "{([Gender].[F], [Marital Status].[S]),\n"
                 + " ([Gender].[M], [Marital Status].[S]),\n"
                 + " ([Gender].[M], [Marital Status].[M])})", "0" );
         // Tuple in set
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "Rank(([Gender].[F], [Marital Status].[M]), \n"
                 + "{([Gender].[F], [Marital Status].[S]),\n"
                 + " ([Gender].[M], [Marital Status].[S]),\n"
                 + " ([Gender].[F], [Marital Status].[M])})", "3" );
         // Tuple not in empty set
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "Rank(([Gender].[F], [Marital Status].[M]), \n" + "{})", "0" );
         // Partially null tuple in set, returns null
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "Rank(([Gender].[F], [Marital Status].Parent), \n"
                 + "{([Gender].[F], [Marital Status].[S]),\n"
                 + " ([Gender].[M], [Marital Status].[S]),\n"
@@ -105,7 +105,7 @@ class RankFunDefTest {
         // value (5), but [Good] ranks 1 and [Top Measure] ranks 2. Even though
         // they are sorted descending on unit sales, they remain in their
         // natural order (member name) because MDX sorts are stable.
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with member [Measures].[Sibling Rank] as ' Rank([Product].CurrentMember, [Product].CurrentMember.Siblings) '\n"
                 + "  member [Measures].[Sales Rank] as ' Rank([Product].CurrentMember, Order([Product].Parent.Children, "
                 + "[Measures].[Unit Sales], DESC)) '\n"
@@ -147,7 +147,7 @@ class RankFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testRankMembersWithTiedExpr(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with "
                 + " Set [Beers] as {[Product].[All Products].[Drink].[Alcoholic Beverages].[Beer and Wine].[Beer].children} "
                 + "  member [Measures].[Sales Rank] as ' Rank([Product].CurrentMember, [Beers], [Measures].[Unit Sales]) '\n"
@@ -181,7 +181,7 @@ class RankFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testRankTuplesWithTiedExpr(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with "
                 + " Set [Beers for Store] as 'NonEmptyCrossJoin("
                 + "[Product].[All Products].[Drink].[Alcoholic Beverages].[Beer and Wine].[Beer].children, "
@@ -223,21 +223,21 @@ class RankFunDefTest {
         // All gender 266,733
         // F          131,558
         // M          135,215
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "Rank([Gender].[All Gender],"
                 + " {[Gender].Members},"
                 + " [Measures].[Unit Sales])", "1" );
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "Rank([Gender].[F],"
                 + " {[Gender].Members},"
                 + " [Measures].[Unit Sales])", "3" );
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "Rank([Gender].[M],"
                 + " {[Gender].Members},"
                 + " [Measures].[Unit Sales])", "2" );
         // Null member. Expression evaluates to null, therefore value does
         // not appear in the list of values, therefore the rank is null.
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "Rank([Gender].[All Gender].Parent,"
                 + " {[Gender].Members},"
                 + " [Measures].[Unit Sales])", "" );
@@ -247,34 +247,34 @@ class RankFunDefTest {
         // a tuple expression, should reference the same hierachies as the
         // second argument, a set expression'. I think that's because it can't
         // deduce a type for '{}'. SSAS's problem, not Mondrian's. :)
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "Rank([Gender].[M],"
                 + " {},"
                 + " [Measures].[Unit Sales])",
             "1" );
         // As above, but SSAS can type-check this.
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "Rank([Gender].[M],"
                 + " Filter(Gender.Members, 1 = 0),"
                 + " [Measures].[Unit Sales])",
             "1" );
         // Member is not in set
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "Rank([Gender].[M]," + " {[Gender].[All Gender], [Gender].[F]})",
             "0" );
         // Even though M is not in the set, its value lies between [All Gender]
         // and [F].
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "Rank([Gender].[M],"
                 + " {[Gender].[All Gender], [Gender].[F]},"
                 + " [Measures].[Unit Sales])", "2" );
         // Expr evaluates to null for some values of set.
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "Rank([Product].[Non-Consumable].[Household],"
                 + " {[Product].[Food], [Product].[All Products], [Product].[Drink].[Dairy]},"
                 + " [Product].CurrentMember.Parent)", "2" );
         // Expr evaluates to null for all values in the set.
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "Rank([Gender].[M],"
                 + " {[Gender].[All Gender], [Gender].[F]},"
                 + " [Marital Status].[All Marital Status].Parent)", "1" );
@@ -286,7 +286,7 @@ class RankFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testRankWithNulls(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with member [Measures].[X] as "
                 + "'iif([Measures].[Store Sales]=777,"
                 + "[Measures].[Store Sales],Null)'\n"
@@ -312,7 +312,7 @@ class RankFunDefTest {
             return;
         }
 
-        checkRankHuge(context.getConnection(),
+        checkRankHuge(context.getConnectionWithDefaultRole(),
             "WITH \n"
                 + "  MEMBER [Measures].[Rank among products] \n"
                 + "    AS ' Rank([Product].CurrentMember, "
@@ -345,7 +345,7 @@ class RankFunDefTest {
             return;
         }
 
-        checkRankHuge(context.getConnection(),
+        checkRankHuge(context.getConnectionWithDefaultRole(),
             "WITH \n"
                 + "  MEMBER [Measures].[Rank among products] \n"
                 + "    AS ' Rank([Product].CurrentMember, [Product].members, [Measures].[Unit Sales]) '\n"

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/set/addcalculatedmembers/AddCalculatedMembersFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/set/addcalculatedmembers/AddCalculatedMembersFunDefTest.java
@@ -32,7 +32,7 @@ class AddCalculatedMembersFunDefTest {
         // AddCalculatedMembers: Calc member in dimension based on level
         // included
         //----------------------------------------------------
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         assertQueryReturns(connection,
             "WITH MEMBER [Store].[USA].[CA plus OR] AS 'AGGREGATE({[Store].[USA].[CA], [Store].[USA].[OR]})' "
                 + "SELECT {[Measures].[Unit Sales], [Measures].[Store Sales]} ON COLUMNS,"

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/set/ascendants/AscendantsFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/set/ascendants/AscendantsFunDefTest.java
@@ -27,7 +27,7 @@ class AscendantsFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testAscendants(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Ascendants([Store].[USA].[CA])",
             "[Store].[USA].[CA]\n"
                 + "[Store].[USA]\n"
@@ -37,14 +37,14 @@ class AscendantsFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testAscendantsAll(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Ascendants([Store].DefaultMember)", "[Store].[All Stores]" );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testAscendantsNull(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Ascendants([Gender].[F].PrevMember)", "" );
     }
 

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/set/distinct/DistinctFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/set/distinct/DistinctFunDefTest.java
@@ -28,7 +28,7 @@ class DistinctFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDistinctTwoMembers(Context context) {
         //getTestContext().withCube( "HR" ).
-        assertAxisReturns(context.getConnection(), "HR",
+        assertAxisReturns(context.getConnectionWithDefaultRole(), "HR",
             "Distinct({[Employees].[All Employees].[Sheri Nowmer].[Donna Arnold],"
                 + "[Employees].[Sheri Nowmer].[Donna Arnold]})",
             "[Employees].[Sheri Nowmer].[Donna Arnold]" );
@@ -38,7 +38,7 @@ class DistinctFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDistinctThreeMembers(Context context) {
         //getTestContext().withCube( "HR" ).
-        assertAxisReturns(context.getConnection(), "HR",
+        assertAxisReturns(context.getConnectionWithDefaultRole(), "HR",
             "Distinct({[Employees].[All Employees].[Sheri Nowmer].[Donna Arnold],"
                 + "[Employees].[All Employees].[Sheri Nowmer].[Darren Stanz],"
                 + "[Employees].[All Employees].[Sheri Nowmer].[Donna Arnold]})",
@@ -50,7 +50,7 @@ class DistinctFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDistinctFourMembers(Context context) {
         //getTestContext().withCube( "HR" ).
-        assertAxisReturns(context.getConnection(), "HR",
+        assertAxisReturns(context.getConnectionWithDefaultRole(), "HR",
             "Distinct({[Employees].[All Employees].[Sheri Nowmer].[Donna Arnold],"
                 + "[Employees].[All Employees].[Sheri Nowmer].[Darren Stanz],"
                 + "[Employees].[All Employees].[Sheri Nowmer].[Donna Arnold],"
@@ -62,7 +62,7 @@ class DistinctFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDistinctTwoTuples(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Distinct({([Time].[1997],[Store].[All Stores].[Mexico]), "
                 + "([Time].[1997], [Store].[All Stores].[Mexico])})",
             "{[Time].[1997], [Store].[Mexico]}" );
@@ -71,7 +71,7 @@ class DistinctFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDistinctSomeTuples(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Distinct({([Time].[1997],[Store].[All Stores].[Mexico]), "
                 + "crossjoin({[Time].[1997]},{[Store].[All Stores].children})})",
             "{[Time].[1997], [Store].[Mexico]}\n"

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/set/existing/ExistingFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/set/existing/ExistingFunDefTest.java
@@ -27,7 +27,7 @@ class ExistingFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testExisting(Context context) {
         // basic test
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with \n"
                 + "  member measures.ExistingCount as\n"
                 + "  count(Existing [Product].[Product Subcategory].Members)\n"
@@ -46,7 +46,7 @@ class ExistingFunDefTest {
                 + "Row #1: 62\n"
                 + "Row #2: 32\n" );
         // same as exists+currentMember
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with member measures.StaticCount as\n"
                 + "  count([Product].[Product Subcategory].Members)\n"
                 + "  member measures.WithExisting as\n"
@@ -81,7 +81,7 @@ class ExistingFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testExistingCalculatedMeasure(Context context) {
         // sorry about the mess, this came from Analyzer
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH \n"
                 + "SET [*NATIVE_CJ_SET] AS 'FILTER({[Time.Weekly].[All Time.Weeklys].[1997].[2],[Time.Weekly].[All Time"
                 + ".Weeklys].[1997].[24]}, NOT ISEMPTY ([Measures].[Store Sales]) OR NOT ISEMPTY ([Measures]"
@@ -118,7 +118,7 @@ class ExistingFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testExistingCalculatedMeasureCompoundSlicer(Context context) {
         // basic test
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with \n"
                 + "  member measures.subcategorystring as SetToStr( EXISTING [Product].[Product Subcategory].Members)\n"
                 + "  select { measures.subcategorystring } on 0\n"
@@ -131,7 +131,7 @@ class ExistingFunDefTest {
                 + "Row #0: {[Product].[Drink].[Alcoholic Beverages].[Beer and Wine].[Beer], [Product].[Drink].[Alcoholic "
                 + "Beverages].[Beer and Wine].[Wine]}\n" );
 
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with MEMBER [Measures].[*CALCULATED_MEASURE_1] AS 'SetToStr( EXISTING [Product].[Product Category].Members )'\n"
                 + " SELECT {[Measures].[*CALCULATED_MEASURE_1]} ON COLUMNS\n"
                 + " FROM [Sales]\n"
@@ -150,7 +150,7 @@ class ExistingFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testExistingAggSet(Context context) {
         // aggregate simple set
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH MEMBER [Measures].[Edible Sales] AS \n"
                 + "Aggregate( Existing {[Product].[Drink], [Product].[Food]}, Measures.[Unit Sales] )\n"
                 + "SELECT {Measures.[Unit Sales], Measures.[Edible Sales]} ON 0,\n"
@@ -180,7 +180,7 @@ class ExistingFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testExistingGenerateAgg(Context context) {
         // generate overrides existing context
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH SET BestOfFamilies AS\n"
                 + "  Generate( [Product].[Product Family].Members,\n"
                 + "            TopCount( Existing [Product].[Brand Name].Members, 10, Measures.[Unit Sales]) ) \n"
@@ -214,7 +214,7 @@ class ExistingFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testExistingGenerateOverrides(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH MEMBER Measures.[StaticSumNC] AS\n"
                 + " 'Sum(Generate([Product].[Non-Consumable],"
                 + "    Existing [Product].[Product Department].Members), Measures.[Unit Sales])'\n"
@@ -236,7 +236,7 @@ class ExistingFunDefTest {
                 + "Row #1: 191,940\n"
                 + "Row #2: 50,236\n"
                 + "Row #2: 50,236\n" );
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH MEMBER Measures.[StaticSumNC] AS\n"
                 + " 'Sum(Generate([Product].[Product Family].Members,"
                 + "    Existing [Product].[Product Department].Members), Measures.[Unit Sales])'\n"
@@ -259,7 +259,7 @@ class ExistingFunDefTest {
     void testExistingVirtualCube(Context context) {
         // this should ideally return 14 for both,
         // but being coherent with exists is good enough
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH MEMBER [Measures].[Count Exists] AS Count(exists( [Time.Weekly].[Week].Members, [Time.Weekly]"
                 + ".CurrentMember ) )\n"
                 + " MEMBER [Measures].[Count Existing] AS Count(existing [Time.Weekly].[Week].Members)\n"

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/set/filter/FilterFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/set/filter/FilterFunDefTest.java
@@ -50,7 +50,7 @@ class FilterFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testFilterWithSlicer(Context context) {
-        Result result = executeQuery(context.getConnection(),
+        Result result = executeQuery(context.getConnectionWithDefaultRole(),
             "select {[Measures].[Unit Sales]} on columns,\n"
                 + " filter([Customers].[USA].children,\n"
                 + "        [Measures].[Unit Sales] > 20000) on rows\n"
@@ -66,7 +66,7 @@ class FilterFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testFilterCompound(Context context) {
-        Result result = executeQuery(context.getConnection(),
+        Result result = executeQuery(context.getConnectionWithDefaultRole(),
             "select {[Measures].[Unit Sales]} on columns,\n"
                 + "  Filter(\n"
                 + "    CrossJoin(\n"
@@ -120,7 +120,7 @@ class FilterFunDefTest {
       TestUtil.withSchema(context, schema);
        */
             withSchema(context, TestFilterWillTimeoutModifier::new);
-            executeAxis(context.getConnection(),
+            executeAxis(context.getConnectionWithDefaultRole(),
                 "Filter("
                     + "Filter(CrossJoin([Customers].[Name].members, [Product].[Product Name].members), SleepUdf([Measures]"
                     + ".[Unit Sales]) > 0),"
@@ -137,10 +137,10 @@ class FilterFunDefTest {
     void testFilterEmpty(Context context) {
         // Unlike "Descendants(<set>, ...)", we do not need to know the precise
         // type of the set, therefore it is OK if the set is empty.
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Filter({}, 1=0)",
             "" );
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Filter({[Time].[Time].Children}, 1=0)",
             "" );
     }
@@ -149,7 +149,7 @@ class FilterFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testFilterCalcSlicer(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with member [Time].[Time].[Date Range] as \n"
                 + "'Aggregate({[Time].[1997].[Q1]:[Time].[1997].[Q3]})'\n"
                 + "select\n"
@@ -169,7 +169,7 @@ class FilterFunDefTest {
                 + "Row #0: 90,131\n"
                 + "Row #0: 76,151.59\n"
                 + "Row #0: 190,776.88\n" );
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with member [Time].[Time].[Date Range] as \n"
                 + "'Aggregate({[Time].[1997].[Q1]:[Time].[1997].[Q3]})'\n"
                 + "select\n"

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/set/hierarchy/AllMembersFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/set/hierarchy/AllMembersFunDefTest.java
@@ -31,7 +31,7 @@ class AllMembersFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testAllMembers(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         // <Level>.allmembers
         assertAxisReturns(connection,
             "{[Customers].[Country].allmembers}",
@@ -113,7 +113,7 @@ class AllMembersFunDefTest {
                 // defined wrong.
                 break;
             default:
-                assertQueryReturns(context.getConnection(),
+                assertQueryReturns(context.getConnectionWithDefaultRole(),
                     "WITH MEMBER [Measures].[Unit to Sales ratio] as\n"
                         + " '[Measures].[Unit Sales] / [Measures].[Store Sales]', FORMAT_STRING='0.0%' "
                         + "SELECT {[Measures].AllMembers} ON COLUMNS,"
@@ -176,7 +176,7 @@ class AllMembersFunDefTest {
                 // defined wrong.
                 break;
             default:
-                assertQueryReturns(context.getConnection(),
+                assertQueryReturns(context.getConnectionWithDefaultRole(),
                     "WITH MEMBER [Measures].[Unit to Sales ratio] as '[Measures].[Unit Sales] / [Measures].[Store Sales]', "
                         + "FORMAT_STRING='0.0%' "
                         + "SELECT {[Measures].AllMembers} ON COLUMNS,"
@@ -239,7 +239,7 @@ class AllMembersFunDefTest {
                 // defined wrong.
                 break;
             default:
-                assertQueryReturns(context.getConnection(),
+                assertQueryReturns(context.getConnectionWithDefaultRole(),
                     "WITH MEMBER [Measures].[Unit to Sales ratio] as '[Measures].[Unit Sales] / [Measures].[Store Sales]', "
                         + "FORMAT_STRING='0.0%' "
                         + "SELECT {[Measures].Members} ON COLUMNS,"
@@ -280,7 +280,7 @@ class AllMembersFunDefTest {
         }
 
         // Calc member in dimension based on level
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH MEMBER [Store].[USA].[CA plus OR] AS 'AGGREGATE({[Store].[USA].[CA], [Store].[USA].[OR]})' "
                 + "SELECT {[Measures].[Unit Sales], [Measures].[Store Sales]} ON COLUMNS,"
                 + "non empty({[Store].[Store State].AllMembers}) ON ROWS "
@@ -306,7 +306,7 @@ class AllMembersFunDefTest {
                 + "Row #3: 76,345.49\n" );
 
         // Calc member in dimension based on level not seen
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH MEMBER [Store].[USA].[CA plus OR] AS 'AGGREGATE({[Store].[USA].[CA], [Store].[USA].[OR]})' "
                 + "SELECT {[Measures].[Unit Sales], [Measures].[Store Sales]} ON COLUMNS,"
                 + "non empty({[Store].[Store Country].AllMembers}) ON ROWS "

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/set/members/MembersFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/set/members/MembersFunDefTest.java
@@ -31,7 +31,7 @@ class MembersFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testMembers(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         // <Level>.members
         assertAxisReturns(connection,
             "{[Customers].[Country].Members}",
@@ -124,7 +124,7 @@ class MembersFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testHierarchyMembers(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         assertAxisReturns(connection,
             "Head({[Time.Weekly].Members}, 10)",
             "[Time].[Weekly].[All Weeklys]\n"

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/set/range/RangeFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/set/range/RangeFunDefTest.java
@@ -29,7 +29,7 @@ class RangeFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testRange(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "[Time].[1997].[Q1].[2] : [Time].[1997].[Q2].[5]",
             "[Time].[1997].[Q1].[2]\n"
                 + "[Time].[1997].[Q1].[3]\n"
@@ -37,7 +37,7 @@ class RangeFunDefTest {
                 + "[Time].[1997].[Q2].[5]" ); // not parents
 
         // testcase for bug XXXXX: braces required
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with set [Set1] as '[Product].[Drink]:[Product].[Food]' \n"
                 + "\n"
                 + "select [Set1] on columns, {[Measures].defaultMember} on rows \n"
@@ -60,7 +60,7 @@ class RangeFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testNullRange(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "[Time].[1997].[Q1].[2] : NULL", //[Time].[1997].[Q2].[5]
             "" ); // Empty Set
     }
@@ -71,7 +71,7 @@ class RangeFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testTwoNullRange(Context context) {
-        assertAxisThrows(context.getConnection(),
+        assertAxisThrows(context.getConnectionWithDefaultRole(),
             "NULL : NULL",
             "Failed to parse query 'select {NULL : NULL} on columns from Sales'" );
     }
@@ -82,7 +82,7 @@ class RangeFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testRangeLarge(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "[Customers].[USA].[CA].[San Francisco] : [Customers].[USA].[WA].[Bellingham]",
             "[Customers].[USA].[CA].[San Francisco]\n"
                 + "[Customers].[USA].[CA].[San Gabriel]\n"
@@ -112,7 +112,7 @@ class RangeFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testRangeStartEqualsEnd(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "[Time].[1997].[Q3].[7] : [Time].[1997].[Q3].[7]",
             "[Time].[1997].[Q3].[7]" );
     }
@@ -120,7 +120,7 @@ class RangeFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testRangeStartEqualsEndLarge(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "[Customers].[USA].[CA] : [Customers].[USA].[CA]",
             "[Customers].[USA].[CA]" );
     }
@@ -128,7 +128,7 @@ class RangeFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testRangeEndBeforeStart(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "[Time].[1997].[Q3].[7] : [Time].[1997].[Q2].[5]",
             "[Time].[1997].[Q2].[5]\n"
                 + "[Time].[1997].[Q2].[6]\n"
@@ -138,7 +138,7 @@ class RangeFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testRangeEndBeforeStartLarge(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "[Customers].[USA].[WA] : [Customers].[USA].[CA]",
             "[Customers].[USA].[CA]\n"
                 + "[Customers].[USA].[OR]\n"
@@ -148,7 +148,7 @@ class RangeFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testRangeBetweenDifferentLevelsIsError(Context context) {
-        assertAxisThrows(context.getConnection(),
+        assertAxisThrows(context.getConnectionWithDefaultRole(),
             "[Time].[1997].[Q2] : [Time].[1997].[Q2].[5]",
             "Members must belong to the same level" );
     }
@@ -156,7 +156,7 @@ class RangeFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testRangeBoundedByAll(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "[Gender] : [Gender]",
             "[Gender].[All Gender]" );
     }
@@ -164,7 +164,7 @@ class RangeFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testRangeBoundedByAllLarge(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "[Customers].DefaultMember : [Customers]",
             "[Customers].[All Customers]" );
     }
@@ -172,7 +172,7 @@ class RangeFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testRangeBoundedByNull(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "[Gender].[F] : [Gender].[M].NextMember",
             "" );
     }
@@ -180,7 +180,7 @@ class RangeFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testRangeBoundedByNullLarge(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "[Customers].PrevMember : [Customers].[USA].[OR]",
             "" );
     }
@@ -215,7 +215,7 @@ class RangeFunDefTest {
                 + "Row #3: 1,237\n"
                 + "Row #4: 394\n"
                 + "Row #5: 1,277\n";
-        assertQueryReturns(context.getConnection(), query, expectedResult );
+        assertQueryReturns(context.getConnectionWithDefaultRole(), query, expectedResult );
     }
 
     @ParameterizedTest
@@ -249,7 +249,7 @@ class RangeFunDefTest {
                 + "Row #3: 1,237\n"
                 + "Row #4: 394\n"
                 + "Row #5: 1,277\n";
-        assertQueryReturns(context.getConnection(), query, expectedResult );
+        assertQueryReturns(context.getConnectionWithDefaultRole(), query, expectedResult );
     }
 
     @ParameterizedTest
@@ -271,7 +271,7 @@ class RangeFunDefTest {
                 + "Axis #1:\n"
                 + "{[Measures].[Customer Count]}\n"
                 + "Row #0: 1,671\n";
-        assertQueryReturns(context.getConnection(), query, expectedResult );
+        assertQueryReturns(context.getConnectionWithDefaultRole(), query, expectedResult );
     }
 
 }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/set/setitem/SetItemFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/set/setitem/SetItemFunDefTest.java
@@ -31,25 +31,25 @@ class SetItemFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testSetItemInt(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "{[Customers].[All Customers].[USA].[OR].[Lebanon].[Mary Frances Christian]}.Item(0)",
             "[Customers].[USA].[OR].[Lebanon].[Mary Frances Christian]" );
 
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "{[Customers].[All Customers].[USA],"
                 + "[Customers].[All Customers].[USA].[WA],"
                 + "[Customers].[All Customers].[USA].[CA],"
                 + "[Customers].[All Customers].[USA].[OR].[Lebanon].[Mary Frances Christian]}.Item(2)",
             "[Customers].[USA].[CA]" );
 
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "{[Customers].[All Customers].[USA],"
                 + "[Customers].[All Customers].[USA].[WA],"
                 + "[Customers].[All Customers].[USA].[CA],"
                 + "[Customers].[All Customers].[USA].[OR].[Lebanon].[Mary Frances Christian]}.Item(100 / 50 - 1)",
             "[Customers].[USA].[WA]" );
 
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "{([Time].[1997].[Q1].[1], [Customers].[All Customers].[USA]),"
                 + "([Time].[1997].[Q1].[2], [Customers].[All Customers].[USA].[WA]),"
                 + "([Time].[1997].[Q1].[3], [Customers].[All Customers].[USA].[CA]),"
@@ -58,7 +58,7 @@ class SetItemFunDefTest {
             "{[Time].[1997].[Q1].[2], [Customers].[USA].[WA]}" );
 
         // given index out of bounds, item returns null
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "{[Customers].[All Customers].[USA],"
                 + "[Customers].[All Customers].[USA].[WA],"
                 + "[Customers].[All Customers].[USA].[CA],"
@@ -66,7 +66,7 @@ class SetItemFunDefTest {
             "" );
 
         // given index out of bounds, item returns null
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "{[Customers].[All Customers].[USA],"
                 + "[Customers].[All Customers].[USA].[WA],"
                 + "[Customers].[All Customers].[USA].[CA],"
@@ -80,31 +80,31 @@ class SetItemFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testSetItemString(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "{[Gender].[M], [Gender].[F]}.Item(\"M\")",
             "[Gender].[M]" );
 
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "{CrossJoin([Gender].Members, [Marital Status].Members)}.Item(\"M\", \"S\")",
             "{[Gender].[M], [Marital Status].[S]}" );
 
         // MSAS fails with "duplicate dimensions across (independent) axes".
         // (That's a bug in MSAS.)
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "{CrossJoin([Gender].Members, [Marital Status].Members)}.Item(\"M\", \"M\")",
             "{[Gender].[M], [Marital Status].[M]}" );
 
         // None found.
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "{[Gender].[M], [Gender].[F]}.Item(\"X\")", "" );
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "{CrossJoin([Gender].Members, [Marital Status].Members)}.Item(\"M\", \"F\")",
             "" );
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "CrossJoin([Gender].Members, [Marital Status].Members).Item(\"S\", \"M\")",
             "" );
 
-        assertAxisThrows(context.getConnection(),
+        assertAxisThrows(context.getConnectionWithDefaultRole(),
             "CrossJoin([Gender].Members, [Marital Status].Members).Item(\"M\")",
             "Argument count does not match set's cardinality 2" );
     }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/set/siblings/SiblingsFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/set/siblings/SiblingsFunDefTest.java
@@ -28,7 +28,7 @@ class SiblingsFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testSiblingsA(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "{[Time].[1997].Siblings}",
             "[Time].[1997]\n"
                 + "[Time].[1998]" );
@@ -37,7 +37,7 @@ class SiblingsFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testSiblingsB(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "{[Store].Siblings}",
             "[Store].[All Stores]" );
     }
@@ -45,7 +45,7 @@ class SiblingsFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testSiblingsC(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "{[Store].[USA].[CA].Siblings}",
             "[Store].[USA].[CA]\n"
                 + "[Store].[USA].[OR]\n"
@@ -56,9 +56,9 @@ class SiblingsFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testSiblingsD(Context context) {
         // The null member has no siblings -- not even itself
-        assertAxisReturns(context.getConnection(), "{[Gender].Parent.Siblings}", "" );
+        assertAxisReturns(context.getConnectionWithDefaultRole(), "{[Gender].Parent.Siblings}", "" );
 
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "count ([Gender].parent.siblings, includeempty)", "0" );
     }
 

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/set/stripcalculatedmembers/StripCalculatedMembersFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/set/stripcalculatedmembers/StripCalculatedMembersFunDefTest.java
@@ -17,7 +17,7 @@ class StripCalculatedMembersFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testStripCalculatedMembers(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         assertAxisReturns(connection,
             "StripCalculatedMembers({[Measures].AllMembers})",
             "[Measures].[Unit Sales]\n"

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/settostr/SetToStrFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/settostr/SetToStrFunDefTest.java
@@ -28,12 +28,12 @@ class SetToStrFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testSetToStr(Context context) {
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "SetToStr([Time].[Time].children)",
             "{[Time].[1997].[Q1], [Time].[1997].[Q2], [Time].[1997].[Q3], [Time].[1997].[Q4]}" );
 
         // Now, applied to tuples
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "SetToStr({CrossJoin([Marital Status].children, {[Gender].[M]})})",
             "{"
                 + "([Marital Status].[M], [Gender].[M]), "

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/stdev/StdevFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/stdev/StdevFunDefTest.java
@@ -28,7 +28,7 @@ class StdevFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testStdev(Context context) {
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "STDEV({[Store].[All Stores].[USA].children},[Measures].[Store Sales])",
             "65,825.45" );
     }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/stdev/StdevPFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/stdev/StdevPFunDefTest.java
@@ -27,7 +27,7 @@ class StdevPFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testStdevP(Context context) {
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "STDEVP({[Store].[All Stores].[USA].children},[Measures].[Store Sales])",
             "53,746.26" );
     }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/string/LenFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/string/LenFunDefTest.java
@@ -29,7 +29,7 @@ class LenFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testLenFunctionWithNullString(Context context) {
         // SSAS2005 returns 0
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with member [Measures].[Foo] as ' NULL '\n"
                 + " member [Measures].[Bar] as ' len([Measures].[Foo]) '\n"
                 + "select [Measures].[Bar] on 0\n"
@@ -40,7 +40,7 @@ class LenFunDefTest {
                 + "{[Measures].[Bar]}\n"
                 + "Row #0: 0\n" );
         // same, but inline
-        assertExprReturns(context.getConnection(), "len(null)", 0, 0 );
+        assertExprReturns(context.getConnectionWithDefaultRole(), "len(null)", 0, 0 );
     }
 
 }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/string/UCaseFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/string/UCaseFunDefTest.java
@@ -34,7 +34,7 @@ class UCaseFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testUCaseWithNonEmptyString(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select filter([Store].MEMBERS, "
                 + " UCase([Store].CURRENTMEMBER.Name) = \"BELLINGHAM\") "
                 + "on 0 from sales",
@@ -48,7 +48,7 @@ class UCaseFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testUCaseWithEmptyString(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select filter([Store].MEMBERS, "
                 + " UCase(\"\") = \"\" "
                 + "And [Store].CURRENTMEMBER.Name = \"Bellingham\") "
@@ -63,7 +63,7 @@ class UCaseFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testUCaseWithNullString(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select filter([Store].MEMBERS, "
                 + " UCase(\"NULL\") = \"\" "
                 + "And [Store].CURRENTMEMBER.Name = \"Bellingham\") "
@@ -77,7 +77,7 @@ class UCaseFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testUCaseWithNull(Context context) {
         try {
-            executeQuery(context.getConnection(),
+            executeQuery(context.getConnectionWithDefaultRole(),
                 "select filter([Store].MEMBERS, "
                     + " UCase(NULL) = \"\" "
                     + "And [Store].CURRENTMEMBER.Name = \"Bellingham\") "

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/strtoset/StrToSetFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/strtoset/StrToSetFunDefTest.java
@@ -38,21 +38,21 @@ class StrToSetFunDefTest {
         // TODO: test spaces before unbracketed names,
         //       e.g. "{Gender. M, Gender. F   }".
 
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "StrToSet("
                 + " \"{[Gender].[F], [Gender].[M]}\","
                 + " [Gender])",
             "[Gender].[F]\n"
                 + "[Gender].[M]" );
 
-        assertAxisThrows(context.getConnection(),
+        assertAxisThrows(context.getConnectionWithDefaultRole(),
             "StrToSet("
                 + " \"{[Gender].[F], [Time].[1997]}\","
                 + " [Gender])",
             "member is of wrong hierarchy" );
 
         // whitespace ok
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "StrToSet("
                 + " \"  {   [Gender] .  [F]  ,[Gender].[M] }  \","
                 + " [Gender])",
@@ -60,7 +60,7 @@ class StrToSetFunDefTest {
                 + "[Gender].[M]" );
 
         // tuples
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "StrToSet("
                 + "\""
                 + "{"
@@ -74,7 +74,7 @@ class StrToSetFunDefTest {
                 + "{[Gender].[M], [Time].[1997]}" );
 
         // matches unique name
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "StrToSet("
                 + "\""
                 + "{"
@@ -92,7 +92,7 @@ class StrToSetFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testStrToSetDupDimensionsFails(Context context) {
-        assertAxisThrows(context.getConnection(),
+        assertAxisThrows(context.getConnectionWithDefaultRole(),
             "StrToSet("
                 + "\""
                 + "{"
@@ -111,7 +111,7 @@ class StrToSetFunDefTest {
     void testStrToSetIgnoreInvalidMembers(Context context) {
         context.getSchemaCache().clear();
         ((TestConfig)context.getConfig()).setIgnoreInvalidMembersDuringQuery(true);
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "StrToSet("
                 + "\""
                 + "{"
@@ -125,7 +125,7 @@ class StrToSetFunDefTest {
             "[Product].[Food]\n"
                 + "[Product].[Drink].[Dairy]" );
 
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "StrToSet("
                 + "\""
                 + "{"

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/strtotuple/StrToTupleFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/strtotuple/StrToTupleFunDefTest.java
@@ -37,12 +37,12 @@ class StrToTupleFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testStrToTuple(Context context) {
         // single dimension yields member
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "{StrToTuple(\"[Time].[1997].[Q2]\", [Time])}",
             "[Time].[1997].[Q2]" );
 
         // multiple dimensions yield tuple
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "{StrToTuple(\"([Gender].[F], [Time].[1997].[Q2])\", [Gender], [Time])}",
             "{[Gender].[F], [Time].[1997].[Q2]}" );
 
@@ -55,7 +55,7 @@ class StrToTupleFunDefTest {
         context.getSchemaCache().clear();
         ((TestConfig)context.getConfig()).setIgnoreInvalidMembersDuringQuery(true);
         // If any member is invalid, the whole tuple is null.
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "StrToTuple(\"([Gender].[M], [Marital Status].[Separated])\","
                 + " [Gender], [Marital Status])",
             "" );
@@ -64,7 +64,7 @@ class StrToTupleFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testStrToTupleDuHierarchiesFails(Context context) {
-        assertAxisThrows(context.getConnection(),
+        assertAxisThrows(context.getConnectionWithDefaultRole(),
             "{StrToTuple(\"([Gender].[F], [Time].[1997].[Q2], [Gender].[M])\", [Gender], [Time], [Gender])}",
             "Tuple contains more than one member of hierarchy '[Gender]'." );
     }
@@ -72,7 +72,7 @@ class StrToTupleFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testStrToTupleDupHierInSameDimensions(Context context) {
-        assertAxisThrows(context.getConnection(),
+        assertAxisThrows(context.getConnectionWithDefaultRole(),
             "{StrToTuple("
                 + "\"([Gender].[F], "
                 + "[Time].[1997].[Q2], "
@@ -86,20 +86,20 @@ class StrToTupleFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testStrToTupleDepends(Context context) {
-        assertMemberExprDependsOn(context.getConnection(),
+        assertMemberExprDependsOn(context.getConnectionWithDefaultRole(),
             "StrToTuple(\"[Time].[1997].[Q2]\", [Time])",
             "{}" );
 
         // converted to scalar, depends set is larger
-        assertExprDependsOn(context.getConnection(),
+        assertExprDependsOn(context.getConnectionWithDefaultRole(),
             "StrToTuple(\"[Time].[1997].[Q2]\", [Time])",
             allHiersExcept( "[Time]" ) );
 
-        assertMemberExprDependsOn(context.getConnection(),
+        assertMemberExprDependsOn(context.getConnectionWithDefaultRole(),
             "StrToTuple(\"[Time].[1997].[Q2], [Gender].[F]\", [Time], [Gender])",
             "{}" );
 
-        assertExprDependsOn(context.getConnection(),
+        assertExprDependsOn(context.getConnectionWithDefaultRole(),
             "StrToTuple(\"[Time].[1997].[Q2], [Gender].[F]\", [Time], [Gender])",
             allHiersExcept( "[Time]", "[Gender]" ) );
     }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/subset/SubsetFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/subset/SubsetFunDefTest.java
@@ -28,7 +28,7 @@ class SubsetFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testSubset(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Subset([Promotion Media].Children, 7, 2)",
             "[Promotion Media].[Product Attachment]\n"
                 + "[Promotion Media].[Radio]" );
@@ -37,7 +37,7 @@ class SubsetFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testSubsetNegativeCount(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Subset([Promotion Media].Children, 3, -1)",
             "" );
     }
@@ -45,7 +45,7 @@ class SubsetFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testSubsetNegativeStart(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Subset([Promotion Media].Children, -2, 4)",
             "" );
     }
@@ -53,7 +53,7 @@ class SubsetFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testSubsetDefault(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Subset([Promotion Media].Children, 11)",
             "[Promotion Media].[Sunday Paper, Radio]\n"
                 + "[Promotion Media].[Sunday Paper, Radio, TV]\n"
@@ -63,7 +63,7 @@ class SubsetFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testSubsetOvershoot(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Subset([Promotion Media].Children, 15)",
             "" );
     }
@@ -71,11 +71,11 @@ class SubsetFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testSubsetEmpty(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Subset([Gender].[F].Children, 1)",
             "" );
 
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Subset([Gender].[F].Children, 1, 3)",
             "" );
     }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/sum/SumFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/sum/SumFunDefTest.java
@@ -27,7 +27,7 @@ class SumFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testSumNoExp(Context context) {
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "SUM({[Promotion Media].[Media Type].members})", "266,773" );
     }
 

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/toggledrillstate/ToggleDrillStateFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/toggledrillstate/ToggleDrillStateFunDefTest.java
@@ -29,7 +29,7 @@ class ToggleDrillStateFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testToggleDrillState(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "ToggleDrillState({[Customers].[USA],[Customers].[Canada]},"
                 + "{[Customers].[USA],[Customers].[USA].[CA]})",
             "[Customers].[USA]\n"
@@ -42,7 +42,7 @@ class ToggleDrillStateFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testToggleDrillState2(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "ToggleDrillState([Product].[Product Department].members, "
                 + "{[Product].[All Products].[Food].[Snack Foods]})",
             "[Product].[Drink].[Alcoholic Beverages]\n"
@@ -74,7 +74,7 @@ class ToggleDrillStateFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testToggleDrillState3(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "ToggleDrillState("
                 + "{[Time].[1997].[Q1],"
                 + " [Time].[1997].[Q2],"
@@ -91,7 +91,7 @@ class ToggleDrillStateFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testToggleDrillStateTuple(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "ToggleDrillState(\n"
                 + "{([Store].[USA].[CA],"
                 + "  [Product].[All Products].[Drink].[Alcoholic Beverages]),\n"

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/topbottomcount/TopBottomCountFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/topbottomcount/TopBottomCountFunDefTest.java
@@ -38,7 +38,7 @@ class TopBottomCountFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testBottomCount(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "BottomCount({[Promotion Media].[Media Type].members}, 2, [Measures].[Unit Sales])",
             "[Promotion Media].[Radio]\n"
                 + "[Promotion Media].[Sunday Paper, Radio, TV]" );
@@ -47,7 +47,7 @@ class TopBottomCountFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testBottomCountUnordered(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "BottomCount({[Promotion Media].[Media Type].members}, 2)",
             "[Promotion Media].[Sunday Paper, Radio, TV]\n"
                 + "[Promotion Media].[TV]" );
@@ -58,7 +58,7 @@ class TopBottomCountFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testTopCount(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "TopCount({[Promotion Media].[Media Type].members}, 2, [Measures].[Unit Sales])",
             "[Promotion Media].[No Media]\n"
                 + "[Promotion Media].[Daily Paper, Radio, TV]" );
@@ -67,7 +67,7 @@ class TopBottomCountFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testTopCountUnordered(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "TopCount({[Promotion Media].[Media Type].members}, 2)",
             "[Promotion Media].[Bulk Mail]\n"
                 + "[Promotion Media].[Cash Register Handout]" );
@@ -76,7 +76,7 @@ class TopBottomCountFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testTopCountTuple(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "TopCount([Customers].[Name].members,2,(Time.[1997].[Q1],[Measures].[Store Sales]))",
             "[Customers].[USA].[WA].[Spokane].[Grace McLaughlin]\n"
                 + "[Customers].[USA].[WA].[Spokane].[Matt Bellah]" );
@@ -85,7 +85,7 @@ class TopBottomCountFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testTopCountEmpty(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "TopCount(Filter({[Promotion Media].[Media Type].members}, 1=0), 2, [Measures].[Unit Sales])",
             "" );
     }
@@ -93,7 +93,7 @@ class TopBottomCountFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testTopCountDepends(Context context) {
-        Connection connection = context.getConnection();
+        Connection connection = context.getConnectionWithDefaultRole();
         checkTopBottomCountPercentDepends(connection, "TopCount" );
         checkTopBottomCountPercentDepends(connection, "TopPercent" );
         checkTopBottomCountPercentDepends(connection, "TopSum" );
@@ -146,10 +146,10 @@ class TopBottomCountFunDefTest {
                 + "Row #1: 199.46\n"
                 + "Row #2: 191.90\n";
         long now = System.currentTimeMillis();
-        assertQueryReturns(context.getConnection(), query, desiredResult );
+        assertQueryReturns(context.getConnectionWithDefaultRole(), query, desiredResult );
         LOGGER.info( "first query took " + ( System.currentTimeMillis() - now ) );
         now = System.currentTimeMillis();
-        assertQueryReturns(context.getConnection(), query, desiredResult );
+        assertQueryReturns(context.getConnectionWithDefaultRole(), query, desiredResult );
         LOGGER.info( "second query took " + ( System.currentTimeMillis() - now ) );
     }
 
@@ -175,8 +175,8 @@ class TopBottomCountFunDefTest {
                 + "0\n"
                 + "FROM [Sales]\n"
                 + "WHERE [Time].[1997].[Q1].[1]:[Time].[1997].[Q3].[8]";
-        final Result result = executeQuery(context.getConnection(), queryWithoutAlias );
-        assertQueryReturns(context.getConnection(),
+        final Result result = executeQuery(context.getConnectionWithDefaultRole(), queryWithoutAlias );
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             queryWithAlias,
             TestUtil.toString(result));
     }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/topbottompercentsum/TopBottomPercentSumFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/topbottompercentsum/TopBottomPercentSumFunDefTest.java
@@ -30,7 +30,7 @@ class TopBottomPercentSumFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testBottomPercent(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "BottomPercent(Filter({[Store].[All Stores].[USA].[CA].Children, [Store].[All Stores].[USA].[OR].Children, "
                 + "[Store].[All Stores].[USA].[WA].Children}, ([Measures].[Unit Sales] > 0.0)), 100.0, [Measures].[Store "
                 + "Sales])",
@@ -48,7 +48,7 @@ class TopBottomPercentSumFunDefTest {
                 + "[Store].[USA].[WA].[Tacoma]\n"
                 + "[Store].[USA].[OR].[Salem]" );
 
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "BottomPercent({[Promotion Media].[Media Type].members}, 1, [Measures].[Unit Sales])",
             "[Promotion Media].[Radio]\n"
                 + "[Promotion Media].[Sunday Paper, Radio, TV]" );
@@ -59,7 +59,7 @@ class TopBottomPercentSumFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testBottomSum(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "BottomSum({[Promotion Media].[Media Type].members}, 5000, [Measures].[Unit Sales])",
             "[Promotion Media].[Radio]\n"
                 + "[Promotion Media].[Sunday Paper, Radio, TV]" );
@@ -72,7 +72,7 @@ class TopBottomPercentSumFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testTopPercentCrossjoin(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "{TopPercent(Crossjoin([Product].[Product Department].members,\n"
                 + "[Time].[1997].children),10,[Measures].[Store Sales])}",
             "{[Product].[Food].[Produce], [Time].[1997].[Q4]}\n"
@@ -84,7 +84,7 @@ class TopBottomPercentSumFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testTopPercent(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "TopPercent({[Promotion Media].[Media Type].members}, 70, [Measures].[Unit Sales])",
             "[Promotion Media].[No Media]" );
     }
@@ -94,7 +94,7 @@ class TopBottomPercentSumFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testTopSum(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "TopSum({[Promotion Media].[Media Type].members}, 200000, [Measures].[Unit Sales])",
             "[Promotion Media].[No Media]\n"
                 + "[Promotion Media].[Daily Paper, Radio, TV]" );
@@ -103,7 +103,7 @@ class TopBottomPercentSumFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testTopSumEmpty(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "TopSum(Filter({[Promotion Media].[Media Type].members}, 1=0), "
                 + "200000, [Measures].[Unit Sales])",
             "" );
@@ -133,8 +133,8 @@ class TopBottomPercentSumFunDefTest {
                 + " TopPercent([*aaa], 50, [Measures].[Unit Sales]) on columns\n"
                 + "from Sales";
 
-        final Result result = executeQuery(context.getConnection(), queryWithoutAlias );
-        assertQueryReturns(context.getConnection(),
+        final Result result = executeQuery(context.getConnectionWithDefaultRole(), queryWithoutAlias );
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             queryWithAlias,
             TestUtil.toString( result ) );
     }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/tupletostr/TupleToStrFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/tupletostr/TupleToStrFunDefTest.java
@@ -31,49 +31,49 @@ class TupleToStrFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testTupleToStr(Context context) {
         // Applied to a dimension (which becomes a member)
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "TupleToStr([Product])",
             "[Product].[All Products]" );
 
         // Applied to a dimension (invalid because has no default hierarchy)
         if ( SystemWideProperties.instance().SsasCompatibleNaming ) {
-            assertExprThrows(context.getConnection(),
+            assertExprThrows(context.getConnectionWithDefaultRole(),
                 "TupleToStr([Time])",
                 "The 'Time' dimension contains more than one hierarchy, "
                     + "therefore the hierarchy must be explicitly specified." );
         } else {
-            assertExprReturns(context.getConnection(),
+            assertExprReturns(context.getConnectionWithDefaultRole(),
                 "TupleToStr([Time])",
                 "[Time].[1997]" );
         }
 
         // Applied to a hierarchy
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "TupleToStr([Time].[Time])",
             "[Time].[1997]" );
 
         // Applied to a member
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "TupleToStr([Store].[USA].[OR])",
             "[Store].[USA].[OR]" );
 
         // Applied to a member (extra set of parens)
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "TupleToStr(([Store].[USA].[OR]))",
             "([Store].[USA].[OR])" );
 
         // Now, applied to a tuple
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "TupleToStr(([Marital Status], [Gender].[M]))",
             "([Marital Status].[All Marital Status], [Gender].[M])" );
 
         // Applied to a tuple containing a null member
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "TupleToStr(([Marital Status], [Gender].Parent))",
             "" );
 
         // Applied to a null member
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "TupleToStr([Marital Status].Parent)",
             "" );
     }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/udf/currentdatemember/CurrentDateMemberFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/udf/currentdatemember/CurrentDateMemberFunDefTest.java
@@ -47,7 +47,7 @@ class CurrentDateMemberFunDefTest {
         withSchema(context, schema);
          */
         withSchema(context, SchemaModifiers.CurrentDateMemberUdfTestModifier1::new);
-        TestUtil.assertQueryReturns(context.getConnection(),
+        TestUtil.assertQueryReturns(context.getConnectionWithDefaultRole(),
             "SELECT NON EMPTY {[Measures].[Org Salary]} ON COLUMNS, "
             + "NON EMPTY {MockCurrentDateMember([Time].[Time], \"[yyyy]\")} ON ROWS "
             + "FROM [HR] ",
@@ -69,7 +69,7 @@ class CurrentDateMemberFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testGetReturnType(Context context) {
-        Connection connection=context.getConnection();
+        Connection connection=context.getConnectionWithDefaultRole();
         String query = "WITH MEMBER [Time].[YTD] AS SUM( YTD(CurrentDateMember"
              + "([Time], '[\"Time\"]\\.[yyyy]\\.[Qq].[m]', EXACT)), Measures.[Unit Sales]) SELECT Time.YTD on 0 FROM sales";
         String expected = "Axis #0:\n" + "{}\n" + "Axis #1:\n"

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/udf/nullvalue/NullValueFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/udf/nullvalue/NullValueFunDefTest.java
@@ -30,7 +30,7 @@ class NullValueFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class )
     void testNullValue(Context context) {
-        Connection connection=context.getConnection();
+        Connection connection=context.getConnectionWithDefaultRole();
         String cubeName="Sales";
         Cell c=  TestUtil.executeExprRaw(connection,cubeName," NullValue()/NullValue() ");
         String s=c.getFormattedValue();

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/union/UnionFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/union/UnionFunDefTest.java
@@ -33,7 +33,7 @@ class UnionFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testUnionAll(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Union({[Gender].[M]}, {[Gender].[F]}, ALL)",
             "[Gender].[M]\n"
                 + "[Gender].[F]" ); // order is preserved
@@ -43,7 +43,7 @@ class UnionFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testUnionAllTuple(Context context) {
         // With the bug, the last 8 rows are repeated.
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with \n"
                 + "set [Set1] as 'Crossjoin({[Time].[1997].[Q1]:[Time].[1997].[Q4]},{[Store].[USA].[CA]:[Store].[USA].[OR]})'\n"
                 + "set [Set2] as 'Crossjoin({[Time].[1997].[Q2]:[Time].[1997].[Q3]},{[Store].[Mexico].[DF]:[Store].[Mexico]"
@@ -94,7 +94,7 @@ class UnionFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testUnion(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Union({[Store].[USA], [Store].[USA], [Store].[USA].[OR]}, "
                 + "{[Store].[USA].[CA], [Store].[USA]})",
             "[Store].[USA]\n"
@@ -105,7 +105,7 @@ class UnionFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testUnionEmptyBoth(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Union({}, {})",
             "" );
     }
@@ -113,7 +113,7 @@ class UnionFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testUnionEmptyRight(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Union({[Gender].[M]}, {})",
             "[Gender].[M]" );
     }
@@ -121,7 +121,7 @@ class UnionFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testUnionTuple(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Union({"
                 + " ([Gender].[M], [Marital Status].[S]),"
                 + " ([Gender].[F], [Marital Status].[S])"
@@ -138,7 +138,7 @@ class UnionFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testUnionTupleDistinct(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Union({"
                 + " ([Gender].[M], [Marital Status].[S]),"
                 + " ([Gender].[F], [Marital Status].[S])"
@@ -155,7 +155,7 @@ class UnionFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testUnionQuery(Context context) {
-        Result result = executeQuery(context.getConnection(),
+        Result result = executeQuery(context.getConnectionWithDefaultRole(),
             "select {[Measures].[Unit Sales], "
                 + "[Measures].[Store Cost], "
                 + "[Measures].[Store Sales]} on columns,\n"

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/uniquename/dimension/UniqueNameFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/uniquename/dimension/UniqueNameFunDefTest.java
@@ -27,7 +27,7 @@ class UniqueNameFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testDimensionUniqueName(Context context) {
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "[Gender].DefaultMember.Dimension.UniqueName",
             "[Gender]" );
     }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/uniquename/hierarchy/UniqueNameFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/uniquename/hierarchy/UniqueNameFunDefTest.java
@@ -28,7 +28,7 @@ class UniqueNameFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testHierarchyUniqueName(Context context) {
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "[Gender].DefaultMember.Hierarchy.UniqueName",
             "[Gender]" );
     }
@@ -36,21 +36,21 @@ class UniqueNameFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testTime(Context context) {
-        TestUtil.assertExprReturns(context.getConnection(),
+        TestUtil.assertExprReturns(context.getConnectionWithDefaultRole(),
             "[Time].[1997].[Q1].[1].Hierarchy.UniqueName", "[Time]" );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testBasic9(Context context) {
-        TestUtil.assertExprReturns(context.getConnection(),
+        TestUtil.assertExprReturns(context.getConnectionWithDefaultRole(),
             "[Gender].[All Gender].[F].Hierarchy.UniqueName", "[Gender]" );
     }
 
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testFirstInLevel9(Context context) {
-        TestUtil.assertExprReturns(context.getConnection(),
+        TestUtil.assertExprReturns(context.getConnectionWithDefaultRole(),
             "[Education Level].[All Education Levels].[Bachelors Degree].Hierarchy.UniqueName",
             "[Education Level]" );
     }
@@ -58,7 +58,7 @@ class UniqueNameFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testHierarchyAll(Context context) {
-        TestUtil.assertExprReturns(context.getConnection(),
+        TestUtil.assertExprReturns(context.getConnectionWithDefaultRole(),
             "[Gender].[All Gender].Hierarchy.UniqueName", "[Gender]" );
     }
 

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/uniquename/level/UniqueNameFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/uniquename/level/UniqueNameFunDefTest.java
@@ -27,7 +27,7 @@ class UniqueNameFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testLevelUniqueName(Context context) {
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "[Gender].DefaultMember.Level.UniqueName",
             "[Gender].[(All)]" );
     }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/uniquename/member/UniqueNameFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/uniquename/member/UniqueNameFunDefTest.java
@@ -29,7 +29,7 @@ class UniqueNameFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testMemberUniqueName(Context context) {
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "[Gender].DefaultMember.UniqueName",
             "[Gender].[All Gender]" );
     }
@@ -38,7 +38,7 @@ class UniqueNameFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testMemberUniqueNameOfNull(Context context) {
         if ( isDefaultNullMemberRepresentation() ) {
-            assertExprReturns(context.getConnection(),
+            assertExprReturns(context.getConnectionWithDefaultRole(),
                 "[Measures].[Unit Sales].FirstChild.UniqueName",
                 "[Measures].[#null]" ); // MSOLAP gives "" here
         }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/unorder/UnorderFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/unorder/UnorderFunDefTest.java
@@ -29,17 +29,17 @@ class UnorderFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testUnorder(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Unorder([Gender].members)",
             "[Gender].[All Gender]\n"
                 + "[Gender].[F]\n"
                 + "[Gender].[M]" );
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Unorder(Order([Gender].members, -[Measures].[Unit Sales]))",
             "[Gender].[All Gender]\n"
                 + "[Gender].[M]\n"
                 + "[Gender].[F]" );
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Unorder(Crossjoin([Gender].members, [Marital Status].Children))",
             "{[Gender].[All Gender], [Marital Status].[M]}\n"
                 + "{[Gender].[All Gender], [Marital Status].[S]}\n"
@@ -49,17 +49,17 @@ class UnorderFunDefTest {
                 + "{[Gender].[M], [Marital Status].[S]}" );
 
         // implicitly convert member to set
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "Unorder([Gender].[M])",
             "[Gender].[M]" );
 
-        assertAxisThrows(context.getConnection(),
+        assertAxisThrows(context.getConnectionWithDefaultRole(),
             "Unorder(1 + 3)",
             "No function matches signature 'Unorder(<Numeric Expression>)'" );
-        assertAxisThrows(context.getConnection(),
+        assertAxisThrows(context.getConnectionWithDefaultRole(),
             "Unorder([Gender].[M], 1 + 3)",
             "No function matches signature 'Unorder(<Member>, <Numeric Expression>)'" );
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Measures].[Store Sales], [Measures].[Unit Sales]} on 0,\n"
                 + "  Unorder([Gender].Members) on 1\n"
                 + "from [Sales]",

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/var/VarFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/var/VarFunDefTest.java
@@ -28,7 +28,7 @@ class VarFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testVar(Context context) {
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "VAR({[Store].[All Stores].[USA].children},[Measures].[Store Sales])",
             "4,332,990,493.69" );
     }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/var/VarPFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/var/VarPFunDefTest.java
@@ -28,7 +28,7 @@ class VarPFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testVarP(Context context) {
-        assertExprReturns(context.getConnection(),
+        assertExprReturns(context.getConnectionWithDefaultRole(),
             "VARP({[Store].[All Stores].[USA].children},[Measures].[Store Sales])",
             "2,888,660,329.13" );
     }

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/visualtotals/VisualTotalsFunDefTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/function/def/visualtotals/VisualTotalsFunDefTest.java
@@ -38,7 +38,7 @@ class VisualTotalsFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testVisualTotalsBasic(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Measures].[Unit Sales]} on columns, "
                 + "{VisualTotals("
                 + "    {[Product].[All Products].[Food].[Baked Goods].[Bread],"
@@ -66,7 +66,7 @@ class VisualTotalsFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testVisualTotalsConsecutively(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Measures].[Unit Sales]} on columns, "
                 + "{VisualTotals("
                 + "    {[Product].[All Products].[Food].[Baked Goods].[Bread],"
@@ -106,7 +106,7 @@ class VisualTotalsFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testVisualTotalsNoPattern(Context context) {
-        assertAxisReturns(context.getConnection(),
+        assertAxisReturns(context.getConnectionWithDefaultRole(),
             "VisualTotals("
                 + "    {[Product].[All Products].[Food].[Baked Goods].[Bread],"
                 + "     [Product].[All Products].[Food].[Baked Goods].[Bread].[Bagels],"
@@ -121,7 +121,7 @@ class VisualTotalsFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testVisualTotalsWithFilter(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Measures].[Unit Sales]} on columns, "
                 + "{Filter("
                 + "    VisualTotals("
@@ -150,7 +150,7 @@ class VisualTotalsFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testVisualTotalsNested(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Measures].[Unit Sales]} on columns, "
                 + "{VisualTotals("
                 + "    Filter("
@@ -179,7 +179,7 @@ class VisualTotalsFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testVisualTotalsFilterInside(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Measures].[Unit Sales]} on columns, "
                 + "{VisualTotals("
                 + "    Filter("
@@ -204,7 +204,7 @@ class VisualTotalsFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testVisualTotalsOutOfOrder(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Measures].[Unit Sales]} on columns, "
                 + "{VisualTotals("
                 + "    {[Product].[All Products].[Food].[Baked Goods].[Bread].[Bagels],"
@@ -231,7 +231,7 @@ class VisualTotalsFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testVisualTotalsGrandparentsAndOutOfOrder(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "select {[Measures].[Unit Sales]} on columns, "
                 + "{VisualTotals("
                 + "    {[Product].[All Products].[Food],"
@@ -273,7 +273,7 @@ class VisualTotalsFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testVisualTotalsCrossjoin(Context context) {
-        assertAxisThrows(context.getConnection(),
+        assertAxisThrows(context.getConnectionWithDefaultRole(),
             "VisualTotals(Crossjoin([Gender].Members, [Store].children))",
             "Argument to 'VisualTotals' function must be a set of members; got set of tuples." );
     }
@@ -295,7 +295,7 @@ class VisualTotalsFunDefTest {
                 + "     [Customers].[USA].[CA],\n"
                 + "     [Customers].[USA].[OR]}) ON 1\n"
                 + "FROM [Sales]";
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             query,
             "Axis #0:\n"
                 + "{}\n"
@@ -312,7 +312,7 @@ class VisualTotalsFunDefTest {
                 + "Row #3: 67,659\n" );
 
         // Check captions
-        final Result result = executeQuery(context.getConnection(), query);
+        final Result result = executeQuery(context.getConnectionWithDefaultRole(), query);
         final List<Position> positionList = result.getAxes()[ 1 ].getPositions();
         assertEquals( "All Customers", positionList.get( 0 ).get( 0 ).getCaption() );
         assertEquals( "USA", positionList.get( 1 ).get( 0 ).getCaption() );
@@ -327,7 +327,7 @@ class VisualTotalsFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testVisualTotalsWithNamedSetAndPivot(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH SET [CA_OR] AS\n"
                 + "    VisualTotals(\n"
                 + "        {[Customers].[All Customers],\n"
@@ -373,7 +373,7 @@ class VisualTotalsFunDefTest {
                 + "Row #3: 16,353\n" );
 
         // same query, swap axes
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH SET [CA_OR] AS\n"
                 + "    VisualTotals(\n"
                 + "        {[Customers].[All Customers],\n"
@@ -428,7 +428,7 @@ class VisualTotalsFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testVisualTotalsIntersect(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH\n"
                 + "SET [XL_Row_Dim_0] AS 'VisualTotals(Distinct(Hierarchize({Ascendants([Customers].[All Customers].[USA]), "
                 + "Descendants([Customers].[All Customers].[USA])})))' \n"
@@ -456,7 +456,7 @@ class VisualTotalsFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testVisualTotalsWithNamedSetAndPivotSameAxis(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH SET [XL_Row_Dim_0] AS\n"
                 + " VisualTotals(\n"
                 + "   Distinct(\n"
@@ -479,7 +479,7 @@ class VisualTotalsFunDefTest {
                 + "Row #0: 24,442\n" );
 
         // now with tuples
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH SET [XL_Row_Dim_0] AS\n"
                 + " VisualTotals(\n"
                 + "   Distinct(\n"
@@ -514,7 +514,7 @@ class VisualTotalsFunDefTest {
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testVisualTotalsDistinctCountMeasure(Context context) {
         // distinct measure
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH SET [XL_Row_Dim_0] AS\n"
                 + " VisualTotals(\n"
                 + "   Distinct(\n"
@@ -537,7 +537,7 @@ class VisualTotalsFunDefTest {
                 + "Row #0: 193\n" );
 
         // distinct measure
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH SET [XL_Row_Dim_0] AS\n"
                 + " VisualTotals(\n"
                 + "   Distinct(\n"
@@ -562,7 +562,7 @@ class VisualTotalsFunDefTest {
                 + "Row #0: 110\n" );
 
         // distinct measure on columns
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH SET [XL_Row_Dim_0] AS\n"
                 + " VisualTotals(\n"
                 + "   Distinct(\n"
@@ -590,7 +590,7 @@ class VisualTotalsFunDefTest {
                 + "Row #1: 193\n" );
 
         // distinct measure with tuples
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH SET [XL_Row_Dim_0] AS\n"
                 + " VisualTotals(\n"
                 + "   Distinct(\n"
@@ -624,7 +624,7 @@ class VisualTotalsFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testVisualTotalsClassCast(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH  SET [XL_Row_Dim_0] AS\n"
                 + " VisualTotals(\n"
                 + "   Distinct(\n"
@@ -710,7 +710,7 @@ class VisualTotalsFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testVisualTotalsWithNamedSetOfTuples(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "WITH SET [XL_Row_Dim_0] AS\n"
                 + " VisualTotals(\n"
                 + "   Distinct(\n"
@@ -747,7 +747,7 @@ class VisualTotalsFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testVisualTotalsLevel(Context context) {
-        Result result = executeQuery(context.getConnection(),
+        Result result = executeQuery(context.getConnectionWithDefaultRole(),
             "select {[Measures].[Unit Sales]} on columns,\n"
                 + "{[Product].[All Products],\n"
                 + " [Product].[All Products].[Food].[Baked Goods].[Bread],\n"
@@ -786,7 +786,7 @@ class VisualTotalsFunDefTest {
     @ParameterizedTest
     @ContextSource(propertyUpdater = AppandFoodMartCatalog.class, dataloader = FastFoodmardDataLoader.class)
     void testVisualTotalsMemberInCalculation(Context context) {
-        assertQueryReturns(context.getConnection(),
+        assertQueryReturns(context.getConnectionWithDefaultRole(),
             "with member [Measures].[Foo] as\n"
                 + " [Product].CurrentMember.Name || ' : ' || [Product].Level.Name\n"
                 + "select {[Measures].[Unit Sales], [Measures].[Foo]} on columns,\n"

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/rolap/core/ServiceTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/rolap/core/ServiceTest.java
@@ -143,7 +143,7 @@ class ServiceTest {
         assertThat(saContext).isNotNull()
                 .extracting(ServiceAware::size)
                 .isEqualTo(1);
-        assertThat(ctx.getConnection()).isNotNull();
+        assertThat(ctx.getConnectionWithDefaultRole()).isNotNull();
         assertThat(ctx).satisfies(x -> {
             assertThat(x.getName()).isEqualTo(theName);
             assertThat(x.getDescription()

--- a/mondrian/src/test/java/org/opencube/junit5/TestUtil.java
+++ b/mondrian/src/test/java/org/opencube/junit5/TestUtil.java
@@ -229,7 +229,7 @@ public class TestUtil {
 	public static void assertQueryThrows(Context context, String queryString, String pattern) {
 		Throwable throwable;
 		try {
-			Result result = executeQuery(context.getConnection(), queryString);
+			Result result = executeQuery(context.getConnectionWithDefaultRole(), queryString);
 //			discard(result);
 			throwable = null;
 		} catch (Throwable e) {
@@ -305,7 +305,7 @@ public class TestUtil {
 				cubeName = Util.quoteMdxIdentifier(cubeName);
 			}
 			expression = expression.replace("'", "''");
-			Result result = executeQuery(context.getConnection(), "with member [Measures].[Foo] as '" + expression
+			Result result = executeQuery(context.getConnectionWithDefaultRole(), "with member [Measures].[Foo] as '" + expression
 					+ "' select {[Measures].[Foo]} on columns from " + cubeName);
 			Cell cell = result.getCell(new int[] { 0 });
 			if (cell.isError()) {
@@ -598,7 +598,7 @@ public class TestUtil {
         //TODO
 		//context.setProperty(RolapConnectionProperties.Ignore.name(),
 		//		"true");
-		final Connection connection = context.getConnection();
+		final Connection connection = context.getConnectionWithDefaultRole();
 				//withProperties( propertyList ).getConnection();
 		return connection.getSchema().getWarnings();
 	}
@@ -1828,7 +1828,7 @@ public class TestUtil {
 						+ cookie,
 				info );
 		*/
-		Connection connection = context.getConnection();
+		Connection connection = context.getConnectionWithDefaultRole();
 		//		con.unwrap( OlapConnection.class );
 
         org.eclipse.daanse.olap.api.Statement statement = connection.createStatement();

--- a/mondrian/src/test/java/org/opencube/junit5/context/TestContextImpl.java
+++ b/mondrian/src/test/java/org/opencube/junit5/context/TestContextImpl.java
@@ -15,7 +15,6 @@ import org.eclipse.daanse.mdx.parser.api.MdxParserProvider;
 import org.eclipse.daanse.mdx.parser.ccc.MdxParserProviderImpl;
 import org.eclipse.daanse.olap.api.BasicContextConfig;
 import org.eclipse.daanse.olap.api.ConnectionProps;
-import org.eclipse.daanse.olap.api.SchemaCache;
 import org.eclipse.daanse.olap.api.function.FunctionService;
 import org.eclipse.daanse.olap.api.result.Scenario;
 import org.eclipse.daanse.olap.calc.api.compiler.ExpressionCompilerFactory;
@@ -694,7 +693,7 @@ public class TestContextImpl extends AbstractBasicContext implements TestContext
 	}
 
 	@Override
-	public org.eclipse.daanse.olap.api.Connection getConnection() {
+	public org.eclipse.daanse.olap.api.Connection getConnectionWithDefaultRole() {
 		return getConnection(new RolapConnectionPropsR());
 	}
 
@@ -711,7 +710,7 @@ public class TestContextImpl extends AbstractBasicContext implements TestContext
     }
 
     @Override
-    public Scenario createScenario() {
+    public Scenario createScenario(List<String> roles) {
         return null;
     }
 

--- a/mondrian/test.bndrun
+++ b/mondrian/test.bndrun
@@ -106,6 +106,6 @@
 	#tester.names='org.eclipse.daanse.olap.function.def.dimension.DimensionFunctionsTest'
     #tester.names='mondrian.rolap.TestAggregationManager'
     #tester.names='mondrian.rolap.aggmatcher.AggMeasureFactCountTest'
--runproperties.tester: \
-	tester.names='mondrian.rolap.FastBatchingCellReaderTest'
+#-runproperties.tester: \
+#	tester.names='mondrian.rolap.FastBatchingCellReaderTest'
 	

--- a/olap/action/api/src/main/java/org/eclipse/daanse/olap/action/api/ActionService.java
+++ b/olap/action/api/src/main/java/org/eclipse/daanse/olap/action/api/ActionService.java
@@ -14,6 +14,8 @@
 package org.eclipse.daanse.olap.action.api;
 
 import org.eclipse.daanse.olap.api.Context;
+import org.eclipse.daanse.xmla.api.RequestMetaData;
+import org.eclipse.daanse.xmla.api.UserPrincipal;
 import org.eclipse.daanse.xmla.api.common.enums.ActionTypeEnum;
 import org.eclipse.daanse.xmla.api.common.enums.CoordinateTypeEnum;
 import org.eclipse.daanse.xmla.api.common.enums.CubeSourceEnum;
@@ -34,6 +36,8 @@ public interface ActionService {
         Optional<String> coordinate,
         CoordinateTypeEnum coordinateType,
         InvocationEnum invocation,
-        Optional<CubeSourceEnum> cubeSource
+        Optional<CubeSourceEnum> cubeSource,
+        RequestMetaData metaData,
+        UserPrincipal userPrincipal
     );
 }

--- a/olap/documentation/common/src/main/java/org/eclipse/daanse/olap/documentation/common/MarkdownDocumentationProvider.java
+++ b/olap/documentation/common/src/main/java/org/eclipse/daanse/olap/documentation/common/MarkdownDocumentationProvider.java
@@ -133,7 +133,7 @@ public class MarkdownDocumentationProvider extends AbstractContextDocumentationP
     @Override
     public void createDocumentation(Context ctx, Path path) throws Exception {
     	RolapContext context=(RolapContext) ctx;
-        metaInfo = databaseService.createMetaInfo(context.getConnection().getDataSource());
+        metaInfo = databaseService.createMetaInfo(context.getConnectionWithDefaultRole().getDataSource());
         File file = path.toFile();
 
         if (file.exists()) {

--- a/olap/xmla/bridge/src/main/java/org/eclipse/daanse/olap/xmla/bridge/discover/DBSchemaDiscoverService.java
+++ b/olap/xmla/bridge/src/main/java/org/eclipse/daanse/olap/xmla/bridge/discover/DBSchemaDiscoverService.java
@@ -19,6 +19,8 @@ import org.eclipse.daanse.olap.xmla.bridge.ContextListSupplyer;
 import org.eclipse.daanse.rolap.mapping.api.model.AccessRoleMapping;
 import org.eclipse.daanse.rolap.mapping.api.model.CatalogMapping;
 import org.eclipse.daanse.rolap.mapping.api.model.SchemaMapping;
+import org.eclipse.daanse.xmla.api.RequestMetaData;
+import org.eclipse.daanse.xmla.api.UserPrincipal;
 import org.eclipse.daanse.xmla.api.XmlaConstants;
 import org.eclipse.daanse.xmla.api.common.enums.ColumnOlapTypeEnum;
 import org.eclipse.daanse.xmla.api.common.enums.LevelDbTypeEnum;
@@ -62,7 +64,7 @@ public class DBSchemaDiscoverService {
         this.contextsListSupplyer = contextsListSupplyer;
     }
 
-    public List<DbSchemaCatalogsResponseRow> dbSchemaCatalogs(DbSchemaCatalogsRequest request) {
+    public List<DbSchemaCatalogsResponseRow> dbSchemaCatalogs(DbSchemaCatalogsRequest request, RequestMetaData metaData, UserPrincipal userPrincipal) {
 
         Optional<String> oName = request.restrictions().catalogName();
         if (oName.isPresent()) {
@@ -111,7 +113,7 @@ public class DBSchemaDiscoverService {
         return schemas.stream().flatMap(s -> s.getAccessRoles().stream()).toList();
     }
 
-    public List<DbSchemaColumnsResponseRow> dbSchemaColumns(DbSchemaColumnsRequest request) {
+    public List<DbSchemaColumnsResponseRow> dbSchemaColumns(DbSchemaColumnsRequest request, RequestMetaData metaData, UserPrincipal userPrincipal) {
         Optional<String> oCatalog = request.restrictions().tableCatalog();
         Optional<String> oTableSchema = request.restrictions().tableSchema();
         Optional<String> oTableName = request.restrictions().tableName();
@@ -134,7 +136,7 @@ public class DBSchemaDiscoverService {
         return result;
     }
 
-    public List<DbSchemaProviderTypesResponseRow> dbSchemaProviderTypes(DbSchemaProviderTypesRequest request) {
+    public List<DbSchemaProviderTypesResponseRow> dbSchemaProviderTypes(DbSchemaProviderTypesRequest request, RequestMetaData metaData, UserPrincipal userPrincipal) {
         List<DbSchemaProviderTypesResponseRow> result = new ArrayList<>();
         Optional<LevelDbTypeEnum> oLevelDbType = request.restrictions().dataType();
 
@@ -303,7 +305,7 @@ public class DBSchemaDiscoverService {
         return result;
     }
 
-    public List<DbSchemaSchemataResponseRow> dbSchemaSchemata(DbSchemaSchemataRequest request) {
+    public List<DbSchemaSchemataResponseRow> dbSchemaSchemata(DbSchemaSchemataRequest request, RequestMetaData metaData, UserPrincipal userPrincipal) {
         String catalogName = request.restrictions().catalogName();
         String schemaName = request.restrictions().schemaName();
         String schemaOwner = request.restrictions().schemaOwner();
@@ -322,7 +324,7 @@ public class DBSchemaDiscoverService {
         return result;
     }
 
-    public List<DbSchemaSourceTablesResponseRow> dbSchemaSourceTables(DbSchemaSourceTablesRequest request) {
+    public List<DbSchemaSourceTablesResponseRow> dbSchemaSourceTables(DbSchemaSourceTablesRequest request, RequestMetaData metaData, UserPrincipal userPrincipal) {
         Optional<String> oCatalogName = request.restrictions().catalogName();
         Optional<String> oSchemaName = request.restrictions().schemaName();
         String tableName = request.restrictions().tableName();
@@ -342,7 +344,7 @@ public class DBSchemaDiscoverService {
     }
 
 
-    public List<DbSchemaTablesResponseRow> dbSchemaTables(DbSchemaTablesRequest request) {
+    public List<DbSchemaTablesResponseRow> dbSchemaTables(DbSchemaTablesRequest request, RequestMetaData metaData, UserPrincipal userPrincipal) {
         Optional<String> oTableCatalog = request.restrictions().tableCatalog();
         Optional<String> oTableSchema = request.restrictions().tableSchema();
         Optional<String> oTableName = request.restrictions().tableName();
@@ -355,17 +357,18 @@ public class DBSchemaDiscoverService {
         if (oTableCatalog.isPresent()) {
             Optional<Context> oContext = oTableCatalog.flatMap(name -> contextsListSupplyer.tryGetFirstByName(name));
             if (oContext.isPresent()) {
-                return getDbSchemaTablesResponseRow(oContext.get(), oTableSchema, oTableName, oTableType);
+                return getDbSchemaTablesResponseRow(oContext.get(), oTableSchema, oTableName, oTableType, metaData, userPrincipal);
             }
         } else {
             return contextsListSupplyer.get().stream()
-                .map(c -> getDbSchemaTablesResponseRow(c, oTableSchema, oTableName, oTableType))
+					.map(c -> getDbSchemaTablesResponseRow(c, oTableSchema, oTableName, oTableType, metaData,
+							userPrincipal))
                 .flatMap(Collection::stream).toList();
         }
         return List.of();
     }
 
-    public List<DbSchemaTablesInfoResponseRow> dbSchemaTablesInfo(DbSchemaTablesInfoRequest request) {
+    public List<DbSchemaTablesInfoResponseRow> dbSchemaTablesInfo(DbSchemaTablesInfoRequest request, RequestMetaData metaData, UserPrincipal userPrincipal) {
         Optional<String> oCatalogName = request.restrictions().catalogName();
         Optional<String> oSchemaName = request.restrictions().schemaName();
         String tableName = request.restrictions().tableName();

--- a/olap/xmla/bridge/src/main/java/org/eclipse/daanse/olap/xmla/bridge/discover/DelegatingDiscoverService.java
+++ b/olap/xmla/bridge/src/main/java/org/eclipse/daanse/olap/xmla/bridge/discover/DelegatingDiscoverService.java
@@ -96,7 +96,7 @@ public class DelegatingDiscoverService implements DiscoverService {
 	public List<DiscoverDataSourcesResponseRow> dataSources(DiscoverDataSourcesRequest request,
                                                             RequestMetaData metaData,
                                                             UserPrincipal userPrincipal) {
-		return otherSchemaService.dataSources(request);
+		return otherSchemaService.dataSources(request, metaData, userPrincipal);
 	}
 
 	@Override
@@ -105,7 +105,7 @@ public class DelegatingDiscoverService implements DiscoverService {
                                                               UserPrincipal userPrincipal) {
 
 
-        return dbSchemaService.dbSchemaCatalogs(request);
+        return dbSchemaService.dbSchemaCatalogs(request, metaData, userPrincipal);
 	}
 
 	@Override
@@ -113,7 +113,7 @@ public class DelegatingDiscoverService implements DiscoverService {
                                                             RequestMetaData metaData,
                                                             UserPrincipal userPrincipal) {
 
-		return dbSchemaService.dbSchemaColumns(request);
+		return dbSchemaService.dbSchemaColumns(request, metaData, userPrincipal);
 	}
 
 	@Override
@@ -121,7 +121,7 @@ public class DelegatingDiscoverService implements DiscoverService {
                                                                         RequestMetaData metaData,
                                                                         UserPrincipal userPrincipal) {
 
-		return dbSchemaService.dbSchemaProviderTypes(request);
+		return dbSchemaService.dbSchemaProviderTypes(request, metaData, userPrincipal);
 	}
 
 	@Override
@@ -129,7 +129,7 @@ public class DelegatingDiscoverService implements DiscoverService {
                                                               RequestMetaData metaData,
                                                               UserPrincipal userPrincipal) {
 
-		return dbSchemaService.dbSchemaSchemata(request);
+		return dbSchemaService.dbSchemaSchemata(request, metaData, userPrincipal);
 	}
 
 	@Override
@@ -137,7 +137,7 @@ public class DelegatingDiscoverService implements DiscoverService {
                                                                       RequestMetaData metaData,
                                                                       UserPrincipal userPrincipal) {
 
-		return dbSchemaService.dbSchemaSourceTables(request);
+		return dbSchemaService.dbSchemaSourceTables(request, metaData, userPrincipal);
 	}
 
 	@Override
@@ -145,7 +145,7 @@ public class DelegatingDiscoverService implements DiscoverService {
                                                           RequestMetaData metaData,
                                                           UserPrincipal userPrincipal) {
 
-		return dbSchemaService.dbSchemaTables(request);
+		return dbSchemaService.dbSchemaTables(request, metaData, userPrincipal);
 	}
 
 	@Override
@@ -153,7 +153,7 @@ public class DelegatingDiscoverService implements DiscoverService {
                                                                   RequestMetaData metaData,
                                                                   UserPrincipal userPrincipal) {
 
-		return dbSchemaService.dbSchemaTablesInfo(request);
+		return dbSchemaService.dbSchemaTablesInfo(request, metaData, userPrincipal);
 	}
 
 	@Override
@@ -161,7 +161,7 @@ public class DelegatingDiscoverService implements DiscoverService {
                                                                     RequestMetaData metaData,
                                                                     UserPrincipal userPrincipal) {
 
-		return otherSchemaService.discoverEnumerators(request);
+		return otherSchemaService.discoverEnumerators(request, metaData, userPrincipal);
 	}
 
 	@Override
@@ -169,7 +169,7 @@ public class DelegatingDiscoverService implements DiscoverService {
                                                               RequestMetaData metaData,
                                                               UserPrincipal userPrincipal) {
 
-		return otherSchemaService.discoverKeywords(request);
+		return otherSchemaService.discoverKeywords(request, metaData, userPrincipal);
 	}
 
 	@Override
@@ -177,7 +177,7 @@ public class DelegatingDiscoverService implements DiscoverService {
                                                               RequestMetaData metaData,
                                                               UserPrincipal userPrincipal) {
 
-		return otherSchemaService.discoverLiterals(request);
+		return otherSchemaService.discoverLiterals(request, metaData, userPrincipal);
 	}
 
 	@Override
@@ -185,7 +185,7 @@ public class DelegatingDiscoverService implements DiscoverService {
                                                                   RequestMetaData metaData,
                                                                   UserPrincipal userPrincipal) {
 
-		return otherSchemaService.discoverProperties(request);
+		return otherSchemaService.discoverProperties(request, metaData, userPrincipal);
 	}
 
 	@Override
@@ -193,7 +193,7 @@ public class DelegatingDiscoverService implements DiscoverService {
                                                                         RequestMetaData metaData,
                                                                         UserPrincipal userPrincipal) {
 
-		return otherSchemaService.discoverSchemaRowsets(request);
+		return otherSchemaService.discoverSchemaRowsets(request, metaData, userPrincipal);
 	}
 
 	@Override
@@ -201,7 +201,7 @@ public class DelegatingDiscoverService implements DiscoverService {
                                                             RequestMetaData metaData,
                                                             UserPrincipal userPrincipal) {
 
-		return mdSchemaService.mdSchemaActions(request);
+		return mdSchemaService.mdSchemaActions(request, metaData, userPrincipal);
 	}
 
 	@Override
@@ -209,7 +209,7 @@ public class DelegatingDiscoverService implements DiscoverService {
                                                         RequestMetaData metaData,
                                                         UserPrincipal userPrincipal) {
 
-		return mdSchemaService.mdSchemaCubes(request);
+		return mdSchemaService.mdSchemaCubes(request, metaData, userPrincipal);
 	}
 
 	@Override
@@ -217,7 +217,7 @@ public class DelegatingDiscoverService implements DiscoverService {
                                                                   RequestMetaData metaData,
                                                                   UserPrincipal userPrincipal) {
 
-		return mdSchemaService.mdSchemaDimensions(request);
+		return mdSchemaService.mdSchemaDimensions(request, metaData, userPrincipal);
 	}
 
 	@Override
@@ -225,7 +225,7 @@ public class DelegatingDiscoverService implements DiscoverService {
                                                                 RequestMetaData metaData,
                                                                 UserPrincipal userPrincipal) {
 
-		return mdSchemaService.mdSchemaFunctions(request);
+		return mdSchemaService.mdSchemaFunctions(request, metaData, userPrincipal);
 	}
 
 	@Override
@@ -233,7 +233,7 @@ public class DelegatingDiscoverService implements DiscoverService {
                                                                     RequestMetaData metaData,
                                                                     UserPrincipal userPrincipal) {
 
-		return mdSchemaService.mdSchemaHierarchies(request);
+		return mdSchemaService.mdSchemaHierarchies(request, metaData, userPrincipal);
 	}
 
 	@Override
@@ -241,7 +241,7 @@ public class DelegatingDiscoverService implements DiscoverService {
                                                       RequestMetaData metaData,
                                                       UserPrincipal userPrincipal) {
 
-		return mdSchemaService.mdSchemaKpis(request);
+		return mdSchemaService.mdSchemaKpis(request, metaData, userPrincipal);
 	}
 
 	@Override
@@ -249,7 +249,7 @@ public class DelegatingDiscoverService implements DiscoverService {
                                                           RequestMetaData metaData,
                                                           UserPrincipal userPrincipal) {
 
-		return mdSchemaService.mdSchemaLevels(request);
+		return mdSchemaService.mdSchemaLevels(request, metaData, userPrincipal);
 	}
 
 	@Override
@@ -258,7 +258,7 @@ public class DelegatingDiscoverService implements DiscoverService {
             RequestMetaData metaData,
             UserPrincipal userPrincipal) {
 
-		return mdSchemaService.mdSchemaMeasureGroupDimensions(request);
+		return mdSchemaService.mdSchemaMeasureGroupDimensions(request, metaData, userPrincipal);
 	}
 
 	@Override
@@ -266,7 +266,7 @@ public class DelegatingDiscoverService implements DiscoverService {
                                                                         RequestMetaData metaData,
                                                                         UserPrincipal userPrincipal) {
 
-		return mdSchemaService.mdSchemaMeasureGroups(request);
+		return mdSchemaService.mdSchemaMeasureGroups(request, metaData, userPrincipal);
 	}
 
 	@Override
@@ -274,7 +274,7 @@ public class DelegatingDiscoverService implements DiscoverService {
                                                               RequestMetaData metaData,
                                                               UserPrincipal userPrincipal) {
 
-		return mdSchemaService.mdSchemaMeasures(request);
+		return mdSchemaService.mdSchemaMeasures(request, metaData, userPrincipal);
 	}
 
 	@Override
@@ -282,7 +282,7 @@ public class DelegatingDiscoverService implements DiscoverService {
                                                             RequestMetaData metaData,
                                                             UserPrincipal userPrincipal) {
 
-		return mdSchemaService.mdSchemaMembers(request);
+		return mdSchemaService.mdSchemaMembers(request, metaData, userPrincipal);
 	}
 
 	@Override
@@ -290,7 +290,7 @@ public class DelegatingDiscoverService implements DiscoverService {
                                                                   RequestMetaData metaData,
                                                                   UserPrincipal userPrincipal) {
 
-		return mdSchemaService.mdSchemaProperties(request);
+		return mdSchemaService.mdSchemaProperties(request, metaData, userPrincipal);
 	}
 
 	@Override
@@ -298,7 +298,7 @@ public class DelegatingDiscoverService implements DiscoverService {
                                                       RequestMetaData metaData,
                                                       UserPrincipal userPrincipal) {
 
-		return mdSchemaService.mdSchemaSets(request);
+		return mdSchemaService.mdSchemaSets(request, metaData, userPrincipal);
 	}
 
 	@Override
@@ -306,7 +306,7 @@ public class DelegatingDiscoverService implements DiscoverService {
                                                             RequestMetaData metaData,
                                                             UserPrincipal userPrincipal) {
 
-		return otherSchemaService.xmlMetaData(request);
+		return otherSchemaService.xmlMetaData(request, metaData, userPrincipal);
 	}
 
 }

--- a/olap/xmla/bridge/src/main/java/org/eclipse/daanse/olap/xmla/bridge/discover/OtherDiscoverService.java
+++ b/olap/xmla/bridge/src/main/java/org/eclipse/daanse/olap/xmla/bridge/discover/OtherDiscoverService.java
@@ -32,6 +32,8 @@ import org.eclipse.daanse.olap.xmla.bridge.ContextGroupXmlaServiceConfig;
 import org.eclipse.daanse.olap.xmla.bridge.ContextListSupplyer;
 import org.eclipse.daanse.rolap.mapping.api.model.SchemaMapping;
 import org.eclipse.daanse.xmla.api.PropertyDefinition;
+import org.eclipse.daanse.xmla.api.RequestMetaData;
+import org.eclipse.daanse.xmla.api.UserPrincipal;
 import org.eclipse.daanse.xmla.api.XmlaConstants;
 import org.eclipse.daanse.xmla.api.annotation.Enumerator;
 import org.eclipse.daanse.xmla.api.annotation.Operation;
@@ -139,7 +141,7 @@ public class OtherDiscoverService {
 
     }
 
-    public List<DiscoverDataSourcesResponseRow> dataSources(DiscoverDataSourcesRequest request) {
+    public List<DiscoverDataSourcesResponseRow> dataSources(DiscoverDataSourcesRequest request, RequestMetaData metaData, UserPrincipal userPrincipal) {
         List<DiscoverDataSourcesResponseRow> result = new ArrayList<>();
         List<Context> contexts = this.contextsListSupplyer.get();
         for (Context context : contexts) {
@@ -159,7 +161,7 @@ public class OtherDiscoverService {
         return result;
     }
 
-    public List<DiscoverEnumeratorsResponseRow> discoverEnumerators(DiscoverEnumeratorsRequest request) {
+    public List<DiscoverEnumeratorsResponseRow> discoverEnumerators(DiscoverEnumeratorsRequest request, RequestMetaData metaData, UserPrincipal userPrincipal) {
         List<DiscoverEnumeratorsResponseRow> result = new ArrayList();
         for (Class c : enums) {
             String enumDescription = getEnumDescription(c.getSimpleName());
@@ -201,7 +203,7 @@ public class OtherDiscoverService {
         return result;
     }
 
-    public List<DiscoverKeywordsResponseRow> discoverKeywords(DiscoverKeywordsRequest request) {
+    public List<DiscoverKeywordsResponseRow> discoverKeywords(DiscoverKeywordsRequest request, RequestMetaData metaData, UserPrincipal userPrincipal) {
         List<DiscoverKeywordsResponseRow> result = new ArrayList<>();
 
         for (String keyword : AbstractBasicContext.KEYWORD_LIST) {
@@ -210,7 +212,7 @@ public class OtherDiscoverService {
         return result;
     }
 
-    public List<DiscoverLiteralsResponseRow> discoverLiterals(DiscoverLiteralsRequest request) {
+    public List<DiscoverLiteralsResponseRow> discoverLiterals(DiscoverLiteralsRequest request, RequestMetaData metaData, UserPrincipal userPrincipal) {
         List<DiscoverLiteralsResponseRow> result = new ArrayList<>();
         for (XmlaConstants.Literal anEnum : XmlaConstants.Literal.values()) {
             result.add(new DiscoverLiteralsResponseRowR(DBLITERAL + anEnum.name(),
@@ -223,7 +225,7 @@ public class OtherDiscoverService {
         return result;
     }
 
-    public List<DiscoverPropertiesResponseRow> discoverProperties(DiscoverPropertiesRequest request) {
+    public List<DiscoverPropertiesResponseRow> discoverProperties(DiscoverPropertiesRequest request, RequestMetaData metaData, UserPrincipal userPrincipal) {
         Optional<String> propertyName = request.restrictions()==null? Optional.empty():request.restrictions().propertyName();
         Optional<String> properetyCatalog = request.properties().catalog();
         List<DiscoverPropertiesResponseRow> result = new ArrayList<>();
@@ -272,7 +274,7 @@ public class OtherDiscoverService {
         return result;
     }
 
-    public List<DiscoverSchemaRowsetsResponseRow> discoverSchemaRowsets(DiscoverSchemaRowsetsRequest request) {
+    public List<DiscoverSchemaRowsetsResponseRow> discoverSchemaRowsets(DiscoverSchemaRowsetsRequest request, RequestMetaData metaData, UserPrincipal userPrincipal) {
         Optional<String> schemaName = request.restrictions().schemaName();
         List<DiscoverSchemaRowsetsResponseRow> result = new ArrayList<>();
         for (Class c : classes) {
@@ -309,7 +311,7 @@ public class OtherDiscoverService {
         return result;
     }
 
-    public List<DiscoverXmlMetaDataResponseRow> xmlMetaData(DiscoverXmlMetaDataRequest request) {
+    public List<DiscoverXmlMetaDataResponseRow> xmlMetaData(DiscoverXmlMetaDataRequest request, RequestMetaData metaData, UserPrincipal userPrincipal) {
         List<DiscoverXmlMetaDataResponseRow> result = new ArrayList<>();
         Optional<String> databaseId = request.restrictions().databaseId();
         if (databaseId.isPresent()) {

--- a/olap/xmla/bridge/src/main/java/org/eclipse/daanse/olap/xmla/bridge/execute/WriteBackService.java
+++ b/olap/xmla/bridge/src/main/java/org/eclipse/daanse/olap/xmla/bridge/execute/WriteBackService.java
@@ -82,7 +82,7 @@ public class WriteBackService {
                     sql.append(writebackTable.getColumns().stream().map(c -> c.getColumn().getName())
                         .collect(Collectors.joining(", ")));
                     sql.append(", ID");
-                    if (userPrincipal != null && userPrincipal.getUserId() != null) {
+                    if (userPrincipal != null && userPrincipal.userId() != null) {
                         sql.append(", USER");
                     }
                     sql.append(") values (");
@@ -97,9 +97,9 @@ public class WriteBackService {
                     }
                     sql.append(", ");
                     dialect.quote(sql, UUID.randomUUID(), Datatype.STRING);
-                    if (userPrincipal != null && userPrincipal.getUserId() != null) {
+                    if (userPrincipal != null && userPrincipal.userId() != null) {
                         sql.append(", ");
-                        dialect.quote(sql, userPrincipal.getUserId(), Datatype.STRING);
+                        dialect.quote(sql, userPrincipal.userId(), Datatype.STRING);
                     }
                     sql.append(")");
                     statement.execute(sql.toString());

--- a/olap/xmla/bridge/src/test/java/org/eclipse/daanse/olap/xmla/bridge/discover/DbSchemaDiscoverServiceTest.java
+++ b/olap/xmla/bridge/src/test/java/org/eclipse/daanse/olap/xmla/bridge/discover/DbSchemaDiscoverServiceTest.java
@@ -15,6 +15,7 @@ package org.eclipse.daanse.olap.xmla.bridge.discover;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -49,6 +50,8 @@ import org.eclipse.daanse.rolap.mapping.api.model.MeasureGroupMapping;
 import org.eclipse.daanse.rolap.mapping.api.model.MeasureMapping;
 import org.eclipse.daanse.rolap.mapping.api.model.PhysicalCubeMapping;
 import org.eclipse.daanse.rolap.mapping.api.model.SchemaMapping;
+import org.eclipse.daanse.xmla.api.RequestMetaData;
+import org.eclipse.daanse.xmla.api.UserPrincipal;
 import org.eclipse.daanse.xmla.api.common.enums.LevelDbTypeEnum;
 import org.eclipse.daanse.xmla.api.common.enums.TableTypeEnum;
 import org.eclipse.daanse.xmla.api.discover.dbschema.catalogs.DbSchemaCatalogsRequest;
@@ -168,6 +171,12 @@ class DbSchemaDiscoverServiceTest {
     private Connection connection;
     @Mock
     private ContextGroup contextGroup;
+    
+    @Mock
+    private RequestMetaData requestMetaData;
+    @Mock
+    private UserPrincipal userPrincipal;
+    
 
     private DBSchemaDiscoverService service;
 
@@ -211,7 +220,7 @@ class DbSchemaDiscoverServiceTest {
         when(context2.getName()).thenReturn("foo");
         when(context2.getCatalogMapping()).thenReturn(catalog);
 
-        List<DbSchemaCatalogsResponseRow> rows = service.dbSchemaCatalogs(request);
+        List<DbSchemaCatalogsResponseRow> rows = service.dbSchemaCatalogs(request, requestMetaData, userPrincipal);
         verify(context1, times(1)).getName();
         verify(context2, times(3)).getName();
         assertThat(rows).isNotNull().hasSize(2);
@@ -268,7 +277,7 @@ class DbSchemaDiscoverServiceTest {
         when(context2.getName()).thenReturn("foo");
         when(context2.getCatalogMapping()).thenReturn(catalog);
 
-        List<DbSchemaColumnsResponseRow> rows = service.dbSchemaColumns(request);
+        List<DbSchemaColumnsResponseRow> rows = service.dbSchemaColumns(request, requestMetaData, userPrincipal);
         verify(context1, times(1)).getName();
         assertThat(rows).isNotNull().hasSize(20);
         DbSchemaColumnsResponseRow row = rows.get(0);
@@ -294,7 +303,7 @@ class DbSchemaDiscoverServiceTest {
         when(request.restrictions()).thenReturn(restrictions);
         when(restrictions.dataType()).thenReturn(Optional.empty());
 
-        List<DbSchemaProviderTypesResponseRow> rows = service.dbSchemaProviderTypes(request);
+        List<DbSchemaProviderTypesResponseRow> rows = service.dbSchemaProviderTypes(request, requestMetaData, userPrincipal);
         assertThat(rows).isNotNull().hasSize(6);
         DbSchemaProviderTypesResponseRow row = rows.get(0);
         assertThat(row).isNotNull();
@@ -392,7 +401,7 @@ class DbSchemaDiscoverServiceTest {
         when(context2.getName()).thenReturn("foo");
         when(context2.getCatalogMapping()).thenReturn(catalog);;
 
-        List<DbSchemaSchemataResponseRow> rows = service.dbSchemaSchemata(request);
+        List<DbSchemaSchemataResponseRow> rows = service.dbSchemaSchemata(request, requestMetaData, userPrincipal);
         verify(context1, times(1)).getName();
         assertThat(rows).isNotNull().hasSize(2);
         DbSchemaSchemataResponseRow row = rows.get(0);
@@ -433,7 +442,7 @@ class DbSchemaDiscoverServiceTest {
         when(context2.getName()).thenReturn("foo");
         when(context2.getDataSource()).thenReturn(dataSource);
 
-        List<DbSchemaSourceTablesResponseRow> rows = service.dbSchemaSourceTables(request);
+        List<DbSchemaSourceTablesResponseRow> rows = service.dbSchemaSourceTables(request, requestMetaData, userPrincipal);
         verify(context1, times(1)).getName();
         assertThat(rows).isNotNull().hasSize(2);
         DbSchemaSourceTablesResponseRow row = rows.get(0);
@@ -477,9 +486,9 @@ class DbSchemaDiscoverServiceTest {
 
         when(context1.getName()).thenReturn("bar");
         when(context2.getName()).thenReturn("foo");
-        when(context2.getConnection()).thenReturn(con);
+        when(context2.getConnection(anyList())).thenReturn(con);
 
-        List<DbSchemaTablesResponseRow> rows = service.dbSchemaTables(request);
+        List<DbSchemaTablesResponseRow> rows = service.dbSchemaTables(request, requestMetaData, userPrincipal);
         verify(context1, times(1)).getName();
         assertThat(rows).isNotNull().hasSize(10);
         checkDbSchemaTablesResponseRow(rows.get(0), "foo", "schema2Name", "cube1Name", "TABLE", "foo - cube1Name Cube");
@@ -529,9 +538,9 @@ class DbSchemaDiscoverServiceTest {
         when(cub2.getDimensions()).thenAnswer(setupDummyArrayAnswer(dim1, dim2));
         when(context1.getName()).thenReturn("bar");
         when(context2.getName()).thenReturn("foo");
-        when(context2.getConnection()).thenReturn(con);
+        when(context2.getConnection(anyList())).thenReturn(con);
 
-        List<DbSchemaTablesResponseRow> rows = service.dbSchemaTables(request);
+        List<DbSchemaTablesResponseRow> rows = service.dbSchemaTables(request, requestMetaData, userPrincipal);
         verify(context1, times(1)).getName();
         assertThat(rows).isNotNull().hasSize(10);
         checkDbSchemaTablesResponseRow(rows.get(0), "foo", "schema2Name", "cube1Name", "TABLE", "foo - cube1Name Cube");
@@ -574,9 +583,9 @@ class DbSchemaDiscoverServiceTest {
         when(context2.getName()).thenReturn("foo");
 
 
-        when(context2.getConnection()).thenReturn(con);
+        when(context2.getConnection(anyList())).thenReturn(con);
 
-        List<DbSchemaTablesResponseRow> rows = service.dbSchemaTables(request);
+        List<DbSchemaTablesResponseRow> rows = service.dbSchemaTables(request, requestMetaData, userPrincipal);
         verify(context1, times(1)).getName();
         assertThat(rows).isNotNull().hasSize(2);
         checkDbSchemaTablesResponseRow(rows.get(0), "foo", "schema2Name", "cube1Name", "TABLE", "foo - cube1Name Cube");
@@ -606,7 +615,7 @@ class DbSchemaDiscoverServiceTest {
         when(context2.getName()).thenReturn("foo");
         when(context2.getCatalogMapping()).thenReturn(catalog);
 
-        List<DbSchemaTablesInfoResponseRow> rows = service.dbSchemaTablesInfo(request);
+        List<DbSchemaTablesInfoResponseRow> rows = service.dbSchemaTablesInfo(request, requestMetaData, userPrincipal);
         verify(context1, times(1)).getName();
         assertThat(rows).isNotNull().hasSize(2);
         checkDbSchemaTablesInfoResponseRow(rows.get(0), "foo", "schema2Name", "cube1Name", false,

--- a/olap/xmla/bridge/src/test/java/org/eclipse/daanse/olap/xmla/bridge/discover/MDSchemaDiscoverServiceTest.java
+++ b/olap/xmla/bridge/src/test/java/org/eclipse/daanse/olap/xmla/bridge/discover/MDSchemaDiscoverServiceTest.java
@@ -16,6 +16,7 @@ package org.eclipse.daanse.olap.xmla.bridge.discover;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -52,6 +53,8 @@ import org.eclipse.daanse.rolap.mapping.api.model.CubeMapping;
 import org.eclipse.daanse.rolap.mapping.api.model.KpiMapping;
 import org.eclipse.daanse.rolap.mapping.api.model.SchemaMapping;
 import org.eclipse.daanse.rolap.mapping.api.model.VirtualCubeMapping;
+import org.eclipse.daanse.xmla.api.RequestMetaData;
+import org.eclipse.daanse.xmla.api.UserPrincipal;
 import org.eclipse.daanse.xmla.api.common.enums.DimensionCardinalityEnum;
 import org.eclipse.daanse.xmla.api.common.enums.DimensionUniqueSettingEnum;
 import org.eclipse.daanse.xmla.api.common.enums.HierarchyOriginEnum;
@@ -188,6 +191,12 @@ class MDSchemaDiscoverServiceTest {
     private Connection connection;
     @Mock
     private ContextGroup contextGroup;
+    
+    @Mock
+    private RequestMetaData requestMetaData;
+    @Mock
+    private UserPrincipal userPrincipal;
+    
 
     private MDSchemaDiscoverService service;
 
@@ -213,7 +222,7 @@ class MDSchemaDiscoverServiceTest {
         MdSchemaActionsRequest request = mock(MdSchemaActionsRequest.class);
         MdSchemaActionsRestrictions restrictions = mock(MdSchemaActionsRestrictions.class);
 
-        List<MdSchemaActionsResponseRow> rows = service.mdSchemaActions(request);
+        List<MdSchemaActionsResponseRow> rows = service.mdSchemaActions(request, requestMetaData, userPrincipal);
         assertThat(rows).isNull();
     }
 
@@ -247,9 +256,9 @@ class MDSchemaDiscoverServiceTest {
         when(context1.getName()).thenReturn("bar");
         when(context2.getName()).thenReturn("foo");
 
-        when(context2.getConnection()).thenReturn(con);
+        when(context2.getConnection(anyList())).thenReturn(con);
 
-        List<MdSchemaCubesResponseRow> rows = service.mdSchemaCubes(request);
+        List<MdSchemaCubesResponseRow> rows = service.mdSchemaCubes(request, requestMetaData, userPrincipal);
         verify(context1, times(1)).getName();
         assertThat(rows).isNotNull().hasSize(3);
         MdSchemaCubesResponseRow row = rows.get(0);
@@ -325,11 +334,11 @@ class MDSchemaDiscoverServiceTest {
         when(context1.getName()).thenReturn("bar");
         when(context2.getName()).thenReturn("foo");
         //when(context1.getConnection()).thenReturn(connection);
-        when(context2.getConnection()).thenReturn(connection);
+        when(context2.getConnection(anyList())).thenReturn(connection);
 
         //when(context2.getDatabaseMappingSchemaProviders()).thenAnswer(setupDummyListAnswer(dmsp1, dmsp2));
 
-        List<MdSchemaDimensionsResponseRow> rows = service.mdSchemaDimensions(request);
+        List<MdSchemaDimensionsResponseRow> rows = service.mdSchemaDimensions(request, requestMetaData, userPrincipal);
         verify(context1, times(1)).getName();
         //verify(context2, times(1)).getName();
         assertThat(rows).isNotNull().hasSize(8);
@@ -419,9 +428,9 @@ class MDSchemaDiscoverServiceTest {
         when(request.restrictions()).thenReturn(restrictions);
         when(connection.getContext()).thenReturn(context1);
 
-        when(context1.getConnection()).thenReturn(connection);
+        when(context1.getConnection(anyList())).thenReturn(connection);
         when(context1.getFunctionService()).thenReturn(functionService);
-        List<MdSchemaFunctionsResponseRow> rows = service.mdSchemaFunctions(request);
+        List<MdSchemaFunctionsResponseRow> rows = service.mdSchemaFunctions(request, requestMetaData, userPrincipal);
         assertThat(rows).isNotNull().hasSize(2);
         checkMdSchemaFunctionsResponseRow(rows.get(0), "functionAtom1Name",
             "functionMetaData1Description", "Integer, Member",
@@ -485,9 +494,9 @@ class MDSchemaDiscoverServiceTest {
         when(context1.getName()).thenReturn("bar");
         when(context2.getName()).thenReturn("foo");
 
-        when(context2.getConnection()).thenReturn(connection);
+        when(context2.getConnection(anyList())).thenReturn(connection);
 
-        List<MdSchemaHierarchiesResponseRow> rows = service.mdSchemaHierarchies(request);
+        List<MdSchemaHierarchiesResponseRow> rows = service.mdSchemaHierarchies(request, requestMetaData, userPrincipal);
         verify(context1, times(1)).getName();
         verify(context2, times(3)).getName();
         assertThat(rows).isNotNull().hasSize(16);
@@ -613,7 +622,7 @@ class MDSchemaDiscoverServiceTest {
         when(context2.getName()).thenReturn("foo");
 
 
-        List<MdSchemaKpisResponseRow> rows = service.mdSchemaKpis(request);
+        List<MdSchemaKpisResponseRow> rows = service.mdSchemaKpis(request, requestMetaData, userPrincipal);
         verify(context1, times(1)).getName();
         verify(context2, times(3)).getName();
         assertThat(rows).isNotNull().hasSize(10);
@@ -691,9 +700,9 @@ class MDSchemaDiscoverServiceTest {
         when(context1.getName()).thenReturn("bar");
         when(context2.getName()).thenReturn("foo");
 
-        when(context2.getConnection()).thenReturn(connection);
+        when(context2.getConnection(anyList())).thenReturn(connection);
 
-        List<MdSchemaLevelsResponseRow> rows = service.mdSchemaLevels(request);
+        List<MdSchemaLevelsResponseRow> rows = service.mdSchemaLevels(request, requestMetaData, userPrincipal);
         verify(context1, times(1)).getName();
         verify(context2, times(3)).getName();
         assertThat(rows).isNotNull().hasSize(32);
@@ -751,9 +760,9 @@ class MDSchemaDiscoverServiceTest {
 
         when(context1.getName()).thenReturn("bar");
         when(context2.getName()).thenReturn("foo");
-        when(context2.getConnection()).thenReturn(connection);
+        when(context2.getConnection(anyList())).thenReturn(connection);
 
-        List<MdSchemaMeasureGroupDimensionsResponseRow> rows = service.mdSchemaMeasureGroupDimensions(request);
+        List<MdSchemaMeasureGroupDimensionsResponseRow> rows = service.mdSchemaMeasureGroupDimensions(request, requestMetaData, userPrincipal);
         verify(context1, times(1)).getName();
         verify(context2, times(3)).getName();
         assertThat(rows).isNotNull().hasSize(8);
@@ -795,7 +804,7 @@ class MDSchemaDiscoverServiceTest {
         when(context2.getName()).thenReturn("foo");
         when(context2.getCatalogMapping()).thenReturn(catalog);
 
-        List<MdSchemaMeasureGroupsResponseRow> rows = service.mdSchemaMeasureGroups(request);
+        List<MdSchemaMeasureGroupsResponseRow> rows = service.mdSchemaMeasureGroups(request, requestMetaData, userPrincipal);
         verify(context1, times(1)).getName();
         verify(context2, times(3)).getName();
         assertThat(rows).isNotNull().hasSize(4);
@@ -855,9 +864,9 @@ class MDSchemaDiscoverServiceTest {
         when(context1.getName()).thenReturn("bar");
         when(context2.getName()).thenReturn("foo");
 
-        when(context2.getConnection()).thenReturn(connection);
+        when(context2.getConnection(anyList())).thenReturn(connection);
 
-        List<MdSchemaMeasuresResponseRow> rows = service.mdSchemaMeasures(request);
+        List<MdSchemaMeasuresResponseRow> rows = service.mdSchemaMeasures(request, requestMetaData, userPrincipal);
         verify(context1, times(1)).getName();
         verify(context2, times(3)).getName();
         assertThat(rows).isNotNull().hasSize(8);
@@ -963,9 +972,9 @@ class MDSchemaDiscoverServiceTest {
         when(context1.getName()).thenReturn("bar");
         when(context2.getName()).thenReturn("foo");
 
-        when(context2.getConnection()).thenReturn(connection);
+        when(context2.getConnection(anyList())).thenReturn(connection);
 
-        List<MdSchemaMembersResponseRow> rows = service.mdSchemaMembers(request);
+        List<MdSchemaMembersResponseRow> rows = service.mdSchemaMembers(request, requestMetaData, userPrincipal);
         verify(context1, times(1)).getName();
         verify(context2, times(3)).getName();
         assertThat(rows).isNotNull().hasSize(32);
@@ -1046,9 +1055,9 @@ class MDSchemaDiscoverServiceTest {
         when(context1.getName()).thenReturn("bar");
         when(context2.getName()).thenReturn("foo");
 
-        when(context2.getConnection()).thenReturn(connection);
+        when(context2.getConnection(anyList())).thenReturn(connection);
 
-        List<MdSchemaPropertiesResponseRow> rows = service.mdSchemaProperties(request);
+        List<MdSchemaPropertiesResponseRow> rows = service.mdSchemaProperties(request, requestMetaData, userPrincipal);
         verify(context1, times(1)).getName();
         verify(context2, times(3)).getName();
         assertThat(rows).isNotNull().hasSize(64);
@@ -1103,9 +1112,9 @@ class MDSchemaDiscoverServiceTest {
         when(context1.getName()).thenReturn("bar");
         when(context2.getName()).thenReturn("foo");
 
-        when(context2.getConnection()).thenReturn(connection);
+        when(context2.getConnection(anyList())).thenReturn(connection);
 
-        List<MdSchemaSetsResponseRow> rows = service.mdSchemaSets(request);
+        List<MdSchemaSetsResponseRow> rows = service.mdSchemaSets(request, requestMetaData, userPrincipal);
         verify(context1, times(1)).getName();
         verify(context2, times(3)).getName();
         assertThat(rows).isNotNull().hasSize(8);

--- a/olap/xmla/bridge/src/test/java/org/eclipse/daanse/olap/xmla/bridge/discover/OtherDiscoverServiceTest.java
+++ b/olap/xmla/bridge/src/test/java/org/eclipse/daanse/olap/xmla/bridge/discover/OtherDiscoverServiceTest.java
@@ -32,6 +32,8 @@ import org.eclipse.daanse.olap.rolap.api.RolapContext;
 import org.eclipse.daanse.olap.xmla.bridge.ContextGroupXmlaServiceConfig;
 import org.eclipse.daanse.olap.xmla.bridge.ContextsSupplyerImpl;
 import org.eclipse.daanse.rolap.mapping.api.model.CatalogMapping;
+import org.eclipse.daanse.xmla.api.RequestMetaData;
+import org.eclipse.daanse.xmla.api.UserPrincipal;
 import org.eclipse.daanse.xmla.api.discover.Properties;
 import org.eclipse.daanse.xmla.api.discover.discover.datasources.DiscoverDataSourcesRequest;
 import org.eclipse.daanse.xmla.api.discover.discover.datasources.DiscoverDataSourcesResponseRow;
@@ -77,6 +79,13 @@ class OtherDiscoverServiceTest {
     private Connection connection;
     @Mock
     private ContextGroup contextGroup;
+    
+    @Mock
+    private RequestMetaData requestMetaData;
+    @Mock
+    private UserPrincipal userPrincipal;
+    
+    
 
     private OtherDiscoverService service;
 
@@ -104,7 +113,7 @@ class OtherDiscoverServiceTest {
         when(context2.getDescription()).thenReturn(Optional.of("fooDescription"));
         when(context2.getDataSource()).thenReturn(dataSource);
 
-        List<DiscoverDataSourcesResponseRow> rows = service.dataSources(request);
+		List<DiscoverDataSourcesResponseRow> rows = service.dataSources(request, requestMetaData, userPrincipal);
         verify(context1, times(1)).getName();
         verify(context2, times(1)).getName();
         assertThat(rows).isNotNull().hasSize(2);
@@ -133,7 +142,7 @@ class OtherDiscoverServiceTest {
     void discoverEnumerators() {
         DiscoverEnumeratorsRequest request = mock(DiscoverEnumeratorsRequest.class);
 
-        List<DiscoverEnumeratorsResponseRow> rows = service.discoverEnumerators(request);
+        List<DiscoverEnumeratorsResponseRow> rows = service.discoverEnumerators(request, requestMetaData, userPrincipal);
         assertThat(rows).isNotNull().hasSize(15)
             .extracting(DiscoverEnumeratorsResponseRow::enumName)
             .containsAnyOf(
@@ -147,7 +156,7 @@ class OtherDiscoverServiceTest {
     @Test
     void discoverKeywords() {
         DiscoverKeywordsRequest request = mock(DiscoverKeywordsRequest.class);
-        List<DiscoverKeywordsResponseRow> rows = service.discoverKeywords(request);
+        List<DiscoverKeywordsResponseRow> rows = service.discoverKeywords(request, requestMetaData, userPrincipal);
         assertThat(rows).isNotNull().hasSize(256)
             .extracting(DiscoverKeywordsResponseRow::keyword)
             .containsExactlyInAnyOrder(
@@ -200,7 +209,7 @@ class OtherDiscoverServiceTest {
         DiscoverLiteralsRequest request = mock(DiscoverLiteralsRequest.class);
         DiscoverLiteralsRestrictions restrictions = mock(DiscoverLiteralsRestrictions.class);       
 
-        List<DiscoverLiteralsResponseRow> rows = service.discoverLiterals(request);
+        List<DiscoverLiteralsResponseRow> rows = service.discoverLiterals(request, requestMetaData, userPrincipal);
         assertThat(rows).isNotNull().hasSize(17);
     }
 
@@ -213,7 +222,7 @@ class OtherDiscoverServiceTest {
         when(request.restrictions()).thenReturn(restrictions);
         when(request.properties()).thenReturn(properties);
 
-        List<DiscoverPropertiesResponseRow> rows = service.discoverProperties(request);
+        List<DiscoverPropertiesResponseRow> rows = service.discoverProperties(request, requestMetaData, userPrincipal);
         assertThat(rows).isNotNull().hasSize(29)
             .extracting(DiscoverPropertiesResponseRow::propertyName)
             .containsExactlyInAnyOrder(
@@ -255,7 +264,7 @@ class OtherDiscoverServiceTest {
         DiscoverSchemaRowsetsRestrictions restrictions = mock(DiscoverSchemaRowsetsRestrictions.class);
         when(request.restrictions()).thenReturn(restrictions);
 
-        List<DiscoverSchemaRowsetsResponseRow> rows = service.discoverSchemaRowsets(request);
+        List<DiscoverSchemaRowsetsResponseRow> rows = service.discoverSchemaRowsets(request, requestMetaData, userPrincipal);
         assertThat(rows).isNotNull().hasSize(27)
             .extracting(DiscoverSchemaRowsetsResponseRow::schemaName)
             .containsExactlyInAnyOrder(
@@ -296,7 +305,7 @@ class OtherDiscoverServiceTest {
         when(restrictions.schemaName()).thenReturn(Optional.of("DISCOVER_SCHEMA_ROWSETS"));
         when(request.restrictions()).thenReturn(restrictions);
 
-        List<DiscoverSchemaRowsetsResponseRow> rows = service.discoverSchemaRowsets(request);
+        List<DiscoverSchemaRowsetsResponseRow> rows = service.discoverSchemaRowsets(request, requestMetaData, userPrincipal);
         assertThat(rows).isNotNull().hasSize(1);
         assertThat(rows.get(0)).isNotNull();
         assertThat(rows.get(0).schemaName()).isEqualTo("DISCOVER_SCHEMA_ROWSETS");
@@ -310,7 +319,7 @@ class OtherDiscoverServiceTest {
         DiscoverXmlMetaDataRestrictions restrictions = mock(DiscoverXmlMetaDataRestrictions.class);        
         when(restrictions.databaseId()).thenReturn(Optional.of("foo"));
         when(request.restrictions()).thenReturn(restrictions);
-        List<DiscoverXmlMetaDataResponseRow> rows = service.xmlMetaData(request);
+        List<DiscoverXmlMetaDataResponseRow> rows = service.xmlMetaData(request, requestMetaData, userPrincipal);
         assertThat(rows).isNotNull().hasSize(2);
         assertThat(rows.get(0)).isNotNull();
         assertThat(rows.get(0).metaData()).isEmpty();


### PR DESCRIPTION
- Comment out unused code in `SqlTupleReader` and `SegmentCacheManager`
- Add role-based connection methods in `Context` and `BasicContext`
- Update `ActionService` and `ActionServiceImpl` to include metadata
- Modify `DBSchemaDiscoverService` to handle metadata and user roles
- Update `DelegatingDiscoverService` to include metadata and user principal
- Add metadata and user principal handling to `MDSchemaDiscoverService`
- Add metadata and user principal handling to `OtherDiscoverService`
- Add metadata and user principal handling to `OlapExecuteService`
- Add metadata and user principal handling to `WriteBackService` and tests
- Add metadata and user principal handling to `OtherDiscoverServiceTest`