### PR TITLE
Refactor to replace `DialectResolver` with `DialectFactory` across

### DIFF
--- a/demo/server/play/src/main/java/org/eclipse/daanse/demo/server/play/CatalogsFileListener.java
+++ b/demo/server/play/src/main/java/org/eclipse/daanse/demo/server/play/CatalogsFileListener.java
@@ -170,8 +170,10 @@ public class CatalogsFileListener implements FileSystemWatcherListener {
 
 		Dictionary<String, Object> props = new Hashtable<>();
 		props.put(BasicContext.REF_NAME_DATA_SOURCE + TARGET_EXT, filterOfMatcherKey(matcherKey));
-		props.put(BasicContext.REF_NAME_EXPRESSION_COMPILER_FACTORY + TARGET_EXT,
-				"(component.name=" + PID_EXP_COMP_FAC + ")");
+        props.put(BasicContext.REF_NAME_EXPRESSION_COMPILER_FACTORY + TARGET_EXT,
+                "(component.name=" + PID_EXP_COMP_FAC + ")");
+        props.put(BasicContext.REF_NAME_DIALECT_FACTORY + TARGET_EXT,
+                "(org.eclipse.daanse.dialect.name=H2)");
 		props.put(BasicContext.REF_NAME_CATALOG_MAPPING_SUPPLIER + TARGET_EXT, filterOfMatcherKey(matcherKey));
 		props.put(BasicContext.REF_NAME_MDX_PARSER_PROVIDER + TARGET_EXT, "(component.name=" + PID_PARSER + ")");
 

--- a/demo/server/play/xmla.demo.server.jdkhttp.bndrun
+++ b/demo/server/play/xmla.demo.server.jdkhttp.bndrun
@@ -40,7 +40,8 @@
 	bnd.identity;id='org.eclipse.daanse.rolap.mapping.verifyer.basic',\
 	bnd.identity;id='org.eclipse.daanse.sql.guard.api',\
 	bnd.identity;id='org.eclipse.daanse.sql.guard.jsqltranspiler',\
-	bnd.identity;id='org.eclipse.daanse.xmla.server.jdk.httpserver'
+	bnd.identity;id='org.eclipse.daanse.xmla.server.jdk.httpserver',\
+	bnd.identity;id='org.apache.felix.fileinstall'
 
 
 # This will help us keep -runbundles sorted
@@ -62,6 +63,7 @@
 	json;version='[20250107.0.0,20250107.0.1)',\
 	org.apache.aries.spifly.dynamic.framework.extension;version='[1.3.7,1.3.8)',\
 	org.apache.felix.configadmin;version='[1.9.26,1.9.27)',\
+	org.apache.felix.fileinstall;version='[3.7.4,3.7.5)',\
 	org.apache.felix.metatype;version='[1.2.4,1.2.5)',\
 	org.apache.felix.scr;version='[2.2.10,2.2.11)',\
 	org.eclipse.daanse.demo.server.play;version='[0.0.1,0.0.2)',\

--- a/mondrian/src/test/java/org/eclipse/daanse/olap/rolap/core/ServiceTest.java
+++ b/mondrian/src/test/java/org/eclipse/daanse/olap/rolap/core/ServiceTest.java
@@ -124,7 +124,7 @@ class ServiceTest {
         Dictionary<String, Object> props = new Hashtable<>();
 
         props.put(BasicContext.REF_NAME_DATA_SOURCE + TARGET_EXT, "(ds=1)");
-        props.put(BasicContext.REF_NAME_DIALECT_RESOLVER + TARGET_EXT, "(dr=2)");
+        props.put(BasicContext.REF_NAME_DIALECT_FACTORY + TARGET_EXT, "(dr=2)");
         props.put(BasicContext.REF_NAME_EXPRESSION_COMPILER_FACTORY + TARGET_EXT, "(ecf=1)");
         props.put(BasicContext.REF_NAME_CATALOG_MAPPING_SUPPLIER + TARGET_EXT, "(dbmsp=1)");
         props.put(BasicContext.REF_NAME_MDX_PARSER_PROVIDER + TARGET_EXT, "(parser=1)");


### PR DESCRIPTION
modules.

- Added `DialectFactory` references in `BasicContext`.
- Updated `CatalogsFileListener` to include `DialectFactory` properties.
- Replaced `DialectResolver` with `DialectFactory` in `ServiceTest`.
- Included `org.apache.felix.fileinstall` in `bndrun` configuration.
- Removed unused imports from `BasicContext`.
- Adjusted dialect initialization logic to use `DialectFactory`.

