### PR TITLE
fix(test): build against CWM-migrated rolap (fastcsv bump + orphan co…

### DIFF
--- a/mondrian/.flattened-pom.xml
+++ b/mondrian/.flattened-pom.xml
@@ -93,7 +93,7 @@
     <dependency>
       <groupId>de.siegmar</groupId>
       <artifactId>fastcsv</artifactId>
-      <version>3.0.0</version>
+      <version>3.1.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -230,13 +230,25 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.daanse</groupId>
-      <artifactId>org.eclipse.daanse.rolap.mapping.modifier.common</artifactId>
+      <artifactId>org.eclipse.daanse.cwm.model.cwm</artifactId>
       <version>0.0.1-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.daanse</groupId>
-      <artifactId>org.eclipse.daanse.rolap.mapping.modifier.emf</artifactId>
+      <artifactId>org.eclipse.daanse.rolap.aggmatch.emf</artifactId>
+      <version>0.0.1-SNAPSHOT</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.daanse</groupId>
+      <artifactId>org.eclipse.daanse.rolap.aggmatch.record</artifactId>
+      <version>0.0.1-SNAPSHOT</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.daanse</groupId>
+      <artifactId>org.eclipse.daanse.rolap.aggmatch.instance.basic</artifactId>
       <version>0.0.1-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
@@ -272,7 +284,7 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.daanse</groupId>
-      <artifactId>org.eclipse.daanse.jdbc.db.core</artifactId>
+      <artifactId>org.eclipse.daanse.jdbc.db.impl</artifactId>
       <version>0.0.1-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
@@ -354,7 +366,7 @@
       <plugin>
         <groupId>biz.aQute.bnd</groupId>
         <artifactId>bnd-maven-plugin</artifactId>
-        <version>7.2.0-SNAPSHOT</version>
+        <version>7.2.0</version>
         <extensions>true</extensions>
       </plugin>
     </plugins>

--- a/mondrian/pom.xml
+++ b/mondrian/pom.xml
@@ -102,7 +102,7 @@
     <dependency>
       <groupId>de.siegmar</groupId>
       <artifactId>fastcsv</artifactId>
-      <version>3.0.0</version>
+      <version>3.1.0</version>
     </dependency>
 
     <dependency>

--- a/mondrian/src/test/java/mondrian/rolap/aggmatcher/AggMeasureFactCountTestModifierEmf.java
+++ b/mondrian/src/test/java/mondrian/rolap/aggmatcher/AggMeasureFactCountTestModifierEmf.java
@@ -541,7 +541,7 @@ public class AggMeasureFactCountTestModifierEmf implements CatalogMappingSupplie
 
         MemberProperty streetAddressProp = LevelFactory.eINSTANCE.createMemberProperty();
         streetAddressProp.setName("Street address");
-        streetAddressProp.setColumn((Column) copier.get(CatalogSupplier.COLUMN_STREET_ADDRESS_STORE));
+        streetAddressProp.setColumn((Column) copier.get(CatalogSupplier.COLUMN_STORE_STREET_ADDRESS_STORE));
         streetAddressProp.setPropertyType(ColumnInternalDataType.STRING);
 
         Level storeCountryLevel = LevelFactory.eINSTANCE.createLevel();

--- a/mondrian/src/test/java/mondrian/rolap/aggmatcher/ExplicitRecognizerTestModifierEmf.java
+++ b/mondrian/src/test/java/mondrian/rolap/aggmatcher/ExplicitRecognizerTestModifierEmf.java
@@ -196,7 +196,7 @@ public class ExplicitRecognizerTestModifierEmf implements CatalogMappingSupplier
         // Street address property
         MemberProperty streetAddressProp = LevelFactory.eINSTANCE.createMemberProperty();
         streetAddressProp.setName("Street address");
-        streetAddressProp.setColumn((Column) copier.get(CatalogSupplier.COLUMN_STREET_ADDRESS_STORE));
+        streetAddressProp.setColumn((Column) copier.get(CatalogSupplier.COLUMN_STORE_STREET_ADDRESS_STORE));
         streetAddressProp.setPropertyType(ColumnInternalDataType.STRING);
 
         storeNameLevel.getMemberProperties().add(streetAddressProp);

--- a/mondrian/test.bndrun
+++ b/mondrian/test.bndrun
@@ -51,7 +51,7 @@
 	com.sun.jna;version='[5.18.1,5.18.2)',\
 	com.sun.xml.bind.jaxb-core;version='[4.0.6,4.0.7)',\
 	com.sun.xml.bind.jaxb-impl;version='[4.0.6,4.0.7)',\
-	de.siegmar.fastcsv;version='[3.0.0,3.0.1)',\
+	de.siegmar.fastcsv;version='[3.1.0,3.1.1)',\
 	jakarta.activation-api;version='[2.1.4,2.1.5)',\
 	jakarta.xml.bind-api;version='[4.0.4,4.0.5)',\
 	junit-jupiter-api;version='[5.12.2,5.12.3)',\
@@ -66,7 +66,12 @@
 	org.apache.commons.lang3;version='[3.17.0,3.17.1)',\
 	org.apache.felix.configadmin;version='[1.9.26,1.9.27)',\
 	org.apache.felix.scr;version='[2.2.10,2.2.11)',\
-	org.eclipse.daanse.cwm.model;version='[0.0.1,0.0.2)',\
+	org.eclipse.daanse.cwm.data.api;version='[0.0.1,0.0.2)',\
+	org.eclipse.daanse.cwm.data.sink.jdbc;version='[0.0.1,0.0.2)',\
+	org.eclipse.daanse.cwm.data.source.csv;version='[0.0.1,0.0.2)',\
+	org.eclipse.daanse.cwm.model.cwm;version='[0.0.1,0.0.2)',\
+	org.eclipse.daanse.cwm.resource.relational.ddl;version='[0.0.1,0.0.2)',\
+	org.eclipse.daanse.cwm.testkit;version='[0.0.1,0.0.2)',\
 	org.eclipse.daanse.cwm.util;version='[0.0.1,0.0.2)',\
 	org.eclipse.daanse.jdbc.db.api;version='[0.0.1,0.0.2)',\
 	org.eclipse.daanse.jdbc.db.dialect.api;version='[0.0.1,0.0.2)',\


### PR DESCRIPTION
…lumn ref)

Adapt the test fragment to the CWM mapping-model migration in org.eclipse.daanse.rolap so mvn clean verify resolves and the aggmatcher tests build their cubes again.

- Bump de.siegmar:fastcsv 3.0.0 -> 3.1.0.

- Point the Street address   member property at the table-attached
column CatalogSupplier.COLUMN_STORE_STREET_ADDRESS_STORE instead of
the orphan COLUMN_STREET_ADDRESS_STORE (never added to a table, so
copier.get(...) returned null and LevelUtil.getPropertyExp NPE'd
during cube construction). Fixes AggMeasureFactCountTest and
ExplicitRecognizerTest.

### What does this PR do?

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Daanse
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
