### PR TITLE
Remove deprecated `getCube` method from CatalogReader implementations

### DIFF
--- a/mondrian/src/main/java/mondrian/olap/DelegatingCatalogReader.java
+++ b/mondrian/src/main/java/mondrian/olap/DelegatingCatalogReader.java
@@ -75,13 +75,6 @@ public abstract class DelegatingCatalogReader implements CatalogReader {
         return schemaReader.getRole();
     }
 
-    @Deprecated
-
-    @Override
-	public Cube getCube() {
-        return schemaReader.getCube();
-    }
-
     @Override
 	public List<Dimension> getCubeDimensions(Cube cube) {
         return schemaReader.getCubeDimensions(cube);

--- a/mondrian/src/main/java/mondrian/rolap/RolapCatalogReader.java
+++ b/mondrian/src/main/java/mondrian/rolap/RolapCatalogReader.java
@@ -411,11 +411,6 @@ public class RolapCatalogReader
     }
 
     @Override
-	public Cube getCube() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
 	public CatalogReader withoutAccessControl() {
         assert this.getClass() == RolapCatalogReader.class
             : new StringBuilder("Subclass ").append(getClass()).append(" must override").toString();

--- a/mondrian/src/main/java/mondrian/rolap/RolapCube.java
+++ b/mondrian/src/main/java/mondrian/rolap/RolapCube.java
@@ -3355,11 +3355,6 @@ public class RolapCube extends CubeBase {
         }
 
         @Override
-		public Cube getCube() {
-            return RolapCube.this;
-        }
-
-        @Override
 		public List<NameResolver.Namespace> getNamespaces() {
             final List<NameResolver.Namespace> list =
                 new ArrayList<>();

--- a/mondrian/src/main/java/org/eclipse/daanse/olap/api/CatalogReader.java
+++ b/mondrian/src/main/java/org/eclipse/daanse/olap/api/CatalogReader.java
@@ -539,14 +539,6 @@ public interface CatalogReader {
     CatalogReader withoutAccessControl();
 
     /**
-     * Returns the default cube in which to look for dimensions etc.
-     *
-     * @return Default cube
-     */
-    @Deprecated
-    Cube getCube();
-
-    /**
      * Returns a schema reader that automatically assigns a locus to each
      * operation.
      *

--- a/mondrian/src/test/java/mondrian/olap/SpyCatalogReader.java
+++ b/mondrian/src/test/java/mondrian/olap/SpyCatalogReader.java
@@ -277,11 +277,6 @@ public class SpyCatalogReader implements CatalogReader {
 	public CatalogReader withoutAccessControl() {
 		return delegate.withoutAccessControl();
 	}
-    @Deprecated
-	@Override
-	public Cube getCube() {
-		return delegate.getCube();
-	}
 
 	@Override
 	public CatalogReader withLocus() {


### PR DESCRIPTION
- Remove `getCube` method from `DelegatingCatalogReader`
- Remove `getCube` method from `RolapCatalogReader`
- Remove `getCube` method from `RolapCube`
- Remove `getCube` method from `CatalogReader` interface
- Remove `getCube` method from `SpyCatalogReader`
- Update related classes and tests accordingly